### PR TITLE
Restore admin reaction and count registration blocks

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -391,16 +391,6 @@ class Admin
             __('Reaction bar', $this->text_domain),
             function (): void {
                 echo '<p>' . esc_html__('Offer quick emoji feedback alongside your share buttons.', $this->text_domain) . '</p>';
-
-    private function register_counts_settings(): void
-    {
-        $page = $this->page_id('counts');
-
-        add_settings_section(
-            'your_share_counts_general',
-            __('Caching & status', $this->text_domain),
-            function (): void {
-                echo '<p>' . esc_html__('Control if share counts are collected and how long cached values are retained.', $this->text_domain) . '</p>';
             },
             $page
         );
@@ -426,6 +416,33 @@ class Admin
             __('Maintenance', $this->text_domain),
             function (): void {
                 echo '<p>' . esc_html__('Reset stored counts when you want to start fresh.', $this->text_domain) . '</p>';
+            },
+            $page
+        );
+
+        add_settings_field(
+            'reactions_reset',
+            __('Reset totals', $this->text_domain),
+            [$this, 'field_reactions_reset'],
+            $page,
+            'your_share_reactions_maintenance'
+        );
+    }
+
+    private function register_counts_settings(): void
+    {
+        $page = $this->page_id('counts');
+
+        add_settings_section(
+            'your_share_counts_general',
+            __('Caching & status', $this->text_domain),
+            function (): void {
+                echo '<p>' . esc_html__('Control if share counts are collected and how long cached values are retained.', $this->text_domain) . '</p>';
+            },
+            $page
+        );
+
+        add_settings_field(
             'counts_general',
             __('Status', $this->text_domain),
             [$this, 'field_counts_general'],
@@ -460,11 +477,6 @@ class Admin
         );
 
         add_settings_field(
-            'reactions_reset',
-            __('Reset totals', $this->text_domain),
-            [$this, 'field_reactions_reset'],
-            $page,
-            'your_share_reactions_maintenance'
             'counts_credentials',
             __('Providers', $this->text_domain),
             [$this, 'field_counts_credentials'],

--- a/includes/class-render.php
+++ b/includes/class-render.php
@@ -26,19 +26,21 @@ class Render
     /** @var string */
     private $text_domain;
 
-    public function __construct(Options $options, Networks $networks, UTM $utm, Icons $icons, Reactions $reactions, string $text_domain)
+    /** @var Counts|null */
+    private $counts;
 
     /** @var bool */
     private $media_config_localized = false;
 
-    public function __construct(Options $options, Networks $networks, UTM $utm, Icons $icons, string $text_domain)
-
-    /** @var Counts|null */
-    private $counts;
-
-    public function __construct(Options $options, Networks $networks, UTM $utm, Icons $icons, string $text_domain, ?Counts $counts = null)
-
-    {
+    public function __construct(
+        Options $options,
+        Networks $networks,
+        UTM $utm,
+        Icons $icons,
+        Reactions $reactions,
+        string $text_domain,
+        ?Counts $counts = null
+    ) {
         $this->options     = $options;
         $this->networks    = $networks;
         $this->utm         = $utm;
@@ -304,6 +306,7 @@ class Render
         wp_localize_script('your-share', 'yourShareMedia', $config);
 
         $this->media_config_localized = true;
+    }
 
     public function render_follow(array $atts): string
     {


### PR DESCRIPTION
## Summary
- close the reaction settings section properly so its fields register without parse errors
- reintroduce the share counts registration blocks with their sections and fields after the reactions configuration

## Testing
- php -l includes/class-admin.php
- php -l includes/class-render.php

------
https://chatgpt.com/codex/tasks/task_e_68cf2a11ea08832c88d9cc3bdacdb6b3