### PR TITLE
Fix settings redirect by preserving referer

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -342,8 +342,36 @@
     var tabs = qsa(root, '[data-your-share-tab]');
     var panels = qsa(root, '[data-your-share-panel]');
     var currentInput = qs(root, '[data-your-share-current-tab]');
+    var refererInput = qs(root, '[data-your-share-referer]');
     if (!tabs.length || !panels.length || !currentInput){
       return;
+    }
+
+    function updateReferer(tab){
+      if (!refererInput){
+        return;
+      }
+      var base = refererInput.getAttribute('data-base') || '';
+      if (!base){
+        refererInput.value = '';
+        return;
+      }
+      try {
+        var url = new URL(base, window.location.origin);
+        if (tab){
+          url.searchParams.set('tab', tab);
+        } else {
+          url.searchParams.delete('tab');
+        }
+        refererInput.value = url.pathname + url.search;
+      } catch (error) {
+        var cleaned = base.replace(/([?&])tab=[^&#]*/g, '$1').replace(/[?&]$/, '');
+        if (tab){
+          refererInput.value = cleaned + (cleaned.indexOf('?') === -1 ? '?' : '&') + 'tab=' + tab;
+        } else {
+          refererInput.value = cleaned;
+        }
+      }
     }
 
     function activateTab(tab, updateUrl){
@@ -370,6 +398,7 @@
       }
 
       currentInput.value = tab;
+      updateReferer(tab);
 
       if (updateUrl){
         try {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -160,6 +160,24 @@ class Admin
                         </div>
                     <?php endforeach; ?>
                 </div>
+                <?php
+                $referer_base  = add_query_arg('page', $this->slug, admin_url('options-general.php'));
+                $referer_value = $referer_base;
+
+                if (!empty($current_tab)) {
+                    $referer_value = add_query_arg('tab', $current_tab, $referer_value);
+                }
+
+                $referer_base  = wp_make_link_relative($referer_base);
+                $referer_value = wp_make_link_relative($referer_value);
+                ?>
+                <input
+                    type="hidden"
+                    name="_wp_http_referer"
+                    value="<?php echo esc_attr($referer_value); ?>"
+                    data-your-share-referer
+                    data-base="<?php echo esc_attr($referer_base); ?>"
+                >
                 <?php submit_button(__('Save settings', $this->text_domain)); ?>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- ensure the Your Share settings form always posts the correct referer so saves redirect back to the plugin page
- update the admin JavaScript tab handler to keep the hidden referer field in sync with the active tab selection

## Testing
- php -l includes/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cfb5cddb2c832c9ed312ce53b38874