### PR TITLE
Fix Render class constructor and method closure

### DIFF
--- a/includes/class-render.php
+++ b/includes/class-render.php
@@ -26,19 +26,21 @@ class Render
     /** @var string */
     private $text_domain;
 
-    public function __construct(Options $options, Networks $networks, UTM $utm, Icons $icons, Reactions $reactions, string $text_domain)
+    /** @var Counts|null */
+    private $counts;
 
     /** @var bool */
     private $media_config_localized = false;
 
-    public function __construct(Options $options, Networks $networks, UTM $utm, Icons $icons, string $text_domain)
-
-    /** @var Counts|null */
-    private $counts;
-
-    public function __construct(Options $options, Networks $networks, UTM $utm, Icons $icons, string $text_domain, ?Counts $counts = null)
-
-    {
+    public function __construct(
+        Options $options,
+        Networks $networks,
+        UTM $utm,
+        Icons $icons,
+        Reactions $reactions,
+        string $text_domain,
+        ?Counts $counts = null
+    ) {
         $this->options     = $options;
         $this->networks    = $networks;
         $this->utm         = $utm;
@@ -304,6 +306,7 @@ class Render
         wp_localize_script('your-share', 'yourShareMedia', $config);
 
         $this->media_config_localized = true;
+    }
 
     public function render_follow(array $atts): string
     {


### PR DESCRIPTION
## Summary
- clean up the Render service properties and constructor definitions to remove duplicate declarations
- ensure the media overlay registration method closes correctly so the follow markup renders

## Testing
- php -l includes/class-render.php

------
https://chatgpt.com/codex/tasks/task_e_68cf2a11ea08832c88d9cc3bdacdb6b3