### PR TITLE
Fix container factory invocation for Waki Share

### DIFF
--- a/includes/class-container.php
+++ b/includes/class-container.php
@@ -31,7 +31,13 @@ class Container
                 throw new \InvalidArgumentException(sprintf('Service "%s" is not registered in the container.', $id));
             }
 
-            $this->instances[$id] = call_user_func($this->factories[$id], $this);
+            $factory = $this->factories[$id];
+
+            try {
+                $this->instances[$id] = $factory($this);
+            } catch (\ArgumentCountError $error) {
+                $this->instances[$id] = $factory();
+            }
         }
 
         return $this->instances[$id];


### PR DESCRIPTION
## Summary
- ensure container factories that do not require the container argument can still be invoked
- store resolved services after trying to call factories with the container or without

## Testing
- php -l includes/class-container.php

------
https://chatgpt.com/codex/tasks/task_e_68cfba2115a4832c8b5544246af79684