### PR TITLE
Revamp admin settings with tabbed interface

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -1,4 +1,193 @@
-.your-share-settings .your-share-floating-controls{margin-top:.5rem;display:flex;gap:1rem;align-items:center;flex-wrap:wrap}
-.your-share-settings .your-share-gap-radius{display:flex;gap:1rem;flex-wrap:wrap}
-.your-share-settings .your-share-gap-radius label,.your-share-settings .your-share-floating-controls label{display:flex;flex-direction:column;font-weight:500;gap:.25rem}
-.your-share-settings .your-share-count{display:inline-block;margin-left:.5rem;background:#111;color:#fff;border-radius:9999px;padding:.1rem .6rem;font-size:.75rem;font-weight:600}
+.your-share-settings[data-your-share-admin] {
+  max-width: 960px;
+}
+
+.your-share-settings__intro {
+  margin-bottom: 1.5rem;
+  max-width: 720px;
+}
+
+.your-share-tab-panels {
+  margin-top: 1.5rem;
+}
+
+.your-share-tab-panel {
+  display: none;
+  border: 1px solid #dcdcde;
+  border-top: 0;
+  padding: 1.5rem;
+  background: #fff;
+}
+
+.your-share-tab-panel.is-active {
+  display: block;
+}
+
+.your-share-field-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
+.your-share-field-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+.your-share-field-grid select,
+.your-share-field-grid input[type="text"],
+.your-share-field-grid input[type="number"] {
+  max-width: 100%;
+}
+
+.your-share-field-grid .your-share-field-wide {
+  grid-column: 1 / -1;
+}
+
+.your-share-field-stack {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.your-share-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.your-share-input-suffix {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.your-share-input-suffix span {
+  color: #6b7280;
+}
+
+.your-share-network-picker {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.your-share-network-selected,
+.your-share-network-available {
+  border: 1px solid #dcdcde;
+  background: #f8f9fb;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.your-share-network-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 0 0 0.5rem;
+  padding: 0;
+}
+
+.your-share-network-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid #dcdcde;
+  background: #fff;
+  cursor: grab;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.your-share-network-item.is-dragging {
+  opacity: 0.7;
+  transform: scale(0.98);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
+}
+
+.your-share-network-handle {
+  font-size: 1rem;
+  line-height: 1;
+  color: #6b7280;
+  cursor: inherit;
+}
+
+.your-share-network-swatch {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: var(--your-share-network-color, #111827);
+}
+
+.your-share-network-remove {
+  border: none;
+  background: none;
+  color: #ef4444;
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.1rem;
+}
+
+.your-share-network-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.your-share-network-add.is-active {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.your-share-shortcode-preview {
+  margin-top: 0.5rem;
+}
+
+.your-share-shortcode-preview code {
+  display: block;
+  background: #111827;
+  color: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  word-break: break-all;
+}
+
+.your-share-summary {
+  background: #f1f5f9;
+  border: 1px solid #cbd5f5;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  color: #1f2937;
+}
+
+.your-share-color-chip {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 999px;
+  display: inline-block;
+  margin-right: 0.35rem;
+  vertical-align: middle;
+  background: var(--your-share-network-color, #111827);
+}
+
+.your-share-network-matrix {
+  margin-top: 1rem;
+}
+
+.your-share-network-buttons .button.button-small {
+  padding: 0.25rem 0.6rem;
+}
+
+@media (max-width: 782px) {
+  .your-share-tab-panel {
+    padding: 1rem;
+  }
+}

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -1,21 +1,351 @@
 (function(){
-  function updateNetworkCount(){
-    var field = document.querySelector('[data-your-share-networks]');
-    var output = document.querySelector('[data-your-share-networks-count]');
-    if (!field || !output) {
-      return;
-    }
-    var networks = field.value.split(',').map(function(item){
-      return item.trim();
-    }).filter(function(item){ return item.length > 0; });
-    output.textContent = '(' + networks.length + ')';
+  function qs(root, selector){
+    return root ? root.querySelector(selector) : null;
   }
 
-  document.addEventListener('DOMContentLoaded', function(){
-    var field = document.querySelector('[data-your-share-networks]');
-    if (field) {
-      field.addEventListener('input', updateNetworkCount);
+  function qsa(root, selector){
+    return root ? Array.prototype.slice.call(root.querySelectorAll(selector)) : [];
+  }
+
+  function init(){
+    var root = document.querySelector('[data-your-share-admin]');
+    if (!root){
+      return;
     }
-    updateNetworkCount();
-  });
+
+    setupTabs(root);
+    setupNetworkPicker(root);
+    setupShortcodePreview(root);
+    setupUtmPreview(root);
+  }
+
+  function setupTabs(root){
+    var tabs = qsa(root, '[data-your-share-tab]');
+    var panels = qsa(root, '[data-your-share-panel]');
+    var currentInput = qs(root, '[data-your-share-current-tab]');
+    if (!tabs.length || !panels.length || !currentInput){
+      return;
+    }
+
+    function activateTab(tab, updateUrl){
+      var found = false;
+      tabs.forEach(function(link){
+        var isActive = link.getAttribute('data-your-share-tab') === tab;
+        if (isActive){
+          found = true;
+        }
+        link.classList.toggle('nav-tab-active', isActive);
+        link.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      });
+
+      panels.forEach(function(panel){
+        var isActive = panel.getAttribute('data-your-share-panel') === tab;
+        panel.classList.toggle('is-active', isActive);
+        panel.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+      });
+
+      if (!found && tabs.length){
+        tab = tabs[0].getAttribute('data-your-share-tab');
+        activateTab(tab, updateUrl);
+        return;
+      }
+
+      currentInput.value = tab;
+
+      if (updateUrl){
+        try {
+          var url = new URL(window.location.href);
+          url.searchParams.set('tab', tab);
+          window.history.replaceState({}, '', url.toString());
+        } catch (error) {
+          // noop
+        }
+      }
+    }
+
+    var initial = (function(){
+      try {
+        var params = new URLSearchParams(window.location.search);
+        return params.get('tab');
+      } catch (error) {
+        return null;
+      }
+    })() || currentInput.value || (tabs[0] && tabs[0].getAttribute('data-your-share-tab'));
+
+    tabs.forEach(function(link){
+      link.addEventListener('click', function(event){
+        event.preventDefault();
+        var tab = link.getAttribute('data-your-share-tab');
+        if (tab){
+          activateTab(tab, true);
+        }
+      });
+    });
+
+    activateTab(initial, false);
+  }
+
+  function setupNetworkPicker(root){
+    qsa(root, '[data-your-share-networks]').forEach(function(picker){
+      var hidden = qs(picker, '[data-your-share-network-input]');
+      var list = qs(picker, '[data-your-share-network-list]');
+      var count = qs(picker, '[data-your-share-network-count]');
+      var buttons = qsa(picker, '.your-share-network-add');
+      if (!hidden || !list){
+        return;
+      }
+
+      function update(){
+        var items = qsa(list, '.your-share-network-item');
+        var values = items.map(function(item){
+          return item.getAttribute('data-value');
+        }).filter(Boolean);
+        hidden.value = values.join(',');
+        if (count){
+          count.textContent = values.length;
+        }
+        refreshShortcodePreview(root);
+      }
+
+      function setButtonState(slug, isActive){
+        buttons.forEach(function(button){
+          if (button.getAttribute('data-value') === slug){
+            button.disabled = !!isActive;
+            button.classList.toggle('is-active', !!isActive);
+          }
+        });
+      }
+
+      function handleRemove(event){
+        var li = event.currentTarget.closest('.your-share-network-item');
+        if (!li){
+          return;
+        }
+        var slug = li.getAttribute('data-value');
+        li.parentNode.removeChild(li);
+        setButtonState(slug, false);
+        update();
+      }
+
+      function attach(li){
+        li.addEventListener('dragstart', function(evt){
+          li.classList.add('is-dragging');
+          try {
+            evt.dataTransfer.effectAllowed = 'move';
+            evt.dataTransfer.setData('text/plain', li.getAttribute('data-value') || '');
+          } catch (error) {
+            // ignore
+          }
+        });
+        li.addEventListener('dragend', function(){
+          li.classList.remove('is-dragging');
+          update();
+        });
+        var removeButton = qs(li, '.your-share-network-remove');
+        if (removeButton){
+          removeButton.addEventListener('click', handleRemove);
+        }
+      }
+
+      function createItem(slug, label, color, removeLabel){
+        var li = document.createElement('li');
+        li.className = 'your-share-network-item';
+        li.setAttribute('data-value', slug);
+        li.setAttribute('draggable', 'true');
+
+        var handle = document.createElement('span');
+        handle.className = 'your-share-network-handle';
+        handle.setAttribute('aria-hidden', 'true');
+        handle.textContent = '⋮⋮';
+
+        var swatch = document.createElement('span');
+        swatch.className = 'your-share-network-swatch';
+        if (color){
+          swatch.style.setProperty('--your-share-network-color', color);
+        }
+
+        var text = document.createElement('span');
+        text.className = 'your-share-network-label';
+        text.textContent = label;
+
+        var remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'your-share-network-remove';
+        remove.setAttribute('data-action', 'remove');
+        remove.setAttribute('aria-label', removeLabel || ('Remove ' + label));
+        remove.textContent = '×';
+
+        li.appendChild(handle);
+        li.appendChild(swatch);
+        li.appendChild(text);
+        li.appendChild(remove);
+
+        attach(li);
+        return li;
+      }
+
+      function dragOver(event){
+        event.preventDefault();
+        var dragging = list.querySelector('.your-share-network-item.is-dragging');
+        if (!dragging){
+          return;
+        }
+        var after = getDragAfterElement(list, event.clientY);
+        if (!after){
+          list.appendChild(dragging);
+        } else {
+          list.insertBefore(dragging, after);
+        }
+      }
+
+      function getDragAfterElement(container, y){
+        var elements = qsa(container, '.your-share-network-item:not(.is-dragging)');
+        var closest = { offset: Number.NEGATIVE_INFINITY, element: null };
+
+        elements.forEach(function(child){
+          var box = child.getBoundingClientRect();
+          var offset = y - box.top - box.height / 2;
+          if (offset < 0 && offset > closest.offset){
+            closest = { offset: offset, element: child };
+          }
+        });
+
+        return closest.element;
+      }
+
+      list.addEventListener('dragover', dragOver);
+
+      buttons.forEach(function(button){
+        button.addEventListener('click', function(){
+          if (button.disabled){
+            return;
+          }
+          var slug = button.getAttribute('data-value');
+          var label = button.getAttribute('data-label') || slug;
+          var color = button.getAttribute('data-color') || '';
+          var removeLabel = button.getAttribute('data-remove-label') || ('Remove ' + label);
+          var item = createItem(slug, label, color, removeLabel);
+          list.appendChild(item);
+          button.disabled = true;
+          button.classList.add('is-active');
+          update();
+        });
+      });
+
+      qsa(list, '.your-share-network-item').forEach(attach);
+      update();
+    });
+  }
+
+  function setupShortcodePreview(root){
+    var inputs = qsa(root, '[data-your-share-shortcode-prop]');
+    inputs.forEach(function(input){
+      input.addEventListener('change', function(){ refreshShortcodePreview(root); });
+      input.addEventListener('input', function(){ refreshShortcodePreview(root); });
+    });
+    refreshShortcodePreview(root);
+  }
+
+  function setupUtmPreview(root){
+    if (!qs(root, '[data-your-share-utm-preview]')){
+      return;
+    }
+    var inputs = qsa(root, '[data-your-share-utm-prop]');
+
+    function refresh(){
+      refreshUtmPreview(root);
+    }
+
+    inputs.forEach(function(input){
+      input.addEventListener('change', refresh);
+      input.addEventListener('input', refresh);
+    });
+    refresh();
+  }
+
+  function refreshShortcodePreview(root){
+    var target = qs(root, '[data-your-share-shortcode]');
+    if (!target){
+      return;
+    }
+    var networksInput = qs(root, '[data-your-share-network-input]');
+    var styleSelect = qs(root, '[data-your-share-shortcode-prop="style"]');
+    var sizeSelect = qs(root, '[data-your-share-shortcode-prop="size"]');
+    var labelsSelect = qs(root, '[data-your-share-shortcode-prop="labels"]');
+    var brandToggle = qs(root, '[data-your-share-shortcode-prop="brand"]');
+
+    var networks = networksInput ? networksInput.value.trim() : '';
+    var style = styleSelect ? styleSelect.value : 'solid';
+    var size = sizeSelect ? sizeSelect.value : 'md';
+    var labels = labelsSelect ? labelsSelect.value : 'auto';
+    var brand = '0';
+    if (brandToggle){
+      if (brandToggle.type === 'checkbox'){
+        brand = brandToggle.checked ? '1' : '0';
+      } else {
+        brand = brandToggle.value || '0';
+      }
+    }
+
+    var shortcode = '[your_share';
+    shortcode += ' networks="' + networks + '"';
+    shortcode += ' style="' + style + '"';
+    shortcode += ' size="' + size + '"';
+    shortcode += ' labels="' + labels + '"';
+    shortcode += ' brand="' + brand + '"';
+    shortcode += ']';
+
+    target.textContent = shortcode;
+  }
+
+  function refreshUtmPreview(root){
+    var container = qs(root, '[data-your-share-utm-preview]');
+    if (!container){
+      return;
+    }
+    var output = qs(container, '[data-your-share-utm-output]');
+    if (!output){
+      return;
+    }
+
+    var base = container.getAttribute('data-base') || window.location.href;
+    var network = container.getAttribute('data-network') || 'x';
+    var enabled = qs(root, '[data-your-share-utm-prop="enabled"]');
+    var medium = qs(root, '[data-your-share-utm-prop="medium"]');
+    var campaign = qs(root, '[data-your-share-utm-prop="campaign"]');
+    var term = qs(root, '[data-your-share-utm-prop="term"]');
+    var content = qs(root, '[data-your-share-utm-prop="content"]');
+
+    var url;
+    try {
+      url = new URL(base);
+    } catch (error) {
+      output.textContent = base;
+      return;
+    }
+
+    if (!enabled || enabled.checked){
+      var params = new URLSearchParams();
+      params.set('utm_source', network);
+      if (medium && medium.value){
+        params.set('utm_medium', medium.value);
+      }
+      if (campaign && campaign.value){
+        params.set('utm_campaign', campaign.value);
+      }
+      if (term && term.value){
+        params.set('utm_term', term.value);
+      }
+      if (content && content.value){
+        params.set('utm_content', content.value);
+      }
+      url.search = params.toString();
+    } else {
+      url.search = '';
+    }
+
+    output.textContent = url.toString();
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
 })();

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -11,15 +11,22 @@ class Admin
     /** @var Options */
     private $options;
 
+    /** @var Networks */
+    private $networks;
+
     /** @var string */
     private $slug;
 
     /** @var string */
     private $text_domain;
 
-    public function __construct(Options $options, string $slug, string $text_domain)
+    /** @var array|null */
+    private $cached_values = null;
+
+    public function __construct(Options $options, Networks $networks, string $slug, string $text_domain)
     {
         $this->options     = $options;
+        $this->networks    = $networks;
         $this->slug        = $slug;
         $this->text_domain = $text_domain;
     }
@@ -28,6 +35,7 @@ class Admin
     {
         add_action('admin_menu', [$this, 'register_menu']);
         add_action('admin_init', [$this, 'register_settings']);
+        add_filter('redirect_post_location', [$this, 'preserve_tab'], 10, 2);
     }
 
     public function register_menu(): void
@@ -46,8 +54,15 @@ class Admin
         register_setting(
             $this->options->key(),
             $this->options->key(),
-            [$this, 'sanitize_settings']
+            [
+                'sanitize_callback' => [$this, 'sanitize_settings'],
+            ]
         );
+
+        $this->register_share_settings();
+        $this->register_sticky_settings();
+        $this->register_smart_settings();
+        $this->register_analytics_settings();
     }
 
     public function sanitize_settings($input): array
@@ -55,6 +70,9 @@ class Admin
         if (!is_array($input)) {
             $input = [];
         }
+
+        unset($input['current_tab']);
+        $this->cached_values = null;
 
         return $this->options->sanitize($input);
     }
@@ -65,134 +83,734 @@ class Admin
             return;
         }
 
-        $opts = $this->options->all();
+        $tabs        = $this->tabs();
+        $current_tab = $this->current_tab();
+
         ?>
-        <div class="wrap your-share-settings">
-            <h1><?php esc_html_e('Your Share Settings', $this->text_domain); ?></h1>
-            <form method="post" action="options.php">
+        <div class="wrap your-share-settings" data-your-share-admin>
+            <h1><?php esc_html_e('Your Share settings', $this->text_domain); ?></h1>
+            <p class="description your-share-settings__intro">
+                <?php esc_html_e('Tune the defaults that power your inline, floating, and smart share experiences.', $this->text_domain); ?>
+            </p>
+            <?php settings_errors($this->options->key()); ?>
+            <h2 class="nav-tab-wrapper" role="tablist">
+                <?php foreach ($tabs as $key => $label) :
+                    $is_active = ($key === $current_tab);
+                    $tab_url   = add_query_arg([
+                        'page' => $this->slug,
+                        'tab'  => $key,
+                    ], admin_url('options-general.php'));
+                    ?>
+                    <a
+                        href="<?php echo esc_url($tab_url); ?>"
+                        class="nav-tab<?php echo $is_active ? ' nav-tab-active' : ''; ?>"
+                        role="tab"
+                        aria-selected="<?php echo $is_active ? 'true' : 'false'; ?>"
+                        aria-controls="<?php echo esc_attr($this->panel_id($key)); ?>"
+                        data-your-share-tab="<?php echo esc_attr($key); ?>"
+                    >
+                        <?php echo esc_html($label); ?>
+                    </a>
+                <?php endforeach; ?>
+            </h2>
+            <form method="post" action="options.php" data-your-share-form>
                 <?php settings_fields($this->options->key()); ?>
-                <table class="form-table" role="presentation">
-                    <tr>
-                        <th scope="row"><?php esc_html_e('Enable UTM parameters', $this->text_domain); ?></th>
-                        <td>
-                            <label>
-                                <input type="checkbox" name="<?php echo esc_attr($this->options->key()); ?>[enable_utm]" <?php checked($opts['enable_utm']); ?>>
-                                <?php esc_html_e('Append utm_* parameters to shared URLs.', $this->text_domain); ?>
-                            </label>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><?php esc_html_e('UTM Medium', $this->text_domain); ?></th>
-                        <td>
-                            <input type="text" class="regular-text" name="<?php echo esc_attr($this->options->key()); ?>[utm_medium]" value="<?php echo esc_attr($opts['utm_medium']); ?>">
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><?php esc_html_e('UTM Campaign (default)', $this->text_domain); ?></th>
-                        <td>
-                            <input type="text" class="regular-text" name="<?php echo esc_attr($this->options->key()); ?>[utm_campaign]" value="<?php echo esc_attr($opts['utm_campaign']); ?>">
-                            <p class="description"><?php esc_html_e('Shortcode can override via the utm_campaign attribute.', $this->text_domain); ?></p>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><?php esc_html_e('UTM Term (default)', $this->text_domain); ?></th>
-                        <td>
-                            <input type="text" class="regular-text" name="<?php echo esc_attr($this->options->key()); ?>[utm_term]" value="<?php echo esc_attr($opts['utm_term']); ?>">
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><?php esc_html_e('UTM Content template', $this->text_domain); ?></th>
-                        <td>
-                            <input type="text" class="regular-text" name="<?php echo esc_attr($this->options->key()); ?>[utm_content]" value="<?php echo esc_attr($opts['utm_content']); ?>">
-                            <p class="description"><?php esc_html_e('Supports tokens: {ID}, {slug}, {post_type}.', $this->text_domain); ?></p>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><?php esc_html_e('Brand colours', $this->text_domain); ?></th>
-                        <td>
-                            <label>
-                                <input type="checkbox" name="<?php echo esc_attr($this->options->key()); ?>[brand_colors]" <?php checked($opts['brand_colors']); ?>>
-                                <?php esc_html_e('Use official network colours.', $this->text_domain); ?>
-                            </label>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><?php esc_html_e('Button style, size, and labels', $this->text_domain); ?></th>
-                        <td>
-                            <select name="<?php echo esc_attr($this->options->key()); ?>[style]">
-                                <option value="solid" <?php selected($opts['style'], 'solid'); ?>><?php esc_html_e('Solid', $this->text_domain); ?></option>
-                                <option value="outline" <?php selected($opts['style'], 'outline'); ?>><?php esc_html_e('Outline', $this->text_domain); ?></option>
-                                <option value="ghost" <?php selected($opts['style'], 'ghost'); ?>><?php esc_html_e('Ghost', $this->text_domain); ?></option>
-                            </select>
-                            <select name="<?php echo esc_attr($this->options->key()); ?>[size]">
-                                <option value="sm" <?php selected($opts['size'], 'sm'); ?>><?php esc_html_e('Small', $this->text_domain); ?></option>
-                                <option value="md" <?php selected($opts['size'], 'md'); ?>><?php esc_html_e('Medium', $this->text_domain); ?></option>
-                                <option value="lg" <?php selected($opts['size'], 'lg'); ?>><?php esc_html_e('Large', $this->text_domain); ?></option>
-                            </select>
-                            <select name="<?php echo esc_attr($this->options->key()); ?>[labels]">
-                                <option value="auto" <?php selected($opts['labels'], 'auto'); ?>><?php esc_html_e('Auto', $this->text_domain); ?></option>
-                                <option value="show" <?php selected($opts['labels'], 'show'); ?>><?php esc_html_e('Show', $this->text_domain); ?></option>
-                                <option value="hide" <?php selected($opts['labels'], 'hide'); ?>><?php esc_html_e('Hide', $this->text_domain); ?></option>
-                            </select>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><?php esc_html_e('Default networks', $this->text_domain); ?></th>
-                        <td>
-                            <input type="text" data-your-share-networks class="regular-text" name="<?php echo esc_attr($this->options->key()); ?>[networks]" value="<?php echo esc_attr($opts['networks']); ?>">
-                            <p class="description">
-                                <?php esc_html_e('Comma separated list such as facebook,x,whatsapp,telegram,linkedin,reddit,email,copy', $this->text_domain); ?>
-                                <span class="your-share-count" data-your-share-networks-count></span>
-                            </p>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><?php esc_html_e('Floating bar', $this->text_domain); ?></th>
-                        <td>
-                            <label>
-                                <input type="checkbox" name="<?php echo esc_attr($this->options->key()); ?>[floating_enabled]" <?php checked($opts['floating_enabled']); ?>>
-                                <?php esc_html_e('Enable floating share bar', $this->text_domain); ?>
-                            </label>
-                            <div class="your-share-floating-controls">
-                                <label>
-                                    <?php esc_html_e('Position', $this->text_domain); ?>
-                                    <select name="<?php echo esc_attr($this->options->key()); ?>[floating_position]">
-                                        <option value="left" <?php selected($opts['floating_position'], 'left'); ?>><?php esc_html_e('Left', $this->text_domain); ?></option>
-                                        <option value="right" <?php selected($opts['floating_position'], 'right'); ?>><?php esc_html_e('Right', $this->text_domain); ?></option>
-                                    </select>
-                                </label>
-                                <label>
-                                    <?php esc_html_e('Show on widths ≥', $this->text_domain); ?>
-                                    <input type="number" min="0" step="1" name="<?php echo esc_attr($this->options->key()); ?>[floating_breakpoint]" value="<?php echo esc_attr($opts['floating_breakpoint']); ?>">
-                                    <?php esc_html_e('px', $this->text_domain); ?>
-                                </label>
-                            </div>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><?php esc_html_e('Gap and radius', $this->text_domain); ?></th>
-                        <td class="your-share-gap-radius">
-                            <label>
-                                <?php esc_html_e('Gap', $this->text_domain); ?>
-                                <input type="number" name="<?php echo esc_attr($this->options->key()); ?>[gap]" value="<?php echo esc_attr($opts['gap']); ?>">
-                                <?php esc_html_e('px', $this->text_domain); ?>
-                            </label>
-                            <label>
-                                <?php esc_html_e('Radius', $this->text_domain); ?>
-                                <input type="number" name="<?php echo esc_attr($this->options->key()); ?>[radius]" value="<?php echo esc_attr($opts['radius']); ?>">
-                                <?php esc_html_e('px', $this->text_domain); ?>
-                            </label>
-                        </td>
-                    </tr>
-                </table>
-                <?php submit_button(); ?>
+                <input type="hidden" name="<?php echo esc_attr($this->options->key()); ?>[current_tab]" value="<?php echo esc_attr($current_tab); ?>" data-your-share-current-tab>
+                <div class="your-share-tab-panels">
+                    <?php foreach ($tabs as $key => $label) :
+                        $is_active = ($key === $current_tab);
+                        ?>
+                        <div
+                            id="<?php echo esc_attr($this->panel_id($key)); ?>"
+                            class="your-share-tab-panel<?php echo $is_active ? ' is-active' : ''; ?>"
+                            role="tabpanel"
+                            aria-hidden="<?php echo $is_active ? 'false' : 'true'; ?>"
+                            data-your-share-panel="<?php echo esc_attr($key); ?>"
+                        >
+                            <?php do_settings_sections($this->page_id($key)); ?>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+                <?php submit_button(__('Save settings', $this->text_domain)); ?>
             </form>
-            <p class="description">
-                <strong><?php esc_html_e('Shortcode', $this->text_domain); ?>:</strong>
-                <code>[your_share]</code>
-                <?php esc_html_e('Attributes: networks, labels, style, size, align, brand, utm_campaign, url, title.', $this->text_domain); ?>
+        </div>
+        <?php
+    }
+
+    public function preserve_tab(string $location, int $status): string
+    {
+        if (empty($_POST[$this->options->key()]['current_tab'])) {
+            return $location;
+        }
+
+        $tab = sanitize_key(wp_unslash($_POST[$this->options->key()]['current_tab']));
+        $tabs = array_keys($this->tabs());
+
+        if (!in_array($tab, $tabs, true)) {
+            return $location;
+        }
+
+        return add_query_arg('tab', $tab, $location);
+    }
+
+    private function register_share_settings(): void
+    {
+        $page = $this->page_id('share');
+
+        add_settings_section(
+            'your_share_share_defaults',
+            __('Button defaults', $this->text_domain),
+            function (): void {
+                echo '<p>' . esc_html__('Control the default inline share buttons used by shortcodes, hooks, and templates.', $this->text_domain) . '</p>';
+            },
+            $page
+        );
+
+        add_settings_field(
+            'share_networks_default',
+            __('Default networks', $this->text_domain),
+            [$this, 'field_share_networks'],
+            $page,
+            'your_share_share_defaults'
+        );
+
+        add_settings_field(
+            'share_design',
+            __('Appearance', $this->text_domain),
+            [$this, 'field_share_design'],
+            $page,
+            'your_share_share_defaults'
+        );
+
+        add_settings_field(
+            'share_layout',
+            __('Layout', $this->text_domain),
+            [$this, 'field_share_layout'],
+            $page,
+            'your_share_share_defaults'
+        );
+
+        add_settings_field(
+            'share_shortcode_preview',
+            __('Shortcode preview', $this->text_domain),
+            [$this, 'field_share_shortcode_preview'],
+            $page,
+            'your_share_share_defaults'
+        );
+
+        add_settings_section(
+            'your_share_share_reference',
+            __('Network reference', $this->text_domain),
+            function (): void {
+                echo '<p>' . esc_html__('A quick look at the bundled networks, their slugs, and brand colours.', $this->text_domain) . '</p>';
+            },
+            $page
+        );
+
+        add_settings_field(
+            'share_network_matrix',
+            __('Available networks', $this->text_domain),
+            [$this, 'field_share_network_matrix'],
+            $page,
+            'your_share_share_reference'
+        );
+    }
+
+    private function register_sticky_settings(): void
+    {
+        $page = $this->page_id('sticky');
+
+        add_settings_section(
+            'your_share_sticky_settings',
+            __('Floating share bar', $this->text_domain),
+            function (): void {
+                echo '<p>' . esc_html__('Enable a persistent share bar that follows the reader along the page.', $this->text_domain) . '</p>';
+            },
+            $page
+        );
+
+        add_settings_field(
+            'sticky_enabled',
+            __('Activation', $this->text_domain),
+            [$this, 'field_sticky_enabled'],
+            $page,
+            'your_share_sticky_settings'
+        );
+
+        add_settings_field(
+            'sticky_position',
+            __('Behaviour', $this->text_domain),
+            [$this, 'field_sticky_behaviour'],
+            $page,
+            'your_share_sticky_settings'
+        );
+
+        add_settings_field(
+            'sticky_spacing',
+            __('Sizing', $this->text_domain),
+            [$this, 'field_sticky_spacing'],
+            $page,
+            'your_share_sticky_settings'
+        );
+
+        add_settings_field(
+            'sticky_selectors',
+            __('Auto-insert selectors', $this->text_domain),
+            [$this, 'field_sticky_selectors'],
+            $page,
+            'your_share_sticky_settings'
+        );
+
+        add_settings_field(
+            'sticky_summary',
+            __('Summary', $this->text_domain),
+            [$this, 'field_sticky_summary'],
+            $page,
+            'your_share_sticky_settings'
+        );
+    }
+
+    private function register_smart_settings(): void
+    {
+        $page = $this->page_id('smart');
+
+        add_settings_section(
+            'your_share_smart_settings',
+            __('Smart Share', $this->text_domain),
+            function (): void {
+                echo '<p>' . esc_html__('Dynamically highlight share CTAs based on reading position and visitor context.', $this->text_domain) . '</p>';
+            },
+            $page
+        );
+
+        add_settings_field(
+            'smart_share_enabled',
+            __('Activation', $this->text_domain),
+            [$this, 'field_smart_share_enabled'],
+            $page,
+            'your_share_smart_settings'
+        );
+
+        add_settings_field(
+            'smart_share_selectors',
+            __('Trigger selectors', $this->text_domain),
+            [$this, 'field_smart_share_selectors'],
+            $page,
+            'your_share_smart_settings'
+        );
+
+        add_settings_field(
+            'geo_source',
+            __('Geo source', $this->text_domain),
+            [$this, 'field_geo_source'],
+            $page,
+            'your_share_smart_settings'
+        );
+
+        add_settings_field(
+            'smart_share_summary',
+            __('Summary', $this->text_domain),
+            [$this, 'field_smart_share_summary'],
+            $page,
+            'your_share_smart_settings'
+        );
+    }
+
+    private function register_analytics_settings(): void
+    {
+        $page = $this->page_id('analytics');
+
+        add_settings_section(
+            'your_share_analytics_utm',
+            __('UTM defaults', $this->text_domain),
+            function (): void {
+                echo '<p>' . esc_html__('Set the tagging rules that apply to every generated share URL.', $this->text_domain) . '</p>';
+            },
+            $page
+        );
+
+        add_settings_field(
+            'utm_defaults',
+            __('UTM parameters', $this->text_domain),
+            [$this, 'field_utm_settings'],
+            $page,
+            'your_share_analytics_utm'
+        );
+
+        add_settings_field(
+            'utm_preview',
+            __('Preview', $this->text_domain),
+            [$this, 'field_utm_preview'],
+            $page,
+            'your_share_analytics_utm'
+        );
+
+        add_settings_section(
+            'your_share_analytics_toggles',
+            __('Analytics toggles', $this->text_domain),
+            function (): void {
+                echo '<p>' . esc_html__('Choose how interactions are tracked in analytics platforms.', $this->text_domain) . '</p>';
+            },
+            $page
+        );
+
+        add_settings_field(
+            'analytics_toggles',
+            __('Event tracking', $this->text_domain),
+            [$this, 'field_analytics_toggles'],
+            $page,
+            'your_share_analytics_toggles'
+        );
+    }
+
+    public function field_share_networks(): void
+    {
+        $values    = $this->values();
+        $active    = $values['share_networks_default'];
+        $available = $this->networks->all();
+        $order     = array_unique(array_merge($active, array_keys($available)));
+        $input_id  = $this->field_id('share_networks_default');
+        ?>
+        <div class="your-share-network-picker" data-your-share-networks>
+            <input type="hidden" id="<?php echo esc_attr($input_id); ?>" name="<?php echo esc_attr($this->name('share_networks_default')); ?>" value="<?php echo esc_attr(implode(',', $active)); ?>" data-your-share-network-input>
+            <div class="your-share-network-selected">
+                <p class="description"><?php esc_html_e('Drag to reorder or remove default networks. The first network is used most prominently.', $this->text_domain); ?></p>
+                <ul class="your-share-network-list" data-your-share-network-list>
+                    <?php foreach ($active as $slug) :
+                        $label        = $available[$slug][0] ?? ucwords(str_replace('-', ' ', $slug));
+                        $color        = $available[$slug][1] ?? '#111827';
+                        $remove_label = sprintf(__('Remove %s', $this->text_domain), $label);
+                        ?>
+                        <li class="your-share-network-item" data-value="<?php echo esc_attr($slug); ?>" draggable="true">
+                            <span class="your-share-network-handle" aria-hidden="true">⋮⋮</span>
+                            <span class="your-share-network-swatch" style="--your-share-network-color: <?php echo esc_attr($color); ?>"></span>
+                            <span class="your-share-network-label"><?php echo esc_html($label); ?></span>
+                            <button type="button" class="your-share-network-remove" data-action="remove" aria-label="<?php echo esc_attr($remove_label); ?>">&times;</button>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+                <p class="description"><span data-your-share-network-count><?php echo esc_html(count($active)); ?></span> <?php esc_html_e('active networks.', $this->text_domain); ?></p>
+            </div>
+            <div class="your-share-network-available">
+                <p class="description"><?php esc_html_e('Add additional services:', $this->text_domain); ?></p>
+                <div class="your-share-network-buttons">
+                    <?php foreach ($order as $slug) :
+                        $label        = $available[$slug][0] ?? ucwords(str_replace('-', ' ', $slug));
+                        $color        = $available[$slug][1] ?? '#111827';
+                        $remove_label = sprintf(__('Remove %s', $this->text_domain), $label);
+                        $is_active    = in_array($slug, $active, true);
+                        ?>
+                        <button
+                            type="button"
+                            class="button button-small your-share-network-add<?php echo $is_active ? ' is-active' : ''; ?>"
+                            data-value="<?php echo esc_attr($slug); ?>"
+                            data-label="<?php echo esc_attr($label); ?>"
+                            data-color="<?php echo esc_attr($color); ?>"
+                            data-remove-label="<?php echo esc_attr($remove_label); ?>"
+                            <?php disabled($is_active); ?>
+                        >
+                            <?php echo esc_html($label); ?>
+                        </button>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+        </div>
+        <?php
+    }
+
+    public function field_share_design(): void
+    {
+        $values = $this->values();
+        ?>
+        <div class="your-share-field-grid">
+            <label for="<?php echo esc_attr($this->field_id('share_style')); ?>">
+                <span><?php esc_html_e('Style', $this->text_domain); ?></span>
+                <select id="<?php echo esc_attr($this->field_id('share_style')); ?>" name="<?php echo esc_attr($this->name('share_style')); ?>" data-your-share-shortcode-prop="style">
+                    <option value="solid" <?php selected($values['share_style'], 'solid'); ?>><?php esc_html_e('Solid', $this->text_domain); ?></option>
+                    <option value="outline" <?php selected($values['share_style'], 'outline'); ?>><?php esc_html_e('Outline', $this->text_domain); ?></option>
+                    <option value="ghost" <?php selected($values['share_style'], 'ghost'); ?>><?php esc_html_e('Ghost', $this->text_domain); ?></option>
+                </select>
+            </label>
+            <label for="<?php echo esc_attr($this->field_id('share_size')); ?>">
+                <span><?php esc_html_e('Size', $this->text_domain); ?></span>
+                <select id="<?php echo esc_attr($this->field_id('share_size')); ?>" name="<?php echo esc_attr($this->name('share_size')); ?>" data-your-share-shortcode-prop="size">
+                    <option value="sm" <?php selected($values['share_size'], 'sm'); ?>><?php esc_html_e('Small', $this->text_domain); ?></option>
+                    <option value="md" <?php selected($values['share_size'], 'md'); ?>><?php esc_html_e('Medium', $this->text_domain); ?></option>
+                    <option value="lg" <?php selected($values['share_size'], 'lg'); ?>><?php esc_html_e('Large', $this->text_domain); ?></option>
+                </select>
+            </label>
+            <label for="<?php echo esc_attr($this->field_id('share_labels')); ?>">
+                <span><?php esc_html_e('Label display', $this->text_domain); ?></span>
+                <select id="<?php echo esc_attr($this->field_id('share_labels')); ?>" name="<?php echo esc_attr($this->name('share_labels')); ?>" data-your-share-shortcode-prop="labels">
+                    <option value="auto" <?php selected($values['share_labels'], 'auto'); ?>><?php esc_html_e('Auto', $this->text_domain); ?></option>
+                    <option value="show" <?php selected($values['share_labels'], 'show'); ?>><?php esc_html_e('Show', $this->text_domain); ?></option>
+                    <option value="hide" <?php selected($values['share_labels'], 'hide'); ?>><?php esc_html_e('Hide', $this->text_domain); ?></option>
+                </select>
+            </label>
+            <label>
+                <input type="checkbox" name="<?php echo esc_attr($this->name('share_brand_colors')); ?>" value="1" <?php checked($values['share_brand_colors'], 1); ?> data-your-share-shortcode-prop="brand">
+                <?php esc_html_e('Use brand colours', $this->text_domain); ?>
+            </label>
+        </div>
+        <?php
+    }
+
+    public function field_share_layout(): void
+    {
+        $values = $this->values();
+        ?>
+        <div class="your-share-field-grid">
+            <label for="<?php echo esc_attr($this->field_id('share_align')); ?>">
+                <span><?php esc_html_e('Alignment', $this->text_domain); ?></span>
+                <select id="<?php echo esc_attr($this->field_id('share_align')); ?>" name="<?php echo esc_attr($this->name('share_align')); ?>">
+                    <option value="left" <?php selected($values['share_align'], 'left'); ?>><?php esc_html_e('Left', $this->text_domain); ?></option>
+                    <option value="center" <?php selected($values['share_align'], 'center'); ?>><?php esc_html_e('Center', $this->text_domain); ?></option>
+                    <option value="right" <?php selected($values['share_align'], 'right'); ?>><?php esc_html_e('Right', $this->text_domain); ?></option>
+                    <option value="space-between" <?php selected($values['share_align'], 'space-between'); ?>><?php esc_html_e('Justify', $this->text_domain); ?></option>
+                </select>
+            </label>
+            <label for="<?php echo esc_attr($this->field_id('share_gap')); ?>">
+                <span><?php esc_html_e('Gap', $this->text_domain); ?></span>
+                <div class="your-share-input-suffix">
+                    <input type="number" min="0" id="<?php echo esc_attr($this->field_id('share_gap')); ?>" name="<?php echo esc_attr($this->name('share_gap')); ?>" value="<?php echo esc_attr($values['share_gap']); ?>">
+                    <span>px</span>
+                </div>
+            </label>
+            <label for="<?php echo esc_attr($this->field_id('share_radius')); ?>">
+                <span><?php esc_html_e('Corner radius', $this->text_domain); ?></span>
+                <div class="your-share-input-suffix">
+                    <input type="number" min="0" id="<?php echo esc_attr($this->field_id('share_radius')); ?>" name="<?php echo esc_attr($this->name('share_radius')); ?>" value="<?php echo esc_attr($values['share_radius']); ?>">
+                    <span>px</span>
+                </div>
+            </label>
+        </div>
+        <?php
+    }
+
+    public function field_share_shortcode_preview(): void
+    {
+        $values   = $this->values();
+        $networks = implode(',', $values['share_networks_default']);
+        $brand    = $values['share_brand_colors'] ? '1' : '0';
+        $shortcode = sprintf('[your_share networks="%s" style="%s" size="%s" labels="%s" brand="%s"]', $networks, $values['share_style'], $values['share_size'], $values['share_labels'], $brand);
+        ?>
+        <div class="your-share-shortcode-preview">
+            <code data-your-share-shortcode><?php echo esc_html($shortcode); ?></code>
+            <p class="description"><?php esc_html_e('Use this shortcode anywhere to pull in the defaults above. Override attributes per placement as needed.', $this->text_domain); ?></p>
+        </div>
+        <?php
+    }
+
+    public function field_share_network_matrix(): void
+    {
+        $networks = $this->networks->all();
+        ?>
+        <table class="widefat striped your-share-network-matrix">
+            <thead>
+                <tr>
+                    <th scope="col"><?php esc_html_e('Network', $this->text_domain); ?></th>
+                    <th scope="col"><?php esc_html_e('Slug', $this->text_domain); ?></th>
+                    <th scope="col"><?php esc_html_e('Brand colour', $this->text_domain); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($networks as $slug => $data) :
+                    [$label, $color] = $data;
+                    ?>
+                    <tr>
+                        <td><?php echo esc_html($label); ?></td>
+                        <td><code><?php echo esc_html($slug); ?></code></td>
+                        <td>
+                            <span class="your-share-color-chip" style="--your-share-network-color: <?php echo esc_attr($color); ?>"></span>
+                            <code><?php echo esc_html($color); ?></code>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+        <?php
+    }
+
+    public function field_sticky_enabled(): void
+    {
+        $values = $this->values();
+        ?>
+        <label class="your-share-toggle">
+            <input type="checkbox" name="<?php echo esc_attr($this->name('sticky_enabled')); ?>" value="1" <?php checked($values['sticky_enabled'], 1); ?> data-your-share-sticky-prop="enabled">
+            <?php esc_html_e('Enable floating share bar on posts', $this->text_domain); ?>
+        </label>
+        <p class="description"><?php esc_html_e('The floating bar inherits the default networks unless overridden via template tags.', $this->text_domain); ?></p>
+        <?php
+    }
+
+    public function field_sticky_behaviour(): void
+    {
+        $values = $this->values();
+        ?>
+        <div class="your-share-field-grid">
+            <label for="<?php echo esc_attr($this->field_id('sticky_position')); ?>">
+                <span><?php esc_html_e('Position', $this->text_domain); ?></span>
+                <select id="<?php echo esc_attr($this->field_id('sticky_position')); ?>" name="<?php echo esc_attr($this->name('sticky_position')); ?>" data-your-share-sticky-prop="position">
+                    <option value="left" <?php selected($values['sticky_position'], 'left'); ?>><?php esc_html_e('Left', $this->text_domain); ?></option>
+                    <option value="right" <?php selected($values['sticky_position'], 'right'); ?>><?php esc_html_e('Right', $this->text_domain); ?></option>
+                </select>
+            </label>
+            <label for="<?php echo esc_attr($this->field_id('sticky_breakpoint')); ?>">
+                <span><?php esc_html_e('Show on widths ≥', $this->text_domain); ?></span>
+                <div class="your-share-input-suffix">
+                    <input type="number" min="0" id="<?php echo esc_attr($this->field_id('sticky_breakpoint')); ?>" name="<?php echo esc_attr($this->name('sticky_breakpoint')); ?>" value="<?php echo esc_attr($values['sticky_breakpoint']); ?>" data-your-share-sticky-prop="breakpoint">
+                    <span>px</span>
+                </div>
+            </label>
+        </div>
+        <?php
+    }
+
+    public function field_sticky_spacing(): void
+    {
+        $values = $this->values();
+        ?>
+        <div class="your-share-field-grid">
+            <label for="<?php echo esc_attr($this->field_id('sticky_gap')); ?>">
+                <span><?php esc_html_e('Button gap', $this->text_domain); ?></span>
+                <div class="your-share-input-suffix">
+                    <input type="number" min="0" id="<?php echo esc_attr($this->field_id('sticky_gap')); ?>" name="<?php echo esc_attr($this->name('sticky_gap')); ?>" value="<?php echo esc_attr($values['sticky_gap']); ?>">
+                    <span>px</span>
+                </div>
+            </label>
+            <label for="<?php echo esc_attr($this->field_id('sticky_radius')); ?>">
+                <span><?php esc_html_e('Corner radius', $this->text_domain); ?></span>
+                <div class="your-share-input-suffix">
+                    <input type="number" min="0" id="<?php echo esc_attr($this->field_id('sticky_radius')); ?>" name="<?php echo esc_attr($this->name('sticky_radius')); ?>" value="<?php echo esc_attr($values['sticky_radius']); ?>">
+                    <span>px</span>
+                </div>
+            </label>
+        </div>
+        <?php
+    }
+
+    public function field_sticky_selectors(): void
+    {
+        $values = $this->values();
+        ?>
+        <textarea rows="3" class="large-text" name="<?php echo esc_attr($this->name('sticky_selectors')); ?>" id="<?php echo esc_attr($this->field_id('sticky_selectors')); ?>" placeholder=".entry-content"><?php echo esc_textarea($values['sticky_selectors']); ?></textarea>
+        <p class="description"><?php esc_html_e('Comma-separated CSS selectors where the floating bar should auto-inject. Leave blank to manage output manually.', $this->text_domain); ?></p>
+        <?php
+    }
+
+    public function field_sticky_summary(): void
+    {
+        $values     = $this->values();
+        $status     = $values['sticky_enabled'] ? __('enabled', $this->text_domain) : __('disabled', $this->text_domain);
+        $position   = $values['sticky_position'] === 'right' ? __('right', $this->text_domain) : __('left', $this->text_domain);
+        $breakpoint = intval($values['sticky_breakpoint']);
+        ?>
+        <div class="your-share-summary" data-your-share-sticky-summary>
+            <p>
+                <?php
+                printf(
+                    esc_html__('Floating bar is %1$s, showing on screens ≥ %2$dpx on the %3$s edge.', $this->text_domain),
+                    esc_html($status),
+                    esc_html($breakpoint),
+                    esc_html($position)
+                );
+                ?>
             </p>
         </div>
         <?php
+    }
+
+    public function field_smart_share_enabled(): void
+    {
+        $values = $this->values();
+        ?>
+        <label class="your-share-toggle">
+            <input type="checkbox" name="<?php echo esc_attr($this->name('smart_share_enabled')); ?>" value="1" <?php checked($values['smart_share_enabled'], 1); ?> data-your-share-smart-prop="enabled">
+            <?php esc_html_e('Enable Smart Share prompts', $this->text_domain); ?>
+        </label>
+        <p class="description"><?php esc_html_e('Promote contextual share prompts as visitors scroll through long-form content.', $this->text_domain); ?></p>
+        <?php
+    }
+
+    public function field_smart_share_selectors(): void
+    {
+        $values = $this->values();
+        ?>
+        <textarea rows="4" class="large-text" name="<?php echo esc_attr($this->name('smart_share_selectors')); ?>" id="<?php echo esc_attr($this->field_id('smart_share_selectors')); ?>" placeholder=".entry-content h2, .entry-content h3"><?php echo esc_textarea($values['smart_share_selectors']); ?></textarea>
+        <p class="description"><?php esc_html_e('Enter selectors that should receive inline Smart Share prompts. One selector per line or comma.', $this->text_domain); ?></p>
+        <?php
+    }
+
+    public function field_geo_source(): void
+    {
+        $values = $this->values();
+        ?>
+        <select id="<?php echo esc_attr($this->field_id('geo_source')); ?>" name="<?php echo esc_attr($this->name('geo_source')); ?>" data-your-share-smart-prop="geo">
+            <option value="auto" <?php selected($values['geo_source'], 'auto'); ?>><?php esc_html_e('Auto detect (recommended)', $this->text_domain); ?></option>
+            <option value="ip" <?php selected($values['geo_source'], 'ip'); ?>><?php esc_html_e('IP address lookup', $this->text_domain); ?></option>
+            <option value="manual" <?php selected($values['geo_source'], 'manual'); ?>><?php esc_html_e('Manual override via filters', $this->text_domain); ?></option>
+        </select>
+        <p class="description"><?php esc_html_e('Determines how Smart Share chooses the best networks for a visitor based on location.', $this->text_domain); ?></p>
+        <?php
+    }
+
+    public function field_smart_share_summary(): void
+    {
+        $values   = $this->values();
+        $status   = $values['smart_share_enabled'] ? __('enabled', $this->text_domain) : __('disabled', $this->text_domain);
+        $geo      = $values['geo_source'];
+        $geo_text = [
+            'auto'   => __('auto-detected by device locale', $this->text_domain),
+            'ip'     => __('resolved via visitor IP', $this->text_domain),
+            'manual' => __('controlled manually', $this->text_domain),
+        ];
+        $geo_label = $geo_text[$geo] ?? $geo_text['auto'];
+        ?>
+        <div class="your-share-summary" data-your-share-smart-summary>
+            <p>
+                <?php
+                printf(
+                    esc_html__('Smart Share is %1$s with audiences %2$s.', $this->text_domain),
+                    esc_html($status),
+                    esc_html($geo_label)
+                );
+                ?>
+            </p>
+        </div>
+        <?php
+    }
+
+    public function field_utm_settings(): void
+    {
+        $values = $this->values();
+        ?>
+        <div class="your-share-utm-settings">
+            <label class="your-share-toggle">
+                <input type="checkbox" name="<?php echo esc_attr($this->name('enable_utm')); ?>" value="1" <?php checked($values['enable_utm'], 1); ?> data-your-share-utm-prop="enabled">
+                <?php esc_html_e('Append UTM parameters to share URLs', $this->text_domain); ?>
+            </label>
+            <div class="your-share-field-grid">
+                <label for="<?php echo esc_attr($this->field_id('utm_medium')); ?>">
+                    <span><?php esc_html_e('utm_medium', $this->text_domain); ?></span>
+                    <input type="text" id="<?php echo esc_attr($this->field_id('utm_medium')); ?>" name="<?php echo esc_attr($this->name('utm_medium')); ?>" value="<?php echo esc_attr($values['utm_medium']); ?>" data-your-share-utm-prop="medium">
+                </label>
+                <label for="<?php echo esc_attr($this->field_id('utm_campaign')); ?>">
+                    <span><?php esc_html_e('utm_campaign (default)', $this->text_domain); ?></span>
+                    <input type="text" id="<?php echo esc_attr($this->field_id('utm_campaign')); ?>" name="<?php echo esc_attr($this->name('utm_campaign')); ?>" value="<?php echo esc_attr($values['utm_campaign']); ?>" data-your-share-utm-prop="campaign">
+                </label>
+                <label for="<?php echo esc_attr($this->field_id('utm_term')); ?>">
+                    <span><?php esc_html_e('utm_term (default)', $this->text_domain); ?></span>
+                    <input type="text" id="<?php echo esc_attr($this->field_id('utm_term')); ?>" name="<?php echo esc_attr($this->name('utm_term')); ?>" value="<?php echo esc_attr($values['utm_term']); ?>" data-your-share-utm-prop="term">
+                </label>
+                <label for="<?php echo esc_attr($this->field_id('utm_content')); ?>" class="your-share-field-wide">
+                    <span><?php esc_html_e('utm_content template', $this->text_domain); ?></span>
+                    <input type="text" id="<?php echo esc_attr($this->field_id('utm_content')); ?>" name="<?php echo esc_attr($this->name('utm_content')); ?>" value="<?php echo esc_attr($values['utm_content']); ?>" data-your-share-utm-prop="content">
+                </label>
+            </div>
+            <p class="description"><?php esc_html_e('Supports template tags like {ID}, {slug}, and {post_type}. Shortcodes can override the campaign per placement.', $this->text_domain); ?></p>
+        </div>
+        <?php
+    }
+
+    public function field_utm_preview(): void
+    {
+        $values    = $this->values();
+        $medium    = $values['utm_medium'];
+        $campaign  = $values['utm_campaign'] ?: __('campaign-name', $this->text_domain);
+        $term      = $values['utm_term'] ?: __('optional-term', $this->text_domain);
+        $content   = $values['utm_content'];
+        $base_url  = home_url('/your-post/');
+        $preview   = add_query_arg([
+            'utm_source'   => 'x',
+            'utm_medium'   => $medium,
+            'utm_campaign' => $campaign,
+            'utm_term'     => $term,
+            'utm_content'  => $content,
+        ], $base_url);
+        ?>
+        <div class="your-share-shortcode-preview" data-your-share-utm-preview data-base="<?php echo esc_attr($base_url); ?>" data-network="x">
+            <code data-your-share-utm-output><?php echo esc_html($preview); ?></code>
+            <p class="description"><?php esc_html_e('Preview of a shared URL for the X network. Term/content are omitted if left empty.', $this->text_domain); ?></p>
+        </div>
+        <?php
+    }
+
+    public function field_analytics_toggles(): void
+    {
+        $values = $this->values();
+        ?>
+        <div class="your-share-field-stack">
+            <label class="your-share-toggle">
+                <input type="checkbox" name="<?php echo esc_attr($this->name('analytics_events')); ?>" value="1" <?php checked($values['analytics_events'], 1); ?>>
+                <?php esc_html_e('Dispatch share events to the browser dataLayer', $this->text_domain); ?>
+            </label>
+            <label class="your-share-toggle">
+                <input type="checkbox" name="<?php echo esc_attr($this->name('analytics_ga4')); ?>" value="1" <?php checked($values['analytics_ga4'], 1); ?>>
+                <?php esc_html_e('Emit Google Analytics 4 compatible events', $this->text_domain); ?>
+            </label>
+            <label class="your-share-toggle">
+                <input type="checkbox" name="<?php echo esc_attr($this->name('analytics_console')); ?>" value="1" <?php checked($values['analytics_console'], 1); ?>>
+                <?php esc_html_e('Log debug output to the browser console', $this->text_domain); ?>
+            </label>
+        </div>
+        <?php
+    }
+
+    private function tabs(): array
+    {
+        return [
+            'share'     => __('Share', $this->text_domain),
+            'sticky'    => __('Sticky Bar', $this->text_domain),
+            'smart'     => __('Smart Share', $this->text_domain),
+            'analytics' => __('Analytics & UTM', $this->text_domain),
+        ];
+    }
+
+    private function current_tab(): string
+    {
+        $tabs    = array_keys($this->tabs());
+        $default = reset($tabs) ?: 'share';
+        $tab     = $default;
+
+        if (isset($_GET['tab'])) {
+            $tab = sanitize_key(wp_unslash($_GET['tab']));
+        } elseif (!empty($_POST[$this->options->key()]['current_tab'])) {
+            $tab = sanitize_key(wp_unslash($_POST[$this->options->key()]['current_tab']));
+        }
+
+        if (!in_array($tab, $tabs, true)) {
+            $tab = $default;
+        }
+
+        return $tab;
+    }
+
+    private function page_id(string $tab): string
+    {
+        return $this->slug . '_' . $tab;
+    }
+
+    private function panel_id(string $tab): string
+    {
+        return 'your-share-panel-' . $tab;
+    }
+
+    private function values(): array
+    {
+        if (null === $this->cached_values) {
+            $this->cached_values = $this->options->all();
+        }
+
+        return $this->cached_values;
+    }
+
+    private function name(string $field): string
+    {
+        return $this->options->key() . '[' . $field . ']';
+    }
+
+    private function field_id(string $field): string
+    {
+        return 'your-share-' . str_replace('_', '-', $field);
     }
 }

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -23,23 +23,47 @@ class Options
 
     public function defaults(): array
     {
-        return [
-            'enable_utm'          => 1,
-            'utm_medium'          => 'social',
-            'utm_campaign'        => '',
-            'utm_term'            => '',
-            'utm_content'         => 'post-{ID}-share',
-            'brand_colors'        => 1,
-            'style'               => 'solid',
-            'size'                => 'md',
-            'labels'              => 'auto',
-            'networks'            => 'facebook,x,whatsapp,telegram,linkedin,reddit,email,copy',
-            'floating_enabled'    => 0,
-            'floating_position'   => 'left',
-            'floating_breakpoint' => 1024,
-            'gap'                 => '8',
-            'radius'              => '9999',
+        $defaults = [
+            'share_brand_colors'        => 1,
+            'share_style'               => 'solid',
+            'share_size'                => 'md',
+            'share_labels'              => 'auto',
+            'share_align'               => 'left',
+            'share_gap'                 => 8,
+            'share_radius'              => 9999,
+            'share_networks_default'    => ['facebook', 'x', 'whatsapp', 'telegram', 'linkedin', 'reddit', 'email', 'copy'],
+            'sticky_enabled'            => 0,
+            'sticky_position'           => 'left',
+            'sticky_breakpoint'         => 1024,
+            'sticky_gap'                => 8,
+            'sticky_radius'             => 9999,
+            'sticky_selectors'          => '.entry-content',
+            'smart_share_enabled'       => 0,
+            'smart_share_selectors'     => ".entry-content h2, .entry-content h3",
+            'geo_source'                => 'auto',
+            'enable_utm'                => 1,
+            'utm_medium'                => 'social',
+            'utm_campaign'              => '',
+            'utm_term'                  => '',
+            'utm_content'               => 'post-{ID}-share',
+            'analytics_events'          => 1,
+            'analytics_console'         => 0,
+            'analytics_ga4'             => 0,
         ];
+
+        // Backwards compatibility aliases for legacy code paths.
+        $defaults['brand_colors']        = $defaults['share_brand_colors'];
+        $defaults['style']               = $defaults['share_style'];
+        $defaults['size']                = $defaults['share_size'];
+        $defaults['labels']              = $defaults['share_labels'];
+        $defaults['networks']            = implode(',', $defaults['share_networks_default']);
+        $defaults['floating_enabled']    = $defaults['sticky_enabled'];
+        $defaults['floating_position']   = $defaults['sticky_position'];
+        $defaults['floating_breakpoint'] = $defaults['sticky_breakpoint'];
+        $defaults['gap']                 = (string) $defaults['share_gap'];
+        $defaults['radius']              = (string) $defaults['share_radius'];
+
+        return $defaults;
     }
 
     public function all(): array
@@ -50,7 +74,21 @@ class Options
             $stored = [];
         }
 
-        return wp_parse_args($stored, $this->defaults());
+        $options = wp_parse_args($stored, $this->defaults());
+
+        $options['share_networks_default'] = $this->normalize_networks($options['share_networks_default']);
+        $options['networks']               = implode(',', $options['share_networks_default']);
+        $options['brand_colors']           = (int) $options['share_brand_colors'];
+        $options['style']                  = $options['share_style'];
+        $options['size']                   = $options['share_size'];
+        $options['labels']                 = $options['share_labels'];
+        $options['floating_enabled']       = (int) $options['sticky_enabled'];
+        $options['floating_position']      = $options['sticky_position'];
+        $options['floating_breakpoint']    = $options['sticky_breakpoint'];
+        $options['gap']                    = (string) $options['share_gap'];
+        $options['radius']                 = (string) $options['share_radius'];
+
+        return $options;
     }
 
     public function sanitize(array $input): array
@@ -58,26 +96,97 @@ class Options
         $defaults = $this->defaults();
 
         $output = [];
-        $output['enable_utm']          = !empty($input['enable_utm']) ? 1 : 0;
-        $output['utm_medium']          = sanitize_text_field($input['utm_medium'] ?? $defaults['utm_medium']);
-        $output['utm_campaign']        = sanitize_text_field($input['utm_campaign'] ?? '');
-        $output['utm_term']            = sanitize_text_field($input['utm_term'] ?? '');
-        $output['utm_content']         = sanitize_text_field($input['utm_content'] ?? $defaults['utm_content']);
-        $output['brand_colors']        = !empty($input['brand_colors']) ? 1 : 0;
-        $output['style']               = in_array($input['style'] ?? $defaults['style'], ['solid', 'outline', 'ghost'], true)
-            ? $input['style'] : $defaults['style'];
-        $output['size']                = in_array($input['size'] ?? $defaults['size'], ['sm', 'md', 'lg'], true)
-            ? $input['size'] : $defaults['size'];
-        $output['labels']              = in_array($input['labels'] ?? $defaults['labels'], ['auto', 'show', 'hide'], true)
-            ? $input['labels'] : $defaults['labels'];
-        $output['networks']            = sanitize_text_field($input['networks'] ?? $defaults['networks']);
-        $output['floating_enabled']    = !empty($input['floating_enabled']) ? 1 : 0;
-        $output['floating_position']   = in_array($input['floating_position'] ?? $defaults['floating_position'], ['left', 'right'], true)
-            ? $input['floating_position'] : $defaults['floating_position'];
-        $output['floating_breakpoint'] = intval($input['floating_breakpoint'] ?? $defaults['floating_breakpoint']);
-        $output['gap']                 = sanitize_text_field($input['gap'] ?? $defaults['gap']);
-        $output['radius']              = sanitize_text_field($input['radius'] ?? $defaults['radius']);
+        $output['share_brand_colors'] = !empty($input['share_brand_colors']) ? 1 : 0;
+        $output['share_style']        = in_array($input['share_style'] ?? '', ['solid', 'outline', 'ghost'], true)
+            ? $input['share_style'] : $defaults['share_style'];
+        $output['share_size']         = in_array($input['share_size'] ?? '', ['sm', 'md', 'lg'], true)
+            ? $input['share_size'] : $defaults['share_size'];
+        $output['share_labels']       = in_array($input['share_labels'] ?? '', ['auto', 'show', 'hide'], true)
+            ? $input['share_labels'] : $defaults['share_labels'];
+        $output['share_align']        = in_array($input['share_align'] ?? '', ['left', 'center', 'right', 'space-between'], true)
+            ? $input['share_align'] : $defaults['share_align'];
+
+        $networks = $input['share_networks_default'] ?? $defaults['share_networks_default'];
+        if (is_string($networks)) {
+            $networks = explode(',', $networks);
+        }
+        if (!is_array($networks)) {
+            $networks = [];
+        }
+        $networks = $this->normalize_networks($networks);
+        if (empty($networks)) {
+            $networks = $defaults['share_networks_default'];
+        }
+        $output['share_networks_default'] = $networks;
+
+        $output['share_gap']    = max(0, intval($input['share_gap'] ?? $defaults['share_gap']));
+        $output['share_radius'] = max(0, intval($input['share_radius'] ?? $defaults['share_radius']));
+
+        $output['sticky_enabled']     = !empty($input['sticky_enabled']) ? 1 : 0;
+        $output['sticky_position']    = in_array($input['sticky_position'] ?? '', ['left', 'right'], true)
+            ? $input['sticky_position'] : $defaults['sticky_position'];
+        $output['sticky_breakpoint']  = max(0, intval($input['sticky_breakpoint'] ?? $defaults['sticky_breakpoint']));
+        $output['sticky_gap']         = max(0, intval($input['sticky_gap'] ?? $defaults['sticky_gap']));
+        $output['sticky_radius']      = max(0, intval($input['sticky_radius'] ?? $defaults['sticky_radius']));
+        $output['sticky_selectors']   = sanitize_text_field($input['sticky_selectors'] ?? $defaults['sticky_selectors']);
+
+        $output['smart_share_enabled']   = !empty($input['smart_share_enabled']) ? 1 : 0;
+        $output['smart_share_selectors'] = sanitize_textarea_field($input['smart_share_selectors'] ?? $defaults['smart_share_selectors']);
+
+        $geo_source = sanitize_key($input['geo_source'] ?? $defaults['geo_source']);
+        if (!in_array($geo_source, ['auto', 'ip', 'manual'], true)) {
+            $geo_source = $defaults['geo_source'];
+        }
+        $output['geo_source'] = $geo_source;
+
+        $output['enable_utm']  = !empty($input['enable_utm']) ? 1 : 0;
+        $output['utm_medium']  = sanitize_text_field($input['utm_medium'] ?? $defaults['utm_medium']);
+        $output['utm_campaign'] = sanitize_text_field($input['utm_campaign'] ?? '');
+        $output['utm_term']    = sanitize_text_field($input['utm_term'] ?? '');
+        $output['utm_content'] = sanitize_text_field($input['utm_content'] ?? $defaults['utm_content']);
+
+        $output['analytics_events']  = !empty($input['analytics_events']) ? 1 : 0;
+        $output['analytics_console'] = !empty($input['analytics_console']) ? 1 : 0;
+        $output['analytics_ga4']     = !empty($input['analytics_ga4']) ? 1 : 0;
+
+        // Legacy aliases to keep existing rendering logic functioning.
+        $output['brand_colors']        = $output['share_brand_colors'];
+        $output['style']               = $output['share_style'];
+        $output['size']                = $output['share_size'];
+        $output['labels']              = $output['share_labels'];
+        $output['networks']            = implode(',', $output['share_networks_default']);
+        $output['floating_enabled']    = $output['sticky_enabled'];
+        $output['floating_position']   = $output['sticky_position'];
+        $output['floating_breakpoint'] = $output['sticky_breakpoint'];
+        $output['gap']                 = (string) $output['share_gap'];
+        $output['radius']              = (string) $output['share_radius'];
+
+        unset($output['current_tab']);
 
         return $output;
+    }
+
+    /**
+     * Normalise the stored network list into a clean array of slugs.
+     *
+     * @param mixed $value Raw value from user input / database.
+     */
+    private function normalize_networks($value): array
+    {
+        if (is_string($value)) {
+            $value = explode(',', $value);
+        }
+
+        if (!is_array($value)) {
+            $value = [];
+        }
+
+        $value = array_filter(array_map(static function ($item) {
+            $item = sanitize_key((string) $item);
+
+            return $item !== '' ? $item : null;
+        }, $value));
+
+        return array_values(array_unique($value));
     }
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -85,7 +85,7 @@ class Plugin
         });
 
         $this->container->set(Admin::class, function (Container $c): Admin {
-            return new Admin($c->get(Options::class), self::SLUG, self::TEXT_DOMAIN);
+            return new Admin($c->get(Options::class), $c->get(Networks::class), self::SLUG, self::TEXT_DOMAIN);
         });
 
         $this->container->set(Shortcode::class, function (Container $c): Shortcode {

--- a/includes/class-shortcode.php
+++ b/includes/class-shortcode.php
@@ -40,13 +40,18 @@ class Shortcode
             $atts = [];
         }
 
+        $networks_default = $options['share_networks_default'];
+        if (is_array($networks_default)) {
+            $networks_default = implode(',', $networks_default);
+        }
+
         $atts = shortcode_atts([
-            'networks'     => $options['networks'],
-            'labels'       => $options['labels'],
-            'style'        => $options['style'],
-            'size'         => $options['size'],
-            'align'        => 'left',
-            'brand'        => $options['brand_colors'] ? '1' : '0',
+            'networks'     => $networks_default,
+            'labels'       => $options['share_labels'],
+            'style'        => $options['share_style'],
+            'size'         => $options['share_size'],
+            'align'        => $options['share_align'],
+            'brand'        => $options['share_brand_colors'] ? '1' : '0',
             'utm_campaign' => '',
             'url'          => '',
             'title'        => '',
@@ -64,17 +69,22 @@ class Shortcode
     {
         $options = $this->options->all();
 
-        if (empty($options['floating_enabled'])) {
+        if (empty($options['sticky_enabled'])) {
             return;
         }
 
+        $networks_default = $options['share_networks_default'];
+        if (is_array($networks_default)) {
+            $networks_default = implode(',', $networks_default);
+        }
+
         $atts = [
-            'networks'     => $options['networks'],
+            'networks'     => $networks_default,
             'labels'       => 'hide',
-            'style'        => $options['style'],
+            'style'        => $options['share_style'],
             'size'         => 'sm',
             'align'        => 'left',
-            'brand'        => $options['brand_colors'] ? '1' : '0',
+            'brand'        => $options['share_brand_colors'] ? '1' : '0',
             'utm_campaign' => '',
             'url'          => '',
             'title'        => '',
@@ -82,8 +92,8 @@ class Shortcode
 
         $context = [
             'placement'  => 'floating',
-            'position'   => $options['floating_position'],
-            'breakpoint' => intval($options['floating_breakpoint']),
+            'position'   => $options['sticky_position'],
+            'breakpoint' => intval($options['sticky_breakpoint']),
         ];
 
         echo $this->renderer->render($context, $atts); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
## Summary
- replace the legacy settings table with a tabbed admin UI covering share, sticky bar, smart share, and analytics sections along with sortable networks and live previews
- expand the options schema to persist the new share, sticky, smart, and analytics settings while keeping legacy aliases and update the renderer/shortcode to use them
- enhance the admin assets with tab navigation, sortable list behaviour, UTM previewing, and refreshed styles

## Testing
- php -l includes/class-admin.php
- php -l includes/class-options.php
- php -l includes/class-shortcode.php
- php -l includes/class-render.php
- php -l includes/class-plugin.php


------
https://chatgpt.com/codex/tasks/task_e_68cf1c455c14832cacead1da5de79d66