### PR TITLE
Add Smart Share geo matrix and visitor detection

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -300,6 +300,14 @@ class Admin
         );
 
         add_settings_field(
+            'smart_share_matrix',
+            __('Country networks', $this->text_domain),
+            [$this, 'field_smart_share_matrix'],
+            $page,
+            'your_share_smart_settings'
+        );
+
+        add_settings_field(
             'geo_source',
             __('Geo source', $this->text_domain),
             [$this, 'field_geo_source'],
@@ -641,6 +649,23 @@ class Admin
         <?php
     }
 
+    public function field_smart_share_matrix(): void
+    {
+        $values = $this->values();
+        $matrix = $values['smart_share_matrix'];
+        $rows   = [];
+
+        foreach ($matrix as $country => $networks) {
+            $rows[] = $country . ': ' . implode(', ', $networks);
+        }
+
+        $value = implode("\n", $rows);
+        ?>
+        <textarea rows="6" class="large-text code" name="<?php echo esc_attr($this->name('smart_share_matrix')); ?>" id="<?php echo esc_attr($this->field_id('smart_share_matrix')); ?>" placeholder="US: facebook, x, linkedin"><?php echo esc_textarea($value); ?></textarea>
+        <p class="description"><?php esc_html_e('Map two-letter country codes to preferred networks. Format each line as CC: network-one, network-two.', $this->text_domain); ?></p>
+        <?php
+    }
+
     public function field_geo_source(): void
     {
         $values = $this->values();
@@ -651,6 +676,7 @@ class Admin
             <option value="manual" <?php selected($values['geo_source'], 'manual'); ?>><?php esc_html_e('Manual override via filters', $this->text_domain); ?></option>
         </select>
         <p class="description"><?php esc_html_e('Determines how Smart Share chooses the best networks for a visitor based on location.', $this->text_domain); ?></p>
+        <p class="description"><?php esc_html_e('When Cloudflare headers are unavailable, auto detection falls back to Accept-Language only—no IP lookups required.', $this->text_domain); ?></p>
         <?php
     }
 

--- a/includes/class-shortcode.php
+++ b/includes/class-shortcode.php
@@ -40,13 +40,8 @@ class Shortcode
             $atts = [];
         }
 
-        $networks_default = $options['share_networks_default'];
-        if (is_array($networks_default)) {
-            $networks_default = implode(',', $networks_default);
-        }
-
         $atts = shortcode_atts([
-            'networks'     => $networks_default,
+            'networks'     => '',
             'labels'       => $options['share_labels'],
             'style'        => $options['share_style'],
             'size'         => $options['share_size'],
@@ -73,13 +68,8 @@ class Shortcode
             return;
         }
 
-        $networks_default = $options['share_networks_default'];
-        if (is_array($networks_default)) {
-            $networks_default = implode(',', $networks_default);
-        }
-
         $atts = [
-            'networks'     => $networks_default,
+            'networks'     => '',
             'labels'       => 'hide',
             'style'        => $options['share_style'],
             'size'         => 'sm',


### PR DESCRIPTION
## Summary
- add Smart Share country matrix defaults and settings field for editing
- resolve visitor country on render using Cloudflare headers with Accept-Language fallback and use geo-aware networks
- expose geo data to the front end with navigator.language fallback handling
- document Accept-Language privacy behaviour in the Smart Share settings

## Testing
- php -l includes/class-options.php
- php -l includes/class-admin.php
- php -l includes/class-render.php
- php -l includes/class-shortcode.php


------
https://chatgpt.com/codex/tasks/task_e_68cf20703328832ca740b1ac5475440c