### PR TITLE
Add share suite blocks and unify renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,37 @@
 
 Modern social sharing plugin featuring configurable layouts, floating share bars, follow buttons, and per-network UTM tagging.
 
+## Blocks
+
+### Share Suite
+
+The **Share Suite** block combines inline share buttons with optional follow links, reactions, and a floating toggle in a single layout. Use the inspector to:
+
+- Override networks, sizing, labels, colours, and UTM metadata.
+- Toggle follow buttons, emoji reactions, and the sticky share bar on/off per block.
+- Configure follow alignment and networks without leaving the editor.
+
+### Sticky Share Toggle
+
+Outputs the floating share bar with the configured theme defaults. Adjust its position, breakpoint, and button styling directly from the block inspector.
+
+### Follow Buttons
+
+Displays the profile links saved in **Settings → Your Share → Follow**. The block exposes controls for network order, alignment, labels, and appearance.
+
+### Reactions
+
+Renders the emoji reaction bar either inline or in floating mode. You can optionally target a specific post ID when embedding the block outside of the main loop.
+
+### Share Overlay
+
+Wrap any media block in the **Share Overlay** wrapper to mark it for share overlays. The block adds a `data-your-share-media="1"` attribute so the share script can attach pop-up menus without writing CSS selectors.
+
 ## Shortcodes
 
-### Share buttons
+### Inline share buttons (`[your_share]`)
 
-Use the `[your_share]` shortcode (alias `[waki_share]`) to output the configured share buttons. Attributes include:
+The `[your_share]` shortcode (alias `[waki_share]`) mirrors the Share Suite share controls and accepts:
 
 | Attribute | Values | Description |
 | --- | --- | --- |
@@ -14,16 +40,35 @@ Use the `[your_share]` shortcode (alias `[waki_share]`) to output the configured
 | `style` | `solid`, `outline`, `ghost` | Override button style. |
 | `size` | `sm`, `md`, `lg` | Override button size. |
 | `labels` | `auto`, `show`, `hide` | Control label visibility. |
+| `align` | `left`, `center`, `right`, `space-between` | Control alignment. |
 | `brand` | `1` or `0` | Enable/disable brand colours. |
 | `utm_campaign` | string | Override the default campaign value. |
 | `url` | URL | Share a specific URL. |
 | `title` | string | Override the share title. |
 
-### Follow buttons
+### Share suite (`[share_suite]`)
 
-Use the `[share_follow]` shortcode (alias `[waki_follow]`) to output follow buttons that link directly to your profiles. Supported networks are X, Instagram, Facebook Page, TikTok, YouTube, and LinkedIn.
+Combines share, follow, reactions, and the floating toggle. Attributes include:
 
-The shortcode accepts the following attributes:
+| Attribute | Values | Description |
+| --- | --- | --- |
+| `networks` | comma-separated slugs | Share button networks. |
+| `show_follow` | `1` or `0` | Include follow buttons. |
+| `show_reactions` | `1` or `0` | Include emoji reactions. |
+| `sticky_toggle` | `1` or `0` | Add the floating share bar. |
+| `follow_networks` | comma-separated slugs | Override follow networks. |
+| `follow_labels` | `show`, `hide`, `auto` | Follow label visibility. |
+| `follow_align` | `left`, `center`, `right`, `space-between` | Follow alignment. |
+| `reactions_placement` | `inline`, `sticky` | Reaction placement. |
+| `sticky_position` | `left`, `right` | Floating share position. |
+| `sticky_breakpoint` | integer | Minimum viewport for floating share. |
+| Other share attributes | Same as `[your_share]` | Styling, labels, UTM overrides. |
+
+Aliases: `[waki_share_suite]` and `[waki_share]`.
+
+### Follow buttons (`[share_follow]`)
+
+Outputs profile buttons (alias `[waki_follow]`):
 
 | Attribute | Values | Description |
 | --- | --- | --- |
@@ -35,6 +80,15 @@ The shortcode accepts the following attributes:
 | `labels` | `show`, `hide`, `auto` | Label visibility (default `show`). |
 
 Profiles without URLs are skipped automatically. Links open in a new tab with `rel="me noopener"` and do not trigger share popups.
+
+### Reactions (`[share_reactions]`)
+
+Embed the emoji reaction bar anywhere (alias `[waki_reactions]`). Attributes:
+
+| Attribute | Values | Description |
+| --- | --- | --- |
+| `placement` | `inline`, `sticky` | Where to render the bar. |
+| `post_id` | integer | Optional post ID override. |
 
 ## Admin settings
 

--- a/blocks/follow/block.json
+++ b/blocks/follow/block.json
@@ -1,0 +1,50 @@
+{
+    "apiVersion": 3,
+    "name": "your-share/follow-buttons",
+    "title": "Follow Buttons",
+    "category": "widgets",
+    "icon": "heart",
+    "description": "Output social profile buttons linked to configured follow URLs.",
+    "keywords": [
+        "follow",
+        "social",
+        "profiles"
+    ],
+    "attributes": {
+        "networks": {
+            "type": "string",
+            "default": ""
+        },
+        "style": {
+            "type": "string",
+            "default": ""
+        },
+        "size": {
+            "type": "string",
+            "default": ""
+        },
+        "align": {
+            "type": "string",
+            "default": ""
+        },
+        "brand": {
+            "type": "boolean",
+            "default": true
+        },
+        "labels": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": [
+            "wide",
+            "full"
+        ]
+    },
+    "editorScript": "file:../index.js",
+    "style": "your-share",
+    "editorStyle": "your-share",
+    "viewScript": "your-share"
+}

--- a/blocks/index.asset.php
+++ b/blocks/index.asset.php
@@ -1,0 +1,12 @@
+<?php
+return [
+    'dependencies' => [
+        'wp-blocks',
+        'wp-element',
+        'wp-i18n',
+        'wp-components',
+        'wp-block-editor',
+        'wp-server-side-render'
+    ],
+    'version' => '1.0.0',
+];

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -1,0 +1,407 @@
+(function (wp) {
+    if (!wp || !wp.blocks || !wp.element || !wp.blockEditor || !wp.components) {
+        return;
+    }
+
+    var registerBlockType = wp.blocks.registerBlockType;
+    var __ = wp.i18n.__;
+    var blockEditor = wp.blockEditor;
+    var InspectorControls = blockEditor.InspectorControls;
+    var useBlockProps = blockEditor.useBlockProps;
+    var InnerBlocks = blockEditor.InnerBlocks;
+    var components = wp.components;
+    var PanelBody = components.PanelBody;
+    var TextControl = components.TextControl;
+    var ToggleControl = components.ToggleControl;
+    var SelectControl = components.SelectControl;
+    var RangeControl = components.RangeControl;
+    var Fragment = wp.element.Fragment;
+    var el = wp.element.createElement;
+    var ServerSideRender = wp.serverSideRender;
+
+    function toNumber(value, fallback) {
+        var parsed = parseInt(value, 10);
+        if (isNaN(parsed)) {
+            return fallback;
+        }
+        return parsed;
+    }
+
+    function inspectorWrapper(children) {
+        return el(InspectorControls, null, children);
+    }
+
+    var LABEL_OPTIONS = [
+        { label: __('Theme default', 'your-share'), value: '' },
+        { label: __('Auto', 'your-share'), value: 'auto' },
+        { label: __('Show', 'your-share'), value: 'show' },
+        { label: __('Hide', 'your-share'), value: 'hide' }
+    ];
+
+    var STYLE_OPTIONS = [
+        { label: __('Theme default', 'your-share'), value: '' },
+        { label: __('Solid', 'your-share'), value: 'solid' },
+        { label: __('Outline', 'your-share'), value: 'outline' },
+        { label: __('Ghost', 'your-share'), value: 'ghost' }
+    ];
+
+    var SIZE_OPTIONS = [
+        { label: __('Theme default', 'your-share'), value: '' },
+        { label: __('Small', 'your-share'), value: 'sm' },
+        { label: __('Medium', 'your-share'), value: 'md' },
+        { label: __('Large', 'your-share'), value: 'lg' }
+    ];
+
+    var ALIGN_OPTIONS = [
+        { label: __('Theme default', 'your-share'), value: '' },
+        { label: __('Left', 'your-share'), value: 'left' },
+        { label: __('Center', 'your-share'), value: 'center' },
+        { label: __('Right', 'your-share'), value: 'right' },
+        { label: __('Space between', 'your-share'), value: 'space-between' }
+    ];
+
+    var STICKY_POSITIONS = [
+        { label: __('Theme default', 'your-share'), value: '' },
+        { label: __('Left', 'your-share'), value: 'left' },
+        { label: __('Right', 'your-share'), value: 'right' }
+    ];
+
+    var REACTION_PLACEMENTS = [
+        { label: __('Inline', 'your-share'), value: 'inline' },
+        { label: __('Sticky', 'your-share'), value: 'sticky' }
+    ];
+
+    var MEDIA_TAGS = [
+        { label: __('Figure', 'your-share'), value: 'figure' },
+        { label: __('Div', 'your-share'), value: 'div' },
+        { label: __('Section', 'your-share'), value: 'section' }
+    ];
+
+    var networkHelp = __('Enter comma-separated network slugs to override the defaults.', 'your-share');
+
+    function renderPreview(blockName, attributes, inspector) {
+        var blockProps = useBlockProps ? useBlockProps() : {};
+
+        return el(Fragment, null,
+            inspectorWrapper(inspector),
+            el('div', blockProps,
+                ServerSideRender ? el(ServerSideRender, {
+                    block: blockName,
+                    attributes: attributes
+                }) : null
+            )
+        );
+    }
+
+    registerBlockType('your-share/share-suite', {
+        edit: function (props) {
+            var attributes = props.attributes;
+            var setAttributes = props.setAttributes;
+
+            var inspector = el(Fragment, null,
+                el(PanelBody, { title: __('Share buttons', 'your-share'), initialOpen: true },
+                    el(TextControl, {
+                        label: __('Networks', 'your-share'),
+                        help: networkHelp,
+                        value: attributes.networks || '',
+                        onChange: function (value) { setAttributes({ networks: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Labels', 'your-share'),
+                        value: attributes.labels || '',
+                        options: LABEL_OPTIONS,
+                        onChange: function (value) { setAttributes({ labels: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Style', 'your-share'),
+                        value: attributes.style || '',
+                        options: STYLE_OPTIONS,
+                        onChange: function (value) { setAttributes({ style: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Size', 'your-share'),
+                        value: attributes.size || '',
+                        options: SIZE_OPTIONS,
+                        onChange: function (value) { setAttributes({ size: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Alignment', 'your-share'),
+                        value: attributes.align || '',
+                        options: ALIGN_OPTIONS,
+                        onChange: function (value) { setAttributes({ align: value }); }
+                    }),
+                    el(ToggleControl, {
+                        label: __('Use brand colours', 'your-share'),
+                        checked: attributes.brand !== false,
+                        onChange: function (value) { setAttributes({ brand: value }); }
+                    }),
+                    el(TextControl, {
+                        label: __('Custom share URL', 'your-share'),
+                        value: attributes.shareUrl || '',
+                        onChange: function (value) { setAttributes({ shareUrl: value }); }
+                    }),
+                    el(TextControl, {
+                        label: __('Custom title', 'your-share'),
+                        value: attributes.shareTitle || '',
+                        onChange: function (value) { setAttributes({ shareTitle: value }); }
+                    }),
+                    el(TextControl, {
+                        label: __('UTM campaign override', 'your-share'),
+                        value: attributes.utmCampaign || '',
+                        onChange: function (value) { setAttributes({ utmCampaign: value }); }
+                    })
+                ),
+                el(PanelBody, { title: __('Enhancements', 'your-share'), initialOpen: false },
+                    el(ToggleControl, {
+                        label: __('Show share buttons', 'your-share'),
+                        checked: attributes.showShare !== false,
+                        onChange: function (value) { setAttributes({ showShare: value }); }
+                    }),
+                    el(ToggleControl, {
+                        label: __('Add follow buttons', 'your-share'),
+                        checked: attributes.showFollow === true,
+                        onChange: function (value) { setAttributes({ showFollow: value }); }
+                    }),
+                    el(ToggleControl, {
+                        label: __('Show reactions', 'your-share'),
+                        checked: attributes.showReactions === true,
+                        onChange: function (value) { setAttributes({ showReactions: value }); }
+                    }),
+                    el(ToggleControl, {
+                        label: __('Include floating toggle', 'your-share'),
+                        checked: attributes.stickyToggle === true,
+                        onChange: function (value) { setAttributes({ stickyToggle: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Floating position', 'your-share'),
+                        value: attributes.stickyPosition || '',
+                        options: STICKY_POSITIONS,
+                        onChange: function (value) { setAttributes({ stickyPosition: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Floating labels', 'your-share'),
+                        value: attributes.stickyLabels || 'hide',
+                        options: LABEL_OPTIONS,
+                        onChange: function (value) { setAttributes({ stickyLabels: value }); }
+                    }),
+                    el(RangeControl, {
+                        label: __('Floating breakpoint', 'your-share'),
+                        value: attributes.stickyBreakpoint || 1024,
+                        onChange: function (value) { setAttributes({ stickyBreakpoint: toNumber(value, 1024) }); },
+                        min: 480,
+                        max: 1600,
+                        step: 20
+                    }),
+                    el(SelectControl, {
+                        label: __('Reactions placement', 'your-share'),
+                        value: attributes.reactionsPlacement || 'inline',
+                        options: REACTION_PLACEMENTS,
+                        onChange: function (value) { setAttributes({ reactionsPlacement: value }); }
+                    })
+                ),
+                attributes.showFollow === true ? el(PanelBody, { title: __('Follow options', 'your-share'), initialOpen: false },
+                    el(TextControl, {
+                        label: __('Follow networks', 'your-share'),
+                        help: networkHelp,
+                        value: attributes.followNetworks || '',
+                        onChange: function (value) { setAttributes({ followNetworks: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Follow labels', 'your-share'),
+                        value: attributes.followLabels || '',
+                        options: LABEL_OPTIONS,
+                        onChange: function (value) { setAttributes({ followLabels: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Follow alignment', 'your-share'),
+                        value: attributes.followAlign || '',
+                        options: ALIGN_OPTIONS,
+                        onChange: function (value) { setAttributes({ followAlign: value }); }
+                    })
+                ) : null
+            );
+
+            return renderPreview('your-share/share-suite', attributes, inspector);
+        },
+        save: function () {
+            return null;
+        }
+    });
+
+    registerBlockType('your-share/sticky-toggle', {
+        edit: function (props) {
+            var attributes = props.attributes;
+            var setAttributes = props.setAttributes;
+
+            var inspector = el(Fragment, null,
+                el(PanelBody, { title: __('Sticky share bar', 'your-share'), initialOpen: true },
+                    el(TextControl, {
+                        label: __('Networks', 'your-share'),
+                        help: networkHelp,
+                        value: attributes.networks || '',
+                        onChange: function (value) { setAttributes({ networks: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Labels', 'your-share'),
+                        value: attributes.labels || 'hide',
+                        options: LABEL_OPTIONS,
+                        onChange: function (value) { setAttributes({ labels: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Style', 'your-share'),
+                        value: attributes.style || '',
+                        options: STYLE_OPTIONS,
+                        onChange: function (value) { setAttributes({ style: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Size', 'your-share'),
+                        value: attributes.size || 'sm',
+                        options: SIZE_OPTIONS,
+                        onChange: function (value) { setAttributes({ size: value }); }
+                    }),
+                    el(ToggleControl, {
+                        label: __('Use brand colours', 'your-share'),
+                        checked: attributes.brand !== false,
+                        onChange: function (value) { setAttributes({ brand: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Floating position', 'your-share'),
+                        value: attributes.stickyPosition || '',
+                        options: STICKY_POSITIONS,
+                        onChange: function (value) { setAttributes({ stickyPosition: value }); }
+                    }),
+                    el(RangeControl, {
+                        label: __('Floating breakpoint', 'your-share'),
+                        value: attributes.stickyBreakpoint || 1024,
+                        onChange: function (value) { setAttributes({ stickyBreakpoint: toNumber(value, 1024) }); },
+                        min: 480,
+                        max: 1600,
+                        step: 20
+                    })
+                )
+            );
+
+            return renderPreview('your-share/sticky-toggle', attributes, inspector);
+        },
+        save: function () {
+            return null;
+        }
+    });
+
+    registerBlockType('your-share/follow-buttons', {
+        edit: function (props) {
+            var attributes = props.attributes;
+            var setAttributes = props.setAttributes;
+
+            var inspector = el(Fragment, null,
+                el(PanelBody, { title: __('Follow buttons', 'your-share'), initialOpen: true },
+                    el(TextControl, {
+                        label: __('Networks', 'your-share'),
+                        help: networkHelp,
+                        value: attributes.networks || '',
+                        onChange: function (value) { setAttributes({ networks: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Labels', 'your-share'),
+                        value: attributes.labels || '',
+                        options: LABEL_OPTIONS,
+                        onChange: function (value) { setAttributes({ labels: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Style', 'your-share'),
+                        value: attributes.style || '',
+                        options: STYLE_OPTIONS,
+                        onChange: function (value) { setAttributes({ style: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Size', 'your-share'),
+                        value: attributes.size || '',
+                        options: SIZE_OPTIONS,
+                        onChange: function (value) { setAttributes({ size: value }); }
+                    }),
+                    el(SelectControl, {
+                        label: __('Alignment', 'your-share'),
+                        value: attributes.align || '',
+                        options: ALIGN_OPTIONS,
+                        onChange: function (value) { setAttributes({ align: value }); }
+                    }),
+                    el(ToggleControl, {
+                        label: __('Use brand colours', 'your-share'),
+                        checked: attributes.brand !== false,
+                        onChange: function (value) { setAttributes({ brand: value }); }
+                    })
+                )
+            );
+
+            return renderPreview('your-share/follow-buttons', attributes, inspector);
+        },
+        save: function () {
+            return null;
+        }
+    });
+
+    registerBlockType('your-share/reactions', {
+        edit: function (props) {
+            var attributes = props.attributes;
+            var setAttributes = props.setAttributes;
+
+            var inspector = el(Fragment, null,
+                el(PanelBody, { title: __('Reactions', 'your-share'), initialOpen: true },
+                    el(SelectControl, {
+                        label: __('Placement', 'your-share'),
+                        value: attributes.placement || 'inline',
+                        options: REACTION_PLACEMENTS,
+                        onChange: function (value) { setAttributes({ placement: value }); }
+                    }),
+                    el(TextControl, {
+                        label: __('Override post ID', 'your-share'),
+                        help: __('Leave blank to use the current post.', 'your-share'),
+                        value: attributes.postId ? String(attributes.postId) : '',
+                        onChange: function (value) { setAttributes({ postId: toNumber(value, 0) }); }
+                    })
+                )
+            );
+
+            return renderPreview('your-share/reactions', attributes, inspector);
+        },
+        save: function () {
+            return null;
+        }
+    });
+
+    registerBlockType('your-share/media-selector', {
+        edit: function (props) {
+            var attributes = props.attributes;
+            var setAttributes = props.setAttributes;
+            var blockProps = useBlockProps ? useBlockProps({ className: 'your-share-media-selector' }) : {};
+
+            var inspector = el(Fragment, null,
+                el(PanelBody, { title: __('Overlay options', 'your-share'), initialOpen: true },
+                    el(SelectControl, {
+                        label: __('Wrapper element', 'your-share'),
+                        value: attributes.tagName || 'figure',
+                        options: MEDIA_TAGS,
+                        onChange: function (value) { setAttributes({ tagName: value }); }
+                    }),
+                    el(TextControl, {
+                        label: __('Overlay label', 'your-share'),
+                        help: __('Optional text announced to assistive technology.', 'your-share'),
+                        value: attributes.overlayLabel || '',
+                        onChange: function (value) { setAttributes({ overlayLabel: value }); }
+                    })
+                )
+            );
+
+            return el(Fragment, null,
+                inspectorWrapper(inspector),
+                el('div', blockProps,
+                    el('p', { className: 'your-share-media-selector__description' }, __('Add media blocks inside to enable the share overlay for that content.', 'your-share')),
+                    el(InnerBlocks)
+                )
+            );
+        },
+        save: function () {
+            return null;
+        }
+    });
+})();

--- a/blocks/media-selector/block.json
+++ b/blocks/media-selector/block.json
@@ -1,0 +1,35 @@
+{
+    "apiVersion": 3,
+    "name": "your-share/media-selector",
+    "title": "Share Overlay",
+    "category": "widgets",
+    "icon": "format-image",
+    "description": "Mark specific images or videos for overlay share controls.",
+    "keywords": [
+        "media",
+        "share",
+        "overlay"
+    ],
+    "attributes": {
+        "tagName": {
+            "type": "string",
+            "default": "figure"
+        },
+        "overlayLabel": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "supports": {
+        "html": false,
+        "anchor": true,
+        "align": [
+            "wide",
+            "full"
+        ]
+    },
+    "editorScript": "file:../index.js",
+    "style": "your-share",
+    "editorStyle": "your-share",
+    "viewScript": "your-share"
+}

--- a/blocks/reactions/block.json
+++ b/blocks/reactions/block.json
@@ -1,0 +1,30 @@
+{
+    "apiVersion": 3,
+    "name": "your-share/reactions",
+    "title": "Reactions",
+    "category": "widgets",
+    "icon": "smiley",
+    "description": "Capture lightweight feedback with emoji reactions.",
+    "keywords": [
+        "reactions",
+        "feedback",
+        "emoji"
+    ],
+    "attributes": {
+        "placement": {
+            "type": "string",
+            "default": "inline"
+        },
+        "postId": {
+            "type": "number",
+            "default": 0
+        }
+    },
+    "supports": {
+        "html": false
+    },
+    "editorScript": "file:../index.js",
+    "style": "your-share",
+    "editorStyle": "your-share",
+    "viewScript": "your-share"
+}

--- a/blocks/share/block.json
+++ b/blocks/share/block.json
@@ -1,0 +1,106 @@
+{
+    "apiVersion": 3,
+    "name": "your-share/share-suite",
+    "title": "Share Suite",
+    "category": "widgets",
+    "icon": "share",
+    "description": "Combine share buttons with optional follow links, reactions, and a floating toggle.",
+    "keywords": [
+        "share",
+        "social",
+        "follow"
+    ],
+    "attributes": {
+        "networks": {
+            "type": "string",
+            "default": ""
+        },
+        "labels": {
+            "type": "string",
+            "default": ""
+        },
+        "style": {
+            "type": "string",
+            "default": ""
+        },
+        "size": {
+            "type": "string",
+            "default": ""
+        },
+        "align": {
+            "type": "string",
+            "default": ""
+        },
+        "brand": {
+            "type": "boolean",
+            "default": true
+        },
+        "utmCampaign": {
+            "type": "string",
+            "default": ""
+        },
+        "shareUrl": {
+            "type": "string",
+            "default": ""
+        },
+        "shareTitle": {
+            "type": "string",
+            "default": ""
+        },
+        "showShare": {
+            "type": "boolean",
+            "default": true
+        },
+        "showFollow": {
+            "type": "boolean",
+            "default": false
+        },
+        "showReactions": {
+            "type": "boolean",
+            "default": false
+        },
+        "stickyToggle": {
+            "type": "boolean",
+            "default": false
+        },
+        "stickyLabels": {
+            "type": "string",
+            "default": "hide"
+        },
+        "stickyPosition": {
+            "type": "string",
+            "default": ""
+        },
+        "stickyBreakpoint": {
+            "type": "number",
+            "default": 1024
+        },
+        "followNetworks": {
+            "type": "string",
+            "default": ""
+        },
+        "followLabels": {
+            "type": "string",
+            "default": ""
+        },
+        "followAlign": {
+            "type": "string",
+            "default": ""
+        },
+        "reactionsPlacement": {
+            "type": "string",
+            "default": "inline"
+        }
+    },
+    "supports": {
+        "html": false,
+        "align": [
+            "wide",
+            "full"
+        ]
+    },
+    "editorScript": "file:../index.js",
+    "style": "your-share",
+    "editorStyle": "your-share",
+    "viewScript": "your-share"
+}

--- a/blocks/sticky-toggle/block.json
+++ b/blocks/sticky-toggle/block.json
@@ -1,0 +1,62 @@
+{
+    "apiVersion": 3,
+    "name": "your-share/sticky-toggle",
+    "title": "Sticky Share Toggle",
+    "category": "widgets",
+    "icon": "admin-links",
+    "description": "Display a floating share bar with configurable networks and positioning.",
+    "keywords": [
+        "share",
+        "floating",
+        "sticky"
+    ],
+    "attributes": {
+        "networks": {
+            "type": "string",
+            "default": ""
+        },
+        "labels": {
+            "type": "string",
+            "default": "hide"
+        },
+        "style": {
+            "type": "string",
+            "default": ""
+        },
+        "size": {
+            "type": "string",
+            "default": "sm"
+        },
+        "brand": {
+            "type": "boolean",
+            "default": true
+        },
+        "utmCampaign": {
+            "type": "string",
+            "default": ""
+        },
+        "shareUrl": {
+            "type": "string",
+            "default": ""
+        },
+        "shareTitle": {
+            "type": "string",
+            "default": ""
+        },
+        "stickyPosition": {
+            "type": "string",
+            "default": ""
+        },
+        "stickyBreakpoint": {
+            "type": "number",
+            "default": 1024
+        }
+    },
+    "supports": {
+        "html": false
+    },
+    "editorScript": "file:../index.js",
+    "style": "your-share",
+    "editorStyle": "your-share",
+    "viewScript": "your-share"
+}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -44,6 +44,7 @@ class Admin
         add_action('admin_menu', [$this, 'register_menu']);
         add_action('admin_init', [$this, 'register_settings']);
         add_filter('redirect_post_location', [$this, 'preserve_tab'], 10, 2);
+        add_action('load-settings_page_' . $this->slug, [$this, 'register_help_tabs']);
     }
 
     public function register_menu(): void
@@ -164,6 +165,52 @@ class Admin
             </form>
         </div>
         <?php
+    }
+
+    public function register_help_tabs(): void
+    {
+        $screen = get_current_screen();
+
+        if (!$screen) {
+            return;
+        }
+
+        $screen->add_help_tab([
+            'id'      => 'your-share-shortcodes',
+            'title'   => __('Blocks & shortcodes', $this->text_domain),
+            'content' => $this->help_tab_markup(),
+        ]);
+
+        $sidebar  = '<p><strong>' . esc_html__('Quick reference', $this->text_domain) . '</strong></p>';
+        $sidebar .= '<p><code>[your_share]</code> &mdash; ' . esc_html__('Inline share buttons.', $this->text_domain) . '</p>';
+        $sidebar .= '<p><code>[share_suite]</code> &mdash; ' . esc_html__('Composite share suite.', $this->text_domain) . '</p>';
+        $sidebar .= '<p><code>[share_follow]</code> &mdash; ' . esc_html__('Profile follow buttons.', $this->text_domain) . '</p>';
+        $sidebar .= '<p><code>[share_reactions]</code> &mdash; ' . esc_html__('Emoji reactions.', $this->text_domain) . '</p>';
+
+        $screen->set_help_sidebar($sidebar);
+    }
+
+    private function help_tab_markup(): string
+    {
+        ob_start();
+        ?>
+        <p><?php esc_html_e('Use the blocks or shortcodes below to embed sharing interfaces anywhere on your site.', $this->text_domain); ?></p>
+        <ul>
+            <li><strong><?php esc_html_e('Share Suite block', $this->text_domain); ?></strong> &mdash; <?php esc_html_e('Combine share buttons, follow links, reactions, and the floating toggle.', $this->text_domain); ?></li>
+            <li><strong><?php esc_html_e('Sticky Share Toggle block', $this->text_domain); ?></strong> &mdash; <?php esc_html_e('Outputs the floating share bar with per-page controls.', $this->text_domain); ?></li>
+            <li><strong><?php esc_html_e('Follow Buttons block', $this->text_domain); ?></strong> &mdash; <?php esc_html_e('Uses the profile URLs saved on the Follow tab.', $this->text_domain); ?></li>
+            <li><strong><?php esc_html_e('Reactions block', $this->text_domain); ?></strong> &mdash; <?php esc_html_e('Adds the emoji reaction bar inline or as a sticky widget.', $this->text_domain); ?></li>
+            <li><strong><?php esc_html_e('Share Overlay block', $this->text_domain); ?></strong> &mdash; <?php esc_html_e('Wrap media that should display a share overlay.', $this->text_domain); ?></li>
+        </ul>
+        <p><?php esc_html_e('Shortcodes mirror the block functionality and can be added to classic editor content:', $this->text_domain); ?></p>
+        <ul>
+            <li><code>[your_share]</code> &mdash; <?php esc_html_e('Inline share buttons.', $this->text_domain); ?></li>
+            <li><code>[share_suite]</code> &mdash; <?php esc_html_e('Composite suite with optional follow and reactions.', $this->text_domain); ?></li>
+            <li><code>[share_follow]</code> &mdash; <?php esc_html_e('Follow buttons linked to your profiles.', $this->text_domain); ?></li>
+            <li><code>[share_reactions]</code> &mdash; <?php esc_html_e('Emoji reactions bar.', $this->text_domain); ?></li>
+        </ul>
+        <?php
+        return (string) ob_get_clean();
     }
 
     public function preserve_tab(string $location, int $status): string

--- a/includes/class-asset-loader.php
+++ b/includes/class-asset-loader.php
@@ -38,23 +38,24 @@ class Asset_Loader
 
     public function register_hooks(): void
     {
-        add_action('wp_enqueue_scripts', [$this, 'enqueue_public']);
+        add_action('init', [$this, 'register_public_assets'], 9);
+        add_action('wp_enqueue_scripts', [$this, 'maybe_enqueue_public']);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_admin']);
     }
 
-    public function enqueue_public(): void
+    public function register_public_assets(): void
     {
         $style_handle  = 'your-share';
         $script_handle = 'your-share';
 
-        wp_enqueue_style(
+        wp_register_style(
             $style_handle,
             $this->plugin_url . 'assets/share.css',
             [],
             $this->version
         );
 
-        wp_enqueue_script(
+        wp_register_script(
             $script_handle,
             $this->plugin_url . 'assets/share.js',
             [],
@@ -62,6 +63,17 @@ class Asset_Loader
             true
         );
 
+        $this->localize_public_scripts($script_handle);
+    }
+
+    public function maybe_enqueue_public(): void
+    {
+        // Assets are conditionally enqueued by blocks and shortcodes. The method
+        // remains to preserve backward compatibility with previous hooks.
+    }
+
+    private function localize_public_scripts(string $script_handle): void
+    {
         wp_localize_script(
             $script_handle,
             'yourShareMessages',

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace YourShare;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Blocks
+{
+    /** @var string */
+    private $plugin_file;
+
+    /** @var Render */
+    private $renderer;
+
+    public function __construct(string $plugin_file, Render $renderer)
+    {
+        $this->plugin_file = $plugin_file;
+        $this->renderer    = $renderer;
+    }
+
+    public function register_hooks(): void
+    {
+        add_action('init', [$this, 'register_blocks']);
+    }
+
+    public function register_blocks(): void
+    {
+        $base    = trailingslashit(plugin_dir_path($this->plugin_file)) . 'blocks/';
+        $entries = [
+            'share'          => [$this, 'render_share_block'],
+            'sticky-toggle'  => [$this, 'render_sticky_block'],
+            'follow'         => [$this, 'render_follow_block'],
+            'reactions'      => [$this, 'render_reactions_block'],
+            'media-selector' => [$this, 'render_media_selector_block'],
+        ];
+
+        foreach ($entries as $directory => $callback) {
+            $path = $base . $directory;
+
+            if (!file_exists($path . '/block.json')) {
+                continue;
+            }
+
+            register_block_type($path, [
+                'render_callback' => $callback,
+            ]);
+        }
+    }
+
+    public function render_share_block($attributes, string $content = '', $block = null): string
+    {
+        $attributes = is_array($attributes) ? $attributes : [];
+
+        return $this->renderer->render_share_suite($attributes);
+    }
+
+    public function render_sticky_block($attributes, string $content = '', $block = null): string
+    {
+        $attributes = is_array($attributes) ? $attributes : [];
+
+        return $this->renderer->render_share_floating($attributes);
+    }
+
+    public function render_follow_block($attributes, string $content = '', $block = null): string
+    {
+        $attributes = is_array($attributes) ? $attributes : [];
+
+        return $this->renderer->render_follow($attributes);
+    }
+
+    public function render_reactions_block($attributes, string $content = '', $block = null): string
+    {
+        $attributes = is_array($attributes) ? $attributes : [];
+
+        return $this->renderer->render_reactions($attributes);
+    }
+
+    public function render_media_selector_block($attributes, string $content = '', $block = null): string
+    {
+        $attributes = is_array($attributes) ? $attributes : [];
+        $tag        = isset($attributes['tagName']) && is_string($attributes['tagName']) ? strtolower($attributes['tagName']) : 'figure';
+        $allowed    = ['div', 'figure', 'section'];
+
+        if (!in_array($tag, $allowed, true)) {
+            $tag = 'figure';
+        }
+
+        $extra = [
+            'data-your-share-media' => '1',
+        ];
+
+        if (!empty($attributes['overlayLabel']) && is_string($attributes['overlayLabel'])) {
+            $extra['data-your-share-media-label'] = sanitize_text_field($attributes['overlayLabel']);
+        }
+
+        if (function_exists('get_block_wrapper_attributes')) {
+            $wrapper = get_block_wrapper_attributes($extra);
+        } else {
+            $wrapper = '';
+        }
+
+        wp_enqueue_style('your-share');
+        wp_enqueue_script('your-share');
+
+        if (trim((string) $content) === '') {
+            return '';
+        }
+
+        $markup = sprintf(
+            '<%1$s %2$s>%3$s</%1$s>',
+            tag_escape($tag),
+            $wrapper,
+            $content
+        );
+
+        return (string) apply_filters('your_share_media_selector_markup', $markup, $attributes, $block);
+    }
+}

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -38,6 +38,7 @@ class Plugin
         $this->container->get(Rest::class)->register_hooks();
         $this->container->get(Analytics::class)->register_hooks();
         $this->container->get(Shortcode::class)->register_hooks();
+        $this->container->get(Blocks::class)->register_hooks();
 
         do_action('your_share_plugin_booted', $this);
     }
@@ -115,6 +116,13 @@ class Plugin
 
         $this->container->set(Shortcode::class, function (Container $c): Shortcode {
             return new Shortcode($c->get(Options::class), $c->get(Render::class));
+        });
+
+        $this->container->set(Blocks::class, function (Container $c) use ($plugin_file): Blocks {
+            return new Blocks(
+                $plugin_file,
+                $c->get(Render::class)
+            );
         });
 
         $this->container->set(Counts::class, function (Container $c): Counts {

--- a/includes/class-reactions.php
+++ b/includes/class-reactions.php
@@ -205,11 +205,7 @@ class Reactions
 
     public function render_inline(int $post_id): string
     {
-        if (!$this->is_enabled('inline')) {
-            return '';
-        }
-
-        return $this->render_markup($post_id, 'inline');
+        return $this->render_block('inline', $post_id);
     }
 
     public function render_sticky(): void
@@ -227,13 +223,44 @@ class Reactions
             return;
         }
 
-        $markup = $this->render_markup($post_id, 'sticky');
+        $markup = $this->render_block('sticky', $post_id);
 
         if ($markup === '') {
             return;
         }
 
         echo $markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+
+    public function render_block(string $placement = 'inline', ?int $post_id = null): string
+    {
+        $placement = $placement === 'sticky' ? 'sticky' : 'inline';
+
+        if ($placement === 'inline' && !$this->is_enabled('inline')) {
+            return '';
+        }
+
+        if ($placement === 'sticky' && !$this->is_enabled('sticky')) {
+            return '';
+        }
+
+        if ($post_id === null || $post_id <= 0) {
+            $post = get_post();
+            if ($post instanceof \WP_Post) {
+                $post_id = (int) $post->ID;
+            } else {
+                $post_id = 0;
+            }
+        }
+
+        if ($post_id <= 0) {
+            return '';
+        }
+
+        wp_enqueue_style('your-share');
+        wp_enqueue_script('your-share');
+
+        return $this->render_markup($post_id, $placement);
     }
 
     public function current_user_reaction(int $post_id): string

--- a/includes/class-shortcode.php
+++ b/includes/class-shortcode.php
@@ -30,56 +30,48 @@ class Shortcode
     {
         add_shortcode('your_share', [$this, 'handle_shortcode']);
         add_shortcode('waki_share', [$this, 'handle_shortcode']);
+        add_shortcode('share_suite', [$this, 'handle_suite_shortcode']);
+        add_shortcode('waki_share_suite', [$this, 'handle_suite_shortcode']);
         add_shortcode('share_follow', [$this, 'handle_follow_shortcode']);
         add_shortcode('waki_follow', [$this, 'handle_follow_shortcode']);
+        add_shortcode('share_reactions', [$this, 'handle_reactions_shortcode']);
+        add_shortcode('waki_reactions', [$this, 'handle_reactions_shortcode']);
     }
 
     public function handle_shortcode($atts, $content = '', string $tag = 'your_share'): string
     {
-        $options = $this->options->all();
-
         if (!is_array($atts)) {
             $atts = [];
         }
 
-        $atts = shortcode_atts([
-            'networks'     => '',
-            'labels'       => $options['share_labels'],
-            'style'        => $options['share_style'],
-            'size'         => $options['share_size'],
-            'align'        => $options['share_align'],
-            'brand'        => $options['share_brand_colors'] ? '1' : '0',
-            'utm_campaign' => '',
-            'url'          => '',
-            'title'        => '',
-        ], $atts, $tag);
-
-        $context = [
-            'placement' => 'inline',
-            'align'     => $atts['align'],
-        ];
-
-        return $this->renderer->render($context, $atts);
+        return $this->renderer->render_share_inline($atts);
     }
 
     public function handle_follow_shortcode($atts, $content = '', string $tag = 'share_follow'): string
     {
-        $options = $this->options->all();
-
         if (!is_array($atts)) {
             $atts = [];
         }
 
-        $atts = shortcode_atts([
-            'networks' => '',
-            'style'    => $options['share_style'],
-            'size'     => $options['share_size'],
-            'align'    => $options['share_align'],
-            'brand'    => $options['share_brand_colors'] ? '1' : '0',
-            'labels'   => 'show',
-        ], $atts, $tag);
-
         return $this->renderer->render_follow($atts);
+    }
+
+    public function handle_suite_shortcode($atts, $content = '', string $tag = 'share_suite'): string
+    {
+        if (!is_array($atts)) {
+            $atts = [];
+        }
+
+        return $this->renderer->render_share_suite($atts);
+    }
+
+    public function handle_reactions_shortcode($atts, $content = '', string $tag = 'share_reactions'): string
+    {
+        if (!is_array($atts)) {
+            $atts = [];
+        }
+
+        return $this->renderer->render_reactions($atts);
     }
 
     public function maybe_render_floating(): void
@@ -91,23 +83,14 @@ class Shortcode
         }
 
         $atts = [
-            'networks'     => '',
-            'labels'       => 'hide',
-            'style'        => $options['share_style'],
-            'size'         => 'sm',
-            'align'        => 'left',
-            'brand'        => $options['share_brand_colors'] ? '1' : '0',
-            'utm_campaign' => '',
-            'url'          => '',
-            'title'        => '',
+            'labels'           => 'hide',
+            'style'            => $options['share_style'],
+            'size'             => 'sm',
+            'brand'            => $options['share_brand_colors'] ? '1' : '0',
+            'sticky_position'  => $options['sticky_position'],
+            'sticky_breakpoint'=> intval($options['sticky_breakpoint']),
         ];
 
-        $context = [
-            'placement'  => 'floating',
-            'position'   => $options['sticky_position'],
-            'breakpoint' => intval($options['sticky_breakpoint']),
-        ];
-
-        echo $this->renderer->render($context, $atts); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        echo $this->renderer->render_share_floating($atts); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
     }
 }


### PR DESCRIPTION
## Summary
- add dynamic Share Suite, Sticky Toggle, Follow, Reactions, and Share Overlay blocks registered via block.json metadata with server previews
- introduce renderer helpers that power new `[share_suite]` and `[share_reactions]` shortcodes alongside existing share/follow handlers
- register on-demand assets, document usage in README/admin help, and wire the new Blocks service into the plugin bootstrap

## Testing
- php -l includes/class-asset-loader.php
- php -l includes/class-render.php
- php -l includes/class-shortcode.php
- php -l includes/class-plugin.php
- php -l includes/class-blocks.php
- php -l includes/class-reactions.php
- php -l includes/class-admin.php


------
https://chatgpt.com/codex/tasks/task_e_68cfacdb9934832cae47f4fa25f12616