### PR TITLE
Add configurable media overlays for share interactions

### DIFF
--- a/assets/share.css
+++ b/assets/share.css
@@ -31,3 +31,29 @@
 #wakiShareToast{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);background:#111;color:#fff;padding:.5rem .75rem;border-radius:8px;font-size:.875rem;opacity:0;pointer-events:none;transition:opacity .25s ease}
 #wakiShareToast.show{opacity:1}
 .waki-share svg,.waki-share svg *{opacity:1;display:inline-block;fill:currentColor}
+.waki-share-placement-overlay{--waki-gap:6px;--waki-radius:9999px}
+.waki-share-overlay-share .waki-btn{padding:.4rem;border-radius:999px;min-width:2.25rem;justify-content:center}
+.waki-share-overlay-share .waki-label{display:none}
+.waki-share-media{position:relative;display:inline-block;max-width:100%;--waki-overlay-gap:.5rem}
+.waki-share-media[data-display="block"]{display:block}
+.waki-share-media>img,.waki-share-media>video,.waki-share-media>iframe,.waki-share-media>a{display:block;max-width:100%}
+.waki-share-media.is-open{z-index:40}
+.waki-share-media .waki-share-overlay{position:absolute;z-index:45;display:flex;flex-direction:column;gap:.35rem;pointer-events:none}
+.waki-share-media .waki-share-overlay__toggle,.waki-share-media .waki-share-overlay__menu{pointer-events:auto}
+.waki-share-overlay[data-position="top-start"]{inset-block-start:var(--waki-overlay-gap);inset-inline-start:var(--waki-overlay-gap);align-items:flex-start}
+.waki-share-overlay[data-position="top-end"]{inset-block-start:var(--waki-overlay-gap);inset-inline-end:var(--waki-overlay-gap);align-items:flex-end}
+.waki-share-overlay[data-position="bottom-start"]{inset-block-end:var(--waki-overlay-gap);inset-inline-start:var(--waki-overlay-gap);align-items:flex-start}
+.waki-share-overlay[data-position="bottom-end"]{inset-block-end:var(--waki-overlay-gap);inset-inline-end:var(--waki-overlay-gap);align-items:flex-end}
+.waki-share-overlay[data-position="bottom-start"] .waki-share-overlay__menu,.waki-share-overlay[data-position="bottom-end"] .waki-share-overlay__menu{order:-1}
+.waki-share-overlay[data-position="center"]{inset-block-start:50%;inset-inline-start:50%;transform:translate(-50%,-50%);align-items:center}
+.waki-share-overlay__toggle{cursor:pointer;border:0;background:rgba(15,23,42,.92);color:#fff;padding:.35rem .65rem;border-radius:999px;font-size:.75rem;font-weight:600;line-height:1;box-shadow:0 8px 20px rgba(15,23,42,.25);transition:background .2s ease,box-shadow .2s ease,transform .2s ease}
+.waki-share-overlay__toggle:hover{transform:translateY(-1px)}
+.waki-share-overlay__toggle:focus-visible{outline:2px solid rgba(255,255,255,.9);outline-offset:2px;box-shadow:0 0 0 4px rgba(15,23,42,.35)}
+.waki-share-overlay__menu{background:rgba(17,24,39,.96);color:#fff;padding:.5rem;border-radius:12px;box-shadow:0 12px 30px rgba(15,23,42,.32);opacity:0;visibility:hidden;pointer-events:none;transform:translateY(-4px);transition:opacity .2s ease,transform .2s ease,visibility .2s ease;max-width:min(100vw - 2rem,18rem)}
+.waki-share-overlay__menu:focus-visible{outline:2px solid rgba(255,255,255,.65);outline-offset:2px}
+.waki-share-overlay__menu .waki-share{--waki-gap:6px;flex-wrap:wrap;justify-content:flex-start}
+.waki-share-overlay__menu .waki-btn{min-width:2.25rem;justify-content:center}
+.waki-share-media.is-open .waki-share-overlay__menu{opacity:1;visibility:visible;pointer-events:auto;transform:translateY(0)}
+.waki-share-media[data-trigger="always"] .waki-share-overlay__menu{opacity:1;visibility:visible;pointer-events:auto;transform:none}
+.waki-share-media[data-trigger="always"] .waki-share-overlay__toggle{display:none}
+@media (max-width:640px){.waki-share-overlay__menu{max-width:min(100vw - 1.5rem,20rem)}.waki-share-overlay[data-position="center"]{inset-block-start:auto;inset-inline-start:50%;inset-block-end:var(--waki-overlay-gap);transform:translate(-50%,0)}}

--- a/assets/share.js
+++ b/assets/share.js
@@ -1,5 +1,389 @@
 (function(){
   var messages = window.yourShareMessages || {};
+  var mediaConfig = window.yourShareMedia || {};
+
+  var overlaySelectors = Array.isArray(mediaConfig.selectors) ? mediaConfig.selectors : [];
+  overlaySelectors = overlaySelectors.map(function(selector){
+    return (selector || '').trim();
+  }).filter(function(selector){
+    return selector.length > 0;
+  });
+
+  var overlayTemplateHtml = (mediaConfig.markup || '').trim();
+  var overlaySelectorString = overlaySelectors.join(',');
+  var overlayPosition = (mediaConfig.position || 'top-end').toLowerCase();
+  var overlayTrigger = (mediaConfig.trigger || 'hover').toLowerCase();
+  var overlayToggleLabel = mediaConfig.toggleLabel || messages.mediaToggle || 'Share this media';
+  var overlayToggleText = mediaConfig.toggleText || messages.shareLabel || 'Share';
+  var overlayStates = [];
+  var overlayObserver = null;
+  var overlayIdCounter = 0;
+
+  var allowedPositions = ['top-start', 'top-end', 'bottom-start', 'bottom-end', 'center'];
+  if (allowedPositions.indexOf(overlayPosition) === -1){
+    overlayPosition = 'top-end';
+  }
+
+  var allowedTriggers = ['hover', 'always'];
+  if (allowedTriggers.indexOf(overlayTrigger) === -1){
+    overlayTrigger = 'hover';
+  }
+
+  function overlayEnabled(){
+    return overlaySelectors.length > 0 && overlayTemplateHtml.length > 0;
+  }
+
+  function cloneOverlayShare(){
+    if (!overlayTemplateHtml){
+      return null;
+    }
+    var template = document.createElement('template');
+    template.innerHTML = overlayTemplateHtml;
+    var first = template.content.firstElementChild;
+    if (!first){
+      return null;
+    }
+    var clone = first.cloneNode(true);
+    clone.classList.add('waki-share-overlay-share');
+    return clone;
+  }
+
+  function getFocusableElements(container){
+    return Array.prototype.filter.call(container.querySelectorAll('a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'), function(el){
+      if (el.hasAttribute('disabled')){
+        return false;
+      }
+      var style = window.getComputedStyle(el);
+      return style.display !== 'none' && style.visibility !== 'hidden';
+    });
+  }
+
+  function trapFocus(event, state){
+    var focusable = getFocusableElements(state.overlay);
+    if (!focusable.length){
+      event.preventDefault();
+      return;
+    }
+
+    var first = focusable[0];
+    var last = focusable[focusable.length - 1];
+    var active = document.activeElement;
+
+    if (event.shiftKey){
+      if (active === first || !state.overlay.contains(active)){
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (active === last){
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function openOverlay(state, focusMenu){
+    if (state.open){
+      return;
+    }
+    state.open = true;
+    state.wrapper.classList.add('is-open');
+    state.overlay.classList.add('is-open');
+    state.menu.setAttribute('aria-hidden', 'false');
+    state.toggle.setAttribute('aria-expanded', 'true');
+
+    if (focusMenu){
+      var focusable = getFocusableElements(state.overlay);
+      for (var i = 0; i < focusable.length; i++){
+        if (focusable[i] !== state.toggle){
+          focusable[i].focus({ preventScroll: true });
+          break;
+        }
+      }
+    }
+  }
+
+  function closeOverlay(state){
+    if (!state.open || overlayTrigger === 'always'){
+      return;
+    }
+    state.open = false;
+    state.wrapper.classList.remove('is-open');
+    state.overlay.classList.remove('is-open');
+    state.menu.setAttribute('aria-hidden', 'true');
+    state.toggle.setAttribute('aria-expanded', 'false');
+  }
+
+  function closeAllOverlays(except){
+    for (var i = 0; i < overlayStates.length; i++){
+      if (overlayStates[i] !== except){
+        closeOverlay(overlayStates[i]);
+      }
+    }
+  }
+
+  function bindOverlayEvents(state){
+    if (overlayTrigger === 'always'){
+      return;
+    }
+
+    var closeTimer = null;
+
+    function scheduleClose(delay){
+      if (overlayTrigger === 'always'){
+        return;
+      }
+      clearTimeout(closeTimer);
+      closeTimer = setTimeout(function(){
+        if (!state.wrapper.contains(document.activeElement)){
+          closeOverlay(state);
+        }
+      }, delay);
+    }
+
+    state.wrapper.addEventListener('mouseenter', function(){
+      if (overlayTrigger !== 'hover'){
+        return;
+      }
+      clearTimeout(closeTimer);
+      closeAllOverlays(state);
+      openOverlay(state, false);
+    });
+
+    state.wrapper.addEventListener('mouseleave', function(){
+      if (overlayTrigger !== 'hover'){
+        return;
+      }
+      scheduleClose(120);
+    });
+
+    state.wrapper.addEventListener('focusin', function(){
+      closeAllOverlays(state);
+      openOverlay(state, false);
+    });
+
+    state.wrapper.addEventListener('focusout', function(event){
+      if (state.wrapper.contains(event.relatedTarget)){
+        return;
+      }
+      if (overlayTrigger === 'hover'){
+        scheduleClose(100);
+      } else {
+        closeOverlay(state);
+      }
+    });
+
+    state.toggle.addEventListener('click', function(event){
+      event.preventDefault();
+      if (state.open){
+        closeOverlay(state);
+      } else {
+        closeAllOverlays(state);
+        openOverlay(state, true);
+      }
+    });
+
+    state.overlay.addEventListener('keydown', function(event){
+      if (event.key === 'Escape' || event.key === 'Esc'){
+        if (state.open && overlayTrigger !== 'always'){
+          event.preventDefault();
+          closeOverlay(state);
+          state.toggle.focus({ preventScroll: true });
+        }
+        return;
+      }
+
+      if (event.key === 'Tab'){
+        if (!state.open && overlayTrigger !== 'always'){
+          return;
+        }
+        trapFocus(event, state);
+      }
+    });
+  }
+
+  function isMediaCandidate(el){
+    if (!el || !el.tagName){
+      return false;
+    }
+    var tag = el.tagName.toLowerCase();
+    if (tag === 'img' || tag === 'video'){
+      return true;
+    }
+    if (tag === 'iframe'){
+      var src = (el.getAttribute('src') || el.getAttribute('data-src') || '').toLowerCase();
+      return /youtube\.com|youtu\.be|youtube-nocookie\.com|player\.vimeo\.com/.test(src);
+    }
+    return false;
+  }
+
+  function findMediaElement(node){
+    if (isMediaCandidate(node)){
+      return node;
+    }
+    var nested = node.querySelectorAll('img, video, iframe');
+    for (var i = 0; i < nested.length; i++){
+      if (isMediaCandidate(nested[i])){
+        return nested[i];
+      }
+    }
+    return null;
+  }
+
+  function promoteTarget(el){
+    var target = el;
+    if (!target){
+      return target;
+    }
+
+    var link = target.closest('a');
+    if (link && link.querySelectorAll('img, video, iframe').length === 1){
+      target = link;
+    }
+
+    return target;
+  }
+
+  function createOverlay(target){
+    if (!target || target.nodeType !== 1){
+      return;
+    }
+    if (target.closest('.waki-share-media') || target.getAttribute('data-your-share-overlay-target') === '1'){
+      return;
+    }
+
+    var parent = target.parentNode;
+    if (!parent){
+      return;
+    }
+
+    var wrapper = document.createElement('span');
+    wrapper.className = 'waki-share-media';
+    wrapper.setAttribute('data-trigger', overlayTrigger);
+    wrapper.setAttribute('data-position', overlayPosition);
+
+    var computed = window.getComputedStyle(target);
+    var display = (computed.display || '').toLowerCase();
+    var blockDisplays = ['block', 'flex', 'grid', 'table', 'list-item'];
+    if (blockDisplays.indexOf(display) !== -1){
+      wrapper.dataset.display = 'block';
+      wrapper.style.display = 'block';
+    } else {
+      wrapper.dataset.display = 'inline';
+      wrapper.style.display = 'inline-block';
+    }
+
+    parent.insertBefore(wrapper, target);
+    wrapper.appendChild(target);
+    wrapper.dataset.yourShareOverlay = '1';
+    target.setAttribute('data-your-share-overlay-target', '1');
+
+    var overlay = document.createElement('div');
+    overlay.className = 'waki-share-overlay';
+    overlay.setAttribute('data-position', overlayPosition);
+
+    var toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'waki-share-overlay__toggle';
+    toggle.setAttribute('aria-haspopup', 'true');
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-label', overlayToggleLabel);
+    toggle.textContent = overlayToggleText;
+
+    var menu = document.createElement('div');
+    menu.className = 'waki-share-overlay__menu';
+    menu.setAttribute('aria-hidden', 'true');
+    menu.setAttribute('role', 'menu');
+    menu.setAttribute('tabindex', '-1');
+
+    var shareMarkup = cloneOverlayShare();
+    if (!shareMarkup){
+      wrapper.parentNode.insertBefore(target, wrapper);
+      wrapper.remove();
+      return;
+    }
+
+    menu.appendChild(shareMarkup);
+    overlay.appendChild(toggle);
+    overlay.appendChild(menu);
+    wrapper.appendChild(overlay);
+
+    overlayIdCounter += 1;
+    var menuId = 'yourShareOverlayMenu' + overlayIdCounter;
+    menu.id = menuId;
+    toggle.setAttribute('aria-controls', menuId);
+
+    var state = {
+      wrapper: wrapper,
+      target: target,
+      overlay: overlay,
+      toggle: toggle,
+      menu: menu,
+      open: false
+    };
+
+    overlayStates.push(state);
+
+    if (overlayTrigger === 'always'){
+      state.open = true;
+      wrapper.classList.add('is-open');
+      overlay.classList.add('is-open');
+      menu.setAttribute('aria-hidden', 'false');
+      toggle.setAttribute('aria-expanded', 'true');
+      toggle.setAttribute('aria-hidden', 'true');
+      toggle.setAttribute('tabindex', '-1');
+    } else {
+      bindOverlayEvents(state);
+    }
+  }
+
+  function maybeCreateOverlay(node){
+    if (!(node instanceof Element)){
+      return;
+    }
+    if (!overlaySelectorString || node.closest('.waki-share-media')){
+      return;
+    }
+
+    if (node.matches && node.matches(overlaySelectorString)){
+      var candidate = findMediaElement(node);
+      if (candidate){
+        createOverlay(promoteTarget(candidate));
+      }
+    }
+
+    var matches = node.querySelectorAll(overlaySelectorString);
+    Array.prototype.forEach.call(matches, function(match){
+      var media = findMediaElement(match);
+      if (media){
+        createOverlay(promoteTarget(media));
+      }
+    });
+  }
+
+  function initMediaOverlays(){
+    if (!overlayEnabled()){
+      return;
+    }
+
+    if (document.body){
+      maybeCreateOverlay(document.body);
+    }
+
+    if (typeof MutationObserver === 'undefined' || !document.body){
+      return;
+    }
+
+    overlayObserver = new MutationObserver(function(mutations){
+      mutations.forEach(function(mutation){
+        Array.prototype.forEach.call(mutation.addedNodes, function(node){
+          if (node instanceof Element){
+            maybeCreateOverlay(node);
+          }
+        });
+      });
+    });
+
+    overlayObserver.observe(document.body, { childList: true, subtree: true });
+  }
 
   function openPopup(url){
     var w = 600;
@@ -144,9 +528,21 @@
   }
 
   document.addEventListener('click', function(event){
+    if (overlayStates.length){
+      overlayStates.forEach(function(state){
+        if (state.open && overlayTrigger !== 'always' && !state.wrapper.contains(event.target)){
+          closeOverlay(state);
+        }
+      });
+    }
+
     var button = event.target.closest('.waki-btn');
     if (!button || !button.closest('.waki-share')) {
       return;
+    }
+
+    if (button.closest('.waki-share-overlay')){
+      closeAllOverlays(null);
     }
 
     var network = button.getAttribute('data-net');
@@ -181,6 +577,7 @@
   function onReady(){
     hydrateGeo();
     updateFloatingVisibility();
+    initMediaOverlays();
   }
 
   if (document.readyState === 'loading'){

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -49,6 +49,9 @@ class Options
                 'BR' => ['whatsapp', 'facebook', 'telegram', 'email', 'copy'],
                 'DE' => ['whatsapp', 'facebook', 'linkedin', 'email', 'copy'],
             ],
+            'media_overlay_selectors'   => ".entry-content img, .entry-content video, .entry-content iframe[src*='youtube'], .entry-content iframe[src*='vimeo']",
+            'media_overlay_position'    => 'top-end',
+            'media_overlay_trigger'     => 'hover',
             'geo_source'                => 'auto',
             'enable_utm'                => 1,
             'utm_medium'                => 'social',
@@ -146,6 +149,22 @@ class Options
         if (empty($output['smart_share_matrix'])) {
             $output['smart_share_matrix'] = $this->normalize_matrix($defaults['smart_share_matrix']);
         }
+
+        $output['media_overlay_selectors'] = sanitize_textarea_field($input['media_overlay_selectors'] ?? $defaults['media_overlay_selectors']);
+
+        $position = sanitize_key($input['media_overlay_position'] ?? $defaults['media_overlay_position']);
+        $allowed_positions = ['top-start', 'top-end', 'bottom-start', 'bottom-end', 'center'];
+        if (!in_array($position, $allowed_positions, true)) {
+            $position = $defaults['media_overlay_position'];
+        }
+        $output['media_overlay_position'] = $position;
+
+        $trigger = sanitize_key($input['media_overlay_trigger'] ?? $defaults['media_overlay_trigger']);
+        $allowed_triggers = ['hover', 'always'];
+        if (!in_array($trigger, $allowed_triggers, true)) {
+            $trigger = $defaults['media_overlay_trigger'];
+        }
+        $output['media_overlay_trigger'] = $trigger;
 
         $geo_source = sanitize_key($input['geo_source'] ?? $defaults['geo_source']);
         if (!in_array($geo_source, ['auto', 'ip', 'manual'], true)) {


### PR DESCRIPTION
## Summary
- add defaults and sanitization for media overlay selectors, position, and trigger options
- register overlay share markup in the renderer and pass configuration to the frontend script
- enhance the public script to wrap eligible media, inject accessible overlay menus, and style them responsively
- introduce overlay-specific styles for proper positioning in both LTR and RTL contexts

## Testing
- php -l includes/class-render.php
- php -l includes/class-options.php

------
https://chatgpt.com/codex/tasks/task_e_68cf22c8b27c832ca8d16544d0f9940b