### PR TITLE
Add analytics logging, reporting, and tooling

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -213,6 +213,150 @@
   font-weight: 600;
 }
 
+.your-share-analytics {
+  margin-top: 1rem;
+  border: 1px solid #dcdcde;
+  border-radius: 10px;
+  padding: 1.25rem;
+  background: #fff;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.your-share-analytics__chart {
+  display: grid;
+  gap: 1rem;
+}
+
+.your-share-analytics__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.your-share-analytics__ranges {
+  display: inline-flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.your-share-analytics__summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: baseline;
+}
+
+.your-share-analytics__summary > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 80px;
+}
+
+.your-share-analytics__summary-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #4b5563;
+}
+
+.your-share-analytics__updated {
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.your-share-analytics__canvas {
+  position: relative;
+  min-height: 320px;
+}
+
+.your-share-analytics__canvas canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.your-share-analytics__lists {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.your-share-analytics__card {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 1rem;
+  background: #f9fafb;
+}
+
+.your-share-analytics__card h4 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+}
+
+.your-share-analytics__card ol {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.your-share-analytics__card li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.your-share-analytics__card a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.your-share-analytics__card a:hover,
+.your-share-analytics__card a:focus {
+  text-decoration: underline;
+}
+
+.your-share-analytics__metric {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.your-share-analytics__tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.your-share-analytics__tools form {
+  margin: 0;
+}
+
+.your-share-analytics__notice {
+  margin: 0;
+  color: #6b7280;
+}
+
+.your-share-analytics__canvas .description {
+  margin-top: 0.75rem;
+}
+
+@media (max-width: 782px) {
+  .your-share-analytics__toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .your-share-analytics__summary {
+    gap: 0.75rem;
+  }
+}
+
 @media (max-width: 782px) {
   .your-share-tab-panel {
     padding: 1rem;

--- a/includes/activator.php
+++ b/includes/activator.php
@@ -44,13 +44,17 @@ class Activator
         $events_sql = "CREATE TABLE {$events_table} (
             id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
             post_id bigint(20) unsigned NOT NULL DEFAULT 0,
+            event_type varchar(20) NOT NULL DEFAULT '',
             network varchar(50) NOT NULL DEFAULT '',
+            placement varchar(50) NOT NULL DEFAULT '',
+            device varchar(20) NOT NULL DEFAULT '',
             share_url text NOT NULL,
             ip_address varchar(100) NOT NULL DEFAULT '',
             user_agent text NULL,
             created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (id),
-            KEY post_network (post_id, network)
+            KEY post_network (post_id, network),
+            KEY created_at (created_at)
         ) {$charset};";
 
         $reactions_sql = "CREATE TABLE {$reactions_table} (

--- a/includes/class-analytics.php
+++ b/includes/class-analytics.php
@@ -1,0 +1,670 @@
+<?php
+
+namespace YourShare;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use wpdb;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Analytics
+{
+    private const RESET_NOTICE_KEY = 'your_share_analytics_reset_notice';
+
+    /** @var Options */
+    private $options;
+
+    /** @var string */
+    private $text_domain;
+
+    /** @var string */
+    private $admin_slug;
+
+    public function __construct(Options $options, string $text_domain, string $admin_slug)
+    {
+        $this->options     = $options;
+        $this->text_domain = $text_domain;
+        $this->admin_slug  = $admin_slug;
+    }
+
+    public function register_hooks(): void
+    {
+        add_action('rest_api_init', [$this, 'register_routes']);
+        add_action('admin_post_your_share_export_events', [$this, 'handle_export_request']);
+        add_action('admin_post_your_share_reset_events', [$this, 'handle_reset_request']);
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route(
+            'your-share/v1',
+            '/event',
+            [
+                'methods'             => 'POST',
+                'callback'            => [$this, 'handle_event'],
+                'permission_callback' => [$this, 'check_nonce'],
+                'args'                => [
+                    'event'     => [
+                        'required'          => true,
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_key',
+                    ],
+                    'post_id'   => [
+                        'required'          => false,
+                        'type'              => 'integer',
+                        'sanitize_callback' => 'absint',
+                    ],
+                    'network'   => [
+                        'required'          => false,
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_key',
+                    ],
+                    'placement' => [
+                        'required'          => false,
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_key',
+                    ],
+                    'url'       => [
+                        'required'          => false,
+                        'type'              => 'string',
+                        'sanitize_callback' => 'esc_url_raw',
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            'your-share/v1',
+            '/analytics/report',
+            [
+                'methods'             => 'GET',
+                'callback'            => [$this, 'handle_report'],
+                'permission_callback' => function () {
+                    return current_user_can('manage_options');
+                },
+            ]
+        );
+    }
+
+    public function check_nonce($request)
+    {
+        if (!$request instanceof WP_REST_Request) {
+            return new WP_Error('your_share_invalid_request', __('Invalid request.', $this->text_domain), ['status' => 400]);
+        }
+
+        $nonce = $request->get_header('x-wp-nonce');
+
+        if (!$nonce) {
+            $nonce = $request->get_param('_wpnonce');
+        }
+
+        if (!$nonce || !wp_verify_nonce($nonce, 'wp_rest')) {
+            return new WP_Error('your_share_invalid_nonce', __('Invalid or missing nonce.', $this->text_domain), ['status' => 403]);
+        }
+
+        return true;
+    }
+
+    public function handle_event(WP_REST_Request $request)
+    {
+        $event_type = sanitize_key($request->get_param('event'));
+
+        if (!in_array($event_type, ['share', 'reaction'], true)) {
+            return new WP_Error('your_share_invalid_event', __('Unsupported event type.', $this->text_domain), ['status' => 400]);
+        }
+
+        $post_id   = absint($request->get_param('post_id'));
+        $network   = sanitize_key($request->get_param('network'));
+        $placement = sanitize_key($request->get_param('placement'));
+        $url       = esc_url_raw((string) $request->get_param('url'));
+
+        $ip_address = $this->resolve_ip_address($request);
+        $user_agent = $this->resolve_user_agent($request);
+        $device     = $this->determine_device($user_agent);
+
+        $options = $this->options->all();
+        $stored  = false;
+
+        if (!empty($options['analytics_events'])) {
+            $stored = $this->store_event([
+                'post_id'    => $post_id,
+                'event_type' => $event_type,
+                'network'    => $network,
+                'placement'  => $placement,
+                'device'     => $device,
+                'share_url'  => $url,
+                'ip_address' => $ip_address,
+                'user_agent' => $user_agent,
+            ]);
+        }
+
+        if (!empty($options['analytics_ga4'])) {
+            $this->dispatch_ga4([
+                'event'      => $event_type,
+                'post_id'    => $post_id,
+                'network'    => $network,
+                'placement'  => $placement,
+                'device'     => $device,
+                'share_url'  => $url,
+                'ip_address' => $ip_address,
+                'user_agent' => $user_agent,
+            ]);
+        }
+
+        return new WP_REST_Response([
+            'recorded' => (bool) $stored,
+        ], 200);
+    }
+
+    public function handle_report(): WP_REST_Response
+    {
+        $options = $this->options->all();
+        $enabled = !empty($options['analytics_events']);
+
+        $report = [
+            'enabled' => $enabled,
+            'series'  => [
+                '7'  => $this->time_series(7),
+                '30' => $this->time_series(30),
+                '90' => $this->time_series(90),
+            ],
+            'top'     => $this->top_lists(),
+            'generated_at' => current_time('mysql'),
+        ];
+
+        return new WP_REST_Response($report, 200);
+    }
+
+    public function handle_export_request(): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('You do not have permission to export analytics.', $this->text_domain));
+        }
+
+        check_admin_referer('your_share_export_events', 'your_share_export_events_nonce');
+
+        $rows = $this->get_all_events();
+        $csv  = $this->generate_csv($rows);
+
+        nocache_headers();
+        header('Content-Type: text/csv; charset=utf-8');
+        header('Content-Disposition: attachment; filename="your-share-events-' . gmdate('Ymd-His') . '.csv"');
+
+        echo $csv; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        exit;
+    }
+
+    public function handle_reset_request(): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('You do not have permission to reset analytics.', $this->text_domain));
+        }
+
+        check_admin_referer('your_share_reset_events', 'your_share_reset_events_nonce');
+
+        $this->truncate_events();
+
+        set_transient(self::RESET_NOTICE_KEY, 1, MINUTE_IN_SECONDS);
+
+        $redirect = add_query_arg(
+            [
+                'page' => $this->admin_slug,
+                'tab'  => 'analytics',
+            ],
+            admin_url('options-general.php')
+        );
+
+        wp_safe_redirect($redirect);
+        exit;
+    }
+
+    public function consume_reset_notice(): bool
+    {
+        $notice = get_transient(self::RESET_NOTICE_KEY);
+
+        if ($notice) {
+            delete_transient(self::RESET_NOTICE_KEY);
+            return true;
+        }
+
+        return false;
+    }
+
+    private function table_name(wpdb $wpdb): string
+    {
+        return $wpdb->prefix . 'yourshare_events';
+    }
+
+    private function store_event(array $data): bool
+    {
+        global $wpdb;
+
+        if (!$wpdb instanceof wpdb) {
+            return false;
+        }
+
+        $table = $this->table_name($wpdb);
+        $row   = [
+            'post_id'    => (int) ($data['post_id'] ?? 0),
+            'event_type' => $data['event_type'] ?? '',
+            'network'    => $data['network'] ?? '',
+            'placement'  => $data['placement'] ?? '',
+            'device'     => $data['device'] ?? '',
+            'share_url'  => $data['share_url'] ?? '',
+            'ip_address' => substr((string) ($data['ip_address'] ?? ''), 0, 100),
+            'user_agent' => $data['user_agent'] ?? '',
+            'created_at' => current_time('mysql'),
+        ];
+
+        return false !== $wpdb->insert($table, $row, ['%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s']);
+    }
+
+    private function resolve_ip_address(WP_REST_Request $request): string
+    {
+        $headers = [
+            'x-forwarded-for',
+            'x-real-ip',
+        ];
+
+        foreach ($headers as $header) {
+            $value = $request->get_header($header);
+            if ($value) {
+                $parts = explode(',', $value);
+                $ip    = trim($parts[0]);
+                if (filter_var($ip, FILTER_VALIDATE_IP)) {
+                    return $ip;
+                }
+            }
+        }
+
+        $remote = $_SERVER['REMOTE_ADDR'] ?? '';
+        if (filter_var($remote, FILTER_VALIDATE_IP)) {
+            return $remote;
+        }
+
+        return '';
+    }
+
+    private function resolve_user_agent(WP_REST_Request $request): string
+    {
+        $header = $request->get_header('user_agent');
+
+        if (!$header) {
+            $header = $_SERVER['HTTP_USER_AGENT'] ?? '';
+        }
+
+        return sanitize_text_field($header);
+    }
+
+    private function determine_device(string $user_agent): string
+    {
+        $ua = strtolower($user_agent);
+
+        if ($ua === '') {
+            return 'unknown';
+        }
+
+        if (strpos($ua, 'tablet') !== false || strpos($ua, 'ipad') !== false) {
+            return 'tablet';
+        }
+
+        if (strpos($ua, 'mobi') !== false || strpos($ua, 'android') !== false) {
+            return 'mobile';
+        }
+
+        if (strpos($ua, 'bot') !== false || strpos($ua, 'spider') !== false) {
+            return 'bot';
+        }
+
+        return 'desktop';
+    }
+
+    private function dispatch_ga4(array $event): void
+    {
+        $measurement_id = apply_filters('your_share_ga4_measurement_id', '');
+        $api_secret     = apply_filters('your_share_ga4_api_secret', '');
+
+        if (empty($measurement_id) || empty($api_secret)) {
+            return;
+        }
+
+        $client_source = $event['ip_address'] . '|' . $event['user_agent'];
+        $client_id     = substr(md5($client_source !== '' ? $client_source : microtime(true)), 0, 32);
+
+        $params = [
+            'interaction_type' => $event['event'],
+            'network'          => $event['network'],
+            'post_id'          => (int) ($event['post_id'] ?? 0),
+            'placement'        => $event['placement'],
+            'device'           => $event['device'],
+        ];
+
+        if (!empty($event['share_url'])) {
+            $params['share_url'] = $event['share_url'];
+        }
+
+        $body = [
+            'client_id' => $client_id,
+            'events'    => [
+                [
+                    'name'   => 'your_share_interaction',
+                    'params' => $params,
+                ],
+            ],
+        ];
+
+        $url = add_query_arg(
+            [
+                'measurement_id' => $measurement_id,
+                'api_secret'     => $api_secret,
+            ],
+            'https://www.google-analytics.com/mp/collect'
+        );
+
+        wp_remote_post(
+            $url,
+            [
+                'timeout' => 5,
+                'body'    => wp_json_encode($body),
+                'headers' => [
+                    'Content-Type' => 'application/json',
+                ],
+            ]
+        );
+    }
+
+    private function time_series(int $days): array
+    {
+        $days = max(1, $days);
+
+        $dates = $this->date_range($days);
+        $series = [
+            'share'    => array_fill_keys($dates, 0),
+            'reaction' => array_fill_keys($dates, 0),
+        ];
+
+        global $wpdb;
+
+        if ($wpdb instanceof wpdb) {
+            $table = $this->table_name($wpdb);
+            $now   = current_time('mysql');
+            $interval = max(0, $days - 1);
+
+            $results = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT DATE(created_at) as day, event_type, COUNT(*) as total FROM {$table} WHERE created_at >= DATE_SUB(%s, INTERVAL %d DAY) GROUP BY DATE(created_at), event_type",
+                    $now,
+                    $interval
+                ),
+                ARRAY_A
+            );
+
+            if (is_array($results)) {
+                foreach ($results as $row) {
+                    $day   = $row['day'] ?? '';
+                    $type  = $row['event_type'] ?? '';
+                    $count = isset($row['total']) ? (int) $row['total'] : 0;
+
+                    if (isset($series[$type]) && isset($series[$type][$day])) {
+                        $series[$type][$day] = $count;
+                    }
+                }
+            }
+        }
+
+        $labels = array_map(static function ($day) {
+            $timestamp = strtotime($day);
+            return $timestamp ? date_i18n('M j', $timestamp) : $day;
+        }, $dates);
+
+        return [
+            'dates'    => $dates,
+            'labels'   => $labels,
+            'share'    => array_values($series['share']),
+            'reaction' => array_values($series['reaction']),
+            'totals'   => [
+                'share'    => array_sum($series['share']),
+                'reaction' => array_sum($series['reaction']),
+            ],
+        ];
+    }
+
+    private function top_lists(): array
+    {
+        return [
+            'posts'    => $this->top_posts(),
+            'networks' => $this->top_networks(),
+            'devices'  => $this->top_devices(),
+        ];
+    }
+
+    private function top_posts(): array
+    {
+        global $wpdb;
+
+        if (!$wpdb instanceof wpdb) {
+            return [];
+        }
+
+        $table    = $this->table_name($wpdb);
+        $now      = current_time('mysql');
+        $interval = 29;
+
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT post_id, COUNT(*) as total FROM {$table} WHERE post_id > 0 AND created_at >= DATE_SUB(%s, INTERVAL %d DAY) GROUP BY post_id ORDER BY total DESC LIMIT 5",
+                $now,
+                $interval
+            ),
+            ARRAY_A
+        );
+
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        $output = [];
+
+        foreach ($rows as $row) {
+            $post_id = isset($row['post_id']) ? (int) $row['post_id'] : 0;
+            if ($post_id <= 0) {
+                continue;
+            }
+
+            $title = get_the_title($post_id);
+            if (!$title) {
+                $title = sprintf(__('Post #%d', $this->text_domain), $post_id);
+            }
+
+            $output[] = [
+                'post_id' => $post_id,
+                'title'   => $title,
+                'total'   => isset($row['total']) ? (int) $row['total'] : 0,
+                'link'    => get_permalink($post_id),
+            ];
+        }
+
+        return $output;
+    }
+
+    private function top_networks(): array
+    {
+        global $wpdb;
+
+        if (!$wpdb instanceof wpdb) {
+            return [];
+        }
+
+        $table    = $this->table_name($wpdb);
+        $now      = current_time('mysql');
+        $interval = 29;
+
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT network, COUNT(*) as total FROM {$table} WHERE event_type = %s AND network <> '' AND created_at >= DATE_SUB(%s, INTERVAL %d DAY) GROUP BY network ORDER BY total DESC LIMIT 5",
+                'share',
+                $now,
+                $interval
+            ),
+            ARRAY_A
+        );
+
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        $output = [];
+
+        foreach ($rows as $row) {
+            $network = sanitize_key($row['network'] ?? '');
+            if ($network === '') {
+                continue;
+            }
+
+            $output[] = [
+                'network' => $network,
+                'total'   => isset($row['total']) ? (int) $row['total'] : 0,
+            ];
+        }
+
+        return $output;
+    }
+
+    private function top_devices(): array
+    {
+        global $wpdb;
+
+        if (!$wpdb instanceof wpdb) {
+            return [];
+        }
+
+        $table    = $this->table_name($wpdb);
+        $now      = current_time('mysql');
+        $interval = 29;
+
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT device, COUNT(*) as total FROM {$table} WHERE event_type = %s AND device <> '' AND created_at >= DATE_SUB(%s, INTERVAL %d DAY) GROUP BY device ORDER BY total DESC",
+                'share',
+                $now,
+                $interval
+            ),
+            ARRAY_A
+        );
+
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        $output = [];
+
+        foreach ($rows as $row) {
+            $device = sanitize_key($row['device'] ?? '');
+            if ($device === '') {
+                continue;
+            }
+
+            $label = $this->device_label($device);
+
+            $output[] = [
+                'device' => $device,
+                'label'  => $label,
+                'total'  => isset($row['total']) ? (int) $row['total'] : 0,
+            ];
+        }
+
+        return $output;
+    }
+
+    private function device_label(string $device): string
+    {
+        $labels = [
+            'desktop' => __('Desktop', $this->text_domain),
+            'mobile'  => __('Mobile', $this->text_domain),
+            'tablet'  => __('Tablet', $this->text_domain),
+            'bot'     => __('Bot', $this->text_domain),
+            'unknown' => __('Unknown', $this->text_domain),
+        ];
+
+        return $labels[$device] ?? ucfirst($device);
+    }
+
+    private function date_range(int $days): array
+    {
+        $days = max(1, $days);
+        $dates = [];
+        $timestamp = current_time('timestamp');
+
+        for ($i = $days - 1; $i >= 0; $i--) {
+            $dates[] = wp_date('Y-m-d', $timestamp - ($i * DAY_IN_SECONDS));
+        }
+
+        return $dates;
+    }
+
+    private function get_all_events(): array
+    {
+        global $wpdb;
+
+        if (!$wpdb instanceof wpdb) {
+            return [];
+        }
+
+        $table = $this->table_name($wpdb);
+
+        $rows = $wpdb->get_results(
+            "SELECT id, created_at, event_type, post_id, network, placement, device, share_url, ip_address, user_agent FROM {$table} ORDER BY created_at DESC",
+            ARRAY_A
+        );
+
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        return $rows;
+    }
+
+    private function generate_csv(array $rows): string
+    {
+        $output = fopen('php://temp', 'w+');
+
+        fputcsv($output, ['ID', 'Created At', 'Event Type', 'Post ID', 'Network', 'Placement', 'Device', 'Share URL', 'IP Address', 'User Agent']);
+
+        foreach ($rows as $row) {
+            fputcsv($output, [
+                $row['id'] ?? '',
+                $row['created_at'] ?? '',
+                $row['event_type'] ?? '',
+                $row['post_id'] ?? '',
+                $row['network'] ?? '',
+                $row['placement'] ?? '',
+                $row['device'] ?? '',
+                $row['share_url'] ?? '',
+                $row['ip_address'] ?? '',
+                $row['user_agent'] ?? '',
+            ]);
+        }
+
+        rewind($output);
+        $csv = stream_get_contents($output);
+        fclose($output);
+
+        return (string) $csv;
+    }
+
+    private function truncate_events(): void
+    {
+        global $wpdb;
+
+        if (!$wpdb instanceof wpdb) {
+            return;
+        }
+
+        $table = $this->table_name($wpdb);
+        $wpdb->query("TRUNCATE TABLE {$table}");
+    }
+}

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -36,6 +36,7 @@ class Plugin
         $this->container->get(Admin::class)->register_hooks();
         $this->container->get(Reactions::class)->register_hooks();
         $this->container->get(Rest::class)->register_hooks();
+        $this->container->get(Analytics::class)->register_hooks();
         $this->container->get(Shortcode::class)->register_hooks();
 
         do_action('your_share_plugin_booted', $this);
@@ -81,6 +82,10 @@ class Plugin
             return new Rest($c->get(Reactions::class), self::TEXT_DOMAIN);
         });
 
+        $this->container->set(Analytics::class, function (Container $c): Analytics {
+            return new Analytics($c->get(Options::class), self::TEXT_DOMAIN, self::SLUG);
+        });
+
         $this->container->set(Render::class, function (Container $c): Render {
             return new Render(
                 $c->get(Options::class),
@@ -98,7 +103,14 @@ class Plugin
         });
 
         $this->container->set(Admin::class, function (Container $c): Admin {
-            return new Admin($c->get(Options::class), $c->get(Networks::class), $c->get(Reactions::class), self::SLUG, self::TEXT_DOMAIN);
+            return new Admin(
+                $c->get(Options::class),
+                $c->get(Networks::class),
+                $c->get(Reactions::class),
+                $c->get(Analytics::class),
+                self::SLUG,
+                self::TEXT_DOMAIN
+            );
         });
 
         $this->container->set(Shortcode::class, function (Container $c): Shortcode {

--- a/includes/class-render.php
+++ b/includes/class-render.php
@@ -129,6 +129,7 @@ class Render
         $base  = $share_ctx['url'];
 
         $counts_state = $this->prepare_counts_state($opts, $networks, $share_ctx);
+        $post_id      = $share_ctx['post'] instanceof \WP_Post ? (int) $share_ctx['post']->ID : 0;
 
         if ($counts_state['enabled']) {
             $classes[] = 'waki-has-counts';
@@ -142,6 +143,7 @@ class Render
             'data-your-share-placement'      => $placement,
             'data-your-share-counts'         => $counts_state['enabled'] ? '1' : '',
             'data-your-share-post'           => $counts_state['post'],
+            'data-your-share-post-id'        => $post_id > 0 ? (string) $post_id : '',
             'data-your-share-networks'       => $counts_state['network_list'],
             'data-your-share-count-url'      => $counts_state['url'],
             'data-your-share-count-ttl'      => $counts_state['ttl'],

--- a/your-share-plugin.php
+++ b/your-share-plugin.php
@@ -23,6 +23,7 @@ require_once __DIR__ . '/includes/class-reactions.php';
 require_once __DIR__ . '/includes/class-counts.php';
 require_once __DIR__ . '/includes/class-render.php';
 require_once __DIR__ . '/includes/class-asset-loader.php';
+require_once __DIR__ . '/includes/class-analytics.php';
 require_once __DIR__ . '/includes/class-admin.php';
 require_once __DIR__ . '/includes/class-shortcode.php';
 require_once __DIR__ . '/includes/rest.php';


### PR DESCRIPTION
## Summary
- add an Analytics service that records events via REST, exposes reporting data, and supports exports and GA4 forwarding
- wire share/reaction UI to send nonce-protected analytics payloads and surface post IDs for attribution
- build analytics dashboards, styling, and localization for the admin tab with Chart.js-powered charts plus export/reset tools

## Testing
- php -l includes/class-analytics.php
- php -l includes/class-admin.php
- php -l includes/class-render.php

------
https://chatgpt.com/codex/tasks/task_e_68cfa2c9f940832cb4e4e8d3281138a2