### PR TITLE
fix: inline katumia emoji assets

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -186,6 +186,33 @@
   padding: 0.25rem 0.6rem;
 }
 
+.your-share-reaction-picker {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.your-share-reaction-picker__label {
+  font-weight: 600;
+}
+
+.your-share-reaction-search {
+  flex: 1 1 260px;
+  max-width: 420px;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid #dcdcde;
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.your-share-reaction-search:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 1px #2563eb33;
+}
+
 .your-share-reaction-grid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
@@ -200,13 +227,33 @@
   background: #fff;
 }
 
+.your-share-reaction-option.is-active {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 1px #2563eb1a;
+}
+
 .your-share-reaction-option input {
   margin: 0;
 }
 
 .your-share-reaction-symbol {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-size: 1.5rem;
   line-height: 1;
+}
+
+.your-share-reaction-symbol.has-image {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+
+.your-share-reaction-symbol.has-image .your-share-reaction-symbol-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .your-share-reaction-text {

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -28,10 +28,40 @@
 
     setupTabs(root);
     setupNetworkPicker(root);
+    setupReactionPicker(root);
     setupShortcodePreview(root);
     setupFollowShortcodePreview(root);
     setupUtmPreview(root);
     setupAnalyticsReports(root);
+  }
+
+  function setupReactionPicker(root){
+    var container = qs(root, '[data-your-share-reaction-picker]');
+    var list = qs(root, '[data-your-share-reaction-list]');
+    if (!container || !list){
+      return;
+    }
+
+    var search = qs(container, '[data-your-share-reaction-search]');
+    if (!search){
+      return;
+    }
+
+    var options = qsa(list, '[data-reaction-slug]');
+
+    function filter(){
+      var term = search.value ? search.value.toLowerCase().trim() : '';
+      options.forEach(function(option){
+        var label = option.getAttribute('data-reaction-label') || '';
+        var slug = option.getAttribute('data-reaction-slug') || '';
+        var match = !term || label.indexOf(term) !== -1 || slug.indexOf(term) !== -1;
+        option.style.display = match ? '' : 'none';
+      });
+    }
+
+    search.addEventListener('input', filter);
+    search.addEventListener('keyup', filter);
+    filter();
   }
 
   function setupAnalyticsReports(root){

--- a/assets/icons/share.svg
+++ b/assets/icons/share.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <path d="M13 5l5 5-5 5V11H9a4 4 0 00-4 4v4h-2v-4a6 6 0 016-6h4V5z"/>
+</svg>

--- a/assets/share.css
+++ b/assets/share.css
@@ -1,4 +1,4 @@
-.waki-share{--waki-gap:8px;--waki-radius:9999px;--waki-pill-height:3rem;--waki-pill-padding:1.1rem;--waki-content-gap:.65rem;--icon-size:calc(var(--waki-pill-height)*0.5625);--optical-x:0px;--optical-y:0px;display:flex;flex-wrap:wrap;gap:var(--waki-gap);align-items:center}
+.waki-share{--waki-gap:8px;--waki-radius:9999px;--waki-pill-height:3rem;--waki-pill-padding:1.1rem;--waki-content-gap:.65rem;--icon-size:calc(var(--waki-pill-height)*0.5625);--optical-x:0px;--optical-y:0px;display:flex;flex-wrap:wrap;gap:var(--waki-gap);align-items:flex-start}
 .waki-share.align-center{justify-content:center}
 .waki-share.align-right{justify-content:flex-end}
 .waki-btn{display:inline-flex;align-items:center;place-items:center;gap:var(--waki-content-gap);text-decoration:none;border:1px solid transparent;border-radius:var(--waki-radius);transition:transform .08s ease,background .2s ease,border-color .2s ease;line-height:1;padding:0 var(--waki-pill-padding);min-block-size:var(--waki-pill-height);min-height:var(--waki-pill-height);height:var(--waki-pill-height)}
@@ -19,6 +19,9 @@
 .waki-style-solid.is-mono .waki-btn{background:#111;color:#fff}
 .waki-style-outline .waki-btn{background:transparent;border-color:rgba(0,0,0,.18);color:#111}
 .waki-style-ghost .waki-btn{background:transparent;color:#111}
+.waki-btn--toggle{cursor:pointer}
+.waki-style-solid .waki-btn--toggle{background:#111;color:#fff}
+.waki-style-outline .waki-btn--toggle,.waki-style-ghost .waki-btn--toggle{background:transparent;border-color:rgba(0,0,0,.18)}
 .waki-style-outline .waki-btn:hover,
 .waki-style-ghost .waki-btn:hover{border-color:rgba(0,0,0,.35);transform:translateY(-1px)}
 .waki-style-solid .waki-btn:hover{filter:brightness(0.95);transform:translateY(-1px)}
@@ -35,6 +38,7 @@
 .is-brand .waki-btn[data-net="email"]{background:#6B7280}
 .is-brand .waki-btn[data-net="copy"]{background:#6B7280}
 .is-brand .waki-btn[data-net="native"]{background:#6B7280}
+.is-brand .waki-btn[data-net="more"]{background:#6B7280}
 .waki-labels-hide .waki-label{display:none}
 @media (max-width:640px){.waki-labels-auto .waki-label{display:none}}
 .waki-share-floating{position:fixed;top:40%;transform:translateY(-50%);z-index:9999;display:flex;flex-direction:column;background:transparent}
@@ -49,7 +53,9 @@
 .waki-reaction:hover{background:#e2e8f0;border-color:rgba(15,23,42,.25);transform:translateY(-1px)}
 .waki-reaction:focus{outline:2px solid #2563eb;outline-offset:2px}
 .waki-reaction.is-active{background:#2563eb;border-color:#2563eb;color:#fff;box-shadow:0 10px 25px rgba(37,99,235,.35)}
-.waki-reaction-emoji{font-size:1.15rem;line-height:1}
+.waki-reaction-emoji{display:inline-flex;align-items:center;justify-content:center;font-size:1.15rem;line-height:1}
+.waki-reaction-emoji.has-image{width:1.85rem;height:1.85rem}
+.waki-reaction-emoji.has-image .waki-reaction-emoji-img{display:block;width:100%;height:100%;object-fit:contain}
 .waki-reaction-label{font-size:.8rem}
 .waki-reaction-count{font-size:.8rem;font-variant-numeric:tabular-nums;color:rgba(15,23,42,.8)}
 #wakiShareToast{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);background:#111;color:#fff;padding:.5rem .75rem;border-radius:8px;font-size:.875rem;opacity:0;pointer-events:none;transition:opacity .25s ease}
@@ -88,5 +94,9 @@
 .waki-share .waki-count{display:inline-flex;align-items:center;justify-content:center;margin-left:0;padding:.15rem .45rem;border-radius:9999px;font-size:.75rem;font-weight:600;line-height:1;flex:0 0 auto}
 .waki-style-solid .waki-count{background:rgba(255,255,255,.28);color:#fff}
 .waki-style-outline .waki-count,.waki-style-ghost .waki-count{background:rgba(17,24,39,.08);color:inherit}
-.waki-share-total{display:flex;align-items:center;gap:.5rem;margin-right:auto;font-size:.875rem;font-weight:600}
-.waki-share-total .waki-total-value{font-size:1rem}
+.waki-share-total{display:flex;flex-direction:column;align-items:flex-start;gap:.25rem;margin-right:auto;font-size:.85rem;font-weight:600;line-height:1.2}
+.waki-share-total .waki-total-value{font-size:1.25rem;font-weight:700}
+.waki-share-buttons{display:flex;flex-wrap:wrap;gap:var(--waki-gap);align-items:center}
+.waki-share-extra{display:flex;flex-wrap:wrap;gap:var(--waki-gap);width:100%;margin-top:var(--waki-gap)}
+.waki-share-extra[hidden]{display:none}
+.waki-btn--toggle.is-active{box-shadow:0 0 0 2px rgba(37,99,235,.18)}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1290,18 +1290,87 @@ class Admin
 
     public function field_reactions_emojis(): void
     {
-        $values  = $this->values();
-        $enabled = $values['reactions_enabled'] ?? [];
-        $emojis  = $this->reactions->emojis();
+        $values       = $this->values();
+        $enabled_map  = $values['reactions_enabled'] ?? [];
+        $emojis       = $this->reactions->emojis();
+        $search_id    = 'your-share-reaction-search-' . wp_generate_uuid4();
+        $enabled_slugs = [];
+
+        if (is_array($enabled_map)) {
+            foreach ($enabled_map as $slug => $flag) {
+                if (!empty($flag)) {
+                    $enabled_slugs[] = sanitize_key((string) $slug);
+                }
+            }
+        }
+
+        $enabled_lookup = array_fill_keys($enabled_slugs, true);
+
+        $keys = array_keys($emojis);
+        usort(
+            $keys,
+            static function ($a, $b) use ($emojis, $enabled_lookup) {
+                $a_active = !empty($enabled_lookup[$a]);
+                $b_active = !empty($enabled_lookup[$b]);
+
+                if ($a_active !== $b_active) {
+                    return $a_active ? -1 : 1;
+                }
+
+                $a_label = isset($emojis[$a]['label']) ? $emojis[$a]['label'] : $a;
+                $b_label = isset($emojis[$b]['label']) ? $emojis[$b]['label'] : $b;
+
+                return strcasecmp((string) $a_label, (string) $b_label);
+            }
+        );
         ?>
-        <div class="your-share-field-grid your-share-reaction-grid">
-            <?php foreach ($emojis as $slug => $emoji) :
-                $is_enabled = !empty($enabled[$slug]);
+        <div class="your-share-reaction-picker" data-your-share-reaction-picker>
+            <label for="<?php echo esc_attr($search_id); ?>" class="your-share-reaction-picker__label"><?php esc_html_e('Search reactions', $this->text_domain); ?></label>
+            <input
+                type="search"
+                id="<?php echo esc_attr($search_id); ?>"
+                class="your-share-reaction-search"
+                placeholder="<?php esc_attr_e('Filter by emoji or name…', $this->text_domain); ?>"
+                data-your-share-reaction-search
+            >
+        </div>
+        <div class="your-share-field-grid your-share-reaction-grid" data-your-share-reaction-list>
+            <?php foreach ($keys as $slug) :
+                if (!isset($emojis[$slug])) {
+                    continue;
+                }
+                $emoji      = $emojis[$slug];
+                $label      = $emoji['label'] ?? $slug;
+                $symbol     = $emoji['emoji'] ?? '';
+                $image_url  = isset($emoji['image_url']) ? (string) $emoji['image_url'] : '';
+                $image_w    = isset($emoji['image_width']) ? (int) $emoji['image_width'] : 0;
+                $image_h    = isset($emoji['image_height']) ? (int) $emoji['image_height'] : 0;
+                $symbol_class = 'your-share-reaction-symbol' . ($image_url !== '' ? ' has-image' : '');
+                $is_enabled = !empty($enabled_lookup[$slug]);
+                $filter_key = function_exists('mb_strtolower') ? mb_strtolower((string) $label) : strtolower((string) $label);
                 ?>
-                <label class="your-share-reaction-option">
+                <label
+                    class="your-share-reaction-option<?php echo $is_enabled ? ' is-active' : ''; ?>"
+                    data-reaction-slug="<?php echo esc_attr($slug); ?>"
+                    data-reaction-label="<?php echo esc_attr(wp_strip_all_tags(wp_specialchars_decode($filter_key, ENT_QUOTES))); ?>"
+                >
                     <input type="checkbox" name="<?php echo esc_attr($this->name('reactions_enabled') . '[' . $slug . ']'); ?>" value="1" <?php checked($is_enabled, true); ?>>
-                    <span class="your-share-reaction-symbol" aria-hidden="true"><?php echo esc_html($emoji['emoji']); ?></span>
-                    <span class="your-share-reaction-text"><?php echo esc_html($emoji['label']); ?></span>
+                    <span class="<?php echo esc_attr($symbol_class); ?>" aria-hidden="true">
+                        <?php if ($image_url !== '') : ?>
+                            <img
+                                src="<?php echo esc_url($image_url); ?>"
+                                alt=""
+                                loading="lazy"
+                                decoding="async"
+                                <?php if ($image_w > 0) : ?>width="<?php echo esc_attr((string) $image_w); ?>"<?php endif; ?>
+                                <?php if ($image_h > 0) : ?>height="<?php echo esc_attr((string) $image_h); ?>"<?php endif; ?>
+                                class="your-share-reaction-symbol-img"
+                            >
+                        <?php else : ?>
+                            <?php echo esc_html($symbol); ?>
+                        <?php endif; ?>
+                    </span>
+                    <span class="your-share-reaction-text"><?php echo esc_html($label); ?></span>
                 </label>
             <?php endforeach; ?>
         </div>

--- a/includes/class-emoji-library.php
+++ b/includes/class-emoji-library.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace YourShare;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Emoji_Library
+{
+    /**
+     * @var array<string, array{
+     *     emoji: string,
+     *     label: string,
+     *     image?: string,
+     *     image_width?: int,
+     *     image_height?: int
+     * }>|null
+     */
+    private static $cache = null;
+
+    /**
+     * Retrieve the complete emoji dataset bundled with the plugin.
+     */
+    public static function all(): array
+    {
+        if (self::$cache !== null) {
+            return self::$cache;
+        }
+
+        $file = __DIR__ . '/data/emoji.php';
+
+        if (!is_readable($file)) {
+            self::$cache = [];
+
+            return self::$cache;
+        }
+
+        $data = include $file;
+
+        if (!is_array($data)) {
+            $data = [];
+        }
+
+        $normalized = [];
+
+        foreach ($data as $slug => $info) {
+            if (!is_array($info)) {
+                continue;
+            }
+
+            $slug = sanitize_key((string) $slug);
+
+            if ($slug === '') {
+                continue;
+            }
+
+            $emoji = isset($info['emoji']) ? (string) $info['emoji'] : '';
+            $label = isset($info['label']) ? (string) $info['label'] : '';
+            $image = isset($info['image']) ? (string) $info['image'] : '';
+            $width = isset($info['image_width']) ? (int) $info['image_width'] : (isset($info['width']) ? (int) $info['width'] : 0);
+            $height = isset($info['image_height']) ? (int) $info['image_height'] : (isset($info['height']) ? (int) $info['height'] : 0);
+
+            if ($width < 0) {
+                $width = 0;
+            }
+
+            if ($height < 0) {
+                $height = 0;
+            }
+
+            if ($emoji === '' && $image === '') {
+                continue;
+            }
+
+            if ($label === '') {
+                $label = ucfirst(str_replace('-', ' ', $slug));
+            }
+
+            $normalized[$slug] = [
+                'emoji' => $emoji,
+                'label' => $label,
+            ];
+
+            if ($image !== '') {
+                if (strpos($image, 'data:') === 0 || preg_match('#^(https?:)?//#', $image) === 1) {
+                    $normalized[$slug]['image'] = $image;
+                } else {
+                    $normalized[$slug]['image'] = ltrim($image, '/');
+                }
+            }
+
+            if ($width > 0) {
+                $normalized[$slug]['image_width'] = $width;
+            }
+
+            if ($height > 0) {
+                $normalized[$slug]['image_height'] = $height;
+            }
+        }
+
+        self::$cache = $normalized;
+
+        return self::$cache;
+    }
+
+    /**
+     * Default emoji slugs to enable for new installations.
+     */
+    public static function defaults(): array
+    {
+        return ['like', 'love', 'celebrate', 'insightful', 'support'];
+    }
+
+    /**
+     * Ensure a list of reaction slugs only contains valid emojis.
+     *
+     * @param array<int|string, mixed> $slugs Raw slug list.
+     *
+     * @return string[]
+     */
+    public static function sanitize_slugs($slugs): array
+    {
+        if (!is_array($slugs)) {
+            $slugs = [];
+        }
+
+        $allowed = self::all();
+        $output  = [];
+
+        foreach ($slugs as $key => $value) {
+            $slug = is_int($key) ? (string) $value : (string) $key;
+            $slug = sanitize_key($slug);
+
+            if ($slug === '' || !isset($allowed[$slug])) {
+                continue;
+            }
+
+            $enabled = is_int($value) || is_bool($value) ? !empty($value) : true;
+
+            if (!$enabled) {
+                continue;
+            }
+
+            if (!in_array($slug, $output, true)) {
+                $output[] = $slug;
+            }
+        }
+
+        return $output;
+    }
+}

--- a/includes/class-icons.php
+++ b/includes/class-icons.php
@@ -40,6 +40,7 @@ class Icons
             'email'    => 'email',
             'copy'     => 'copy',
             'native'   => 'native',
+            'share-toggle' => 'share',
             'instagram'     => 'instagram',
             'tiktok'        => 'tiktok',
             'youtube'       => 'youtube',

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -75,8 +75,13 @@ class Plugin
             return new UTM($c->get(Options::class));
         });
 
-        $this->container->set(Reactions::class, function (Container $c): Reactions {
-            return new Reactions($c->get(Options::class), self::TEXT_DOMAIN);
+        $this->container->set(Reactions::class, function (Container $c) use ($plugin_dir, $plugin_url): Reactions {
+            return new Reactions(
+                $c->get(Options::class),
+                self::TEXT_DOMAIN,
+                $plugin_dir . 'assets/emoji',
+                $plugin_url . 'assets/emoji'
+            );
         });
 
         $this->container->set(Rest::class, function (Container $c): Rest {

--- a/includes/data/emoji.php
+++ b/includes/data/emoji.php
@@ -1,0 +1,2936 @@
+<?php
+return [
+    'katumia-like' => [
+        'emoji' => '😺',
+        'label' => 'Katumia Like',
+        'image' => 'data:image/png;base64,' .
+            'iVBORw0KGgoAAAANSUhEUgAAAKAAAACgCAYAAACLz2ctAAA300lEQVR4nO29aXQd13Um+u1zTlXdGfNEcB5FgKRIgZQoWTbp2LGVwVPHQHe7091JO4k66aTb' .
+            'SpwXW24HRMcabMWd4eWt9ZROXl6Gtl+ItO2V2G4nVkzRlkRSIiWLFqCBokiKEgcMJAjgDlV1ztnvR9W9AEVSoixKvADup4W1RNxbhapTX+157wPUUEMNNdRQ' .
+            'Qw011FBDDTXUUEMNNdRQQw011FBDDTXUUEMNNdRQQw011FBDDTXUUEMNNdRQQw011FBDDTXUUMM8RH8/BPdDvNPH1lBDDTVcP3B/vwCA/b+3acWhL27YursX' .
+            'svy7qzmW+yEO3rPhhkP3bNg0+3w1zKC2IK+H7mECAHL0x7Tlh/sGYYAB0FUdPAAagA1hvxUK+6uzz1dDDVcFBmhP/7LE/vu6Xn3+j2/kR7+w/j8AwJ7+Her1' .
+            'jit//ugXuj84/Icbi/vv7dLD925rAkCMq+TvAkFNAl4BBx/sccBAKpn9tfqUavVDo5Oe/I3D921s2NndysxXJBJlF03Tsb/YkXAk3WUMEtmkxAUUBgDwoQd7' .
+            'Xpe8Cw01Al4GzKCeU4fMo19alxHApwqBVXmfbSYhNxfY3EF9gwaDvZddu929EFvvPBSeeHlsYyYpPjhVMqYUWGQTou/x+9asfKlhpWWu2YJl1BbiMhgc7BU0' .
+            'ACtC9clMUizxQ2slQRV8Yy3jXgBA3yC/9jju7xdDXeBHvrhxXVNGfq0UmFAQidAwlKIWY9Vv9PUNGux6p++oelEj4GtQVq1P3rO5JeGK3wi1NQSAAeGH1jRl' .
+            'VeeB+7p/iQB78MEe56KDu4dpYABWavNLSZcW+5qJCEQgkS8Z6zrykz+4v2spDQzY11HhCwq1RXgNuH+HAvbaA4muX23KOH8yNhmGQpADAAzYhCNEaHg4IfmO' .
+            'DUu7TqF30BKBGaBd/aAPZXsaTVg8QyARi0gCAGYOG7OOOp/Xf1goNv8f2UXTtPXOQ+H1u9PqQE0CzgIDhF17Dbp7iS12XSgYJkEVp4EAUfCNaUjLrimf/4z6' .
+            'Bs2f3hk5FYce7FEDA7BhUNqVSymyYINZLzgROeemNSTRr6bSo809pw6Z/lqGpLYAF2HPDkkEPvDiM3flUrJZW2vpNVpCChLnp3XQkFbbH7+/+7ZTHYfMM/1d' .
+            '7j+cOmQev2/9+9Me9RVKhsEkLzk/s016lDAhPk8DsDuxY8Gv/4JfgDK4v18Mjrbyow+sbE068pe1ZYvLmyhkLEsAOWP40wMDsN3d3WZgANYw/YUU1BIaENFl' .
+            'jiWQH1iTTciPH/j9TWsfxk670LMjC/rmL0L3MPX1DRoRuh9PJeTaom8tgS67PkQkJ0vGJlzxscfv7d5GfYNm/31dv9KYcVqnSzYguvy6Ekj4mjnhilbr618e' .
+            'GBiwCz07sqBvfjYYoP/9R6vdpoJ7wlHUonXk+V75+6wbU4omSubrN//OUO9Tv79hiIi6SoG19PovNkdeNdss27auu58bZ4AIuCSssxBQk4CIsh4EcGPR+y8N' .
+            'GdUUhGwuIh9R9DMLBFLnC0YI4GcP3Lv+/zYGXSXf4hLyXXosWbDJpRRNsvgCEDkwb9vNVTlqBATQszbDBx/scYixxDIpzNYMRGCjYXV4CQkBkGUk0kl1p7Fs' .
+            'L/n4dY5lhhCSOh778uJkz9rMgpR+QE0FoxwK+WjixqVQ5pivmWd7vtYapHLNEMrB9PgpSOWA+WK+MLMhutTrZWuQnHWskA5mNC3rupRSE9Phe24Jnn0U3b1E' .
+            'fYPmbbzVqsSCl4A7sUMMDMAWrb7XUQQw2/JnRASrQ6zs+SDW3voxAAxrLxVWlyMfkYAJ/fjYj15GepLwtYUF7qcBWAxdmtpbCFjQBOTeXvkw9toDX+raXJeU' .
+            'd/iBNYg9XxICOiihsXMNUnWtcLwk2tdsBbMGXaqKLwKRQFiaRsuKTUjmWuAk0mhdvhE6KIJmHGsKNeu6lNNz4P7uD9IA7BuVec1HLGgCAsDAAKzV+HWlqCE0' .
+            'zOX4HTNDSAdtq28CKQcm9LH8pg8iXd+GMChekYRlydey/EasueXDADPAjNZVm+F4yYsErLEMIniC6K4X/mi1V/7923/X1YMFS8B+QNDgoNn/e5tWOJI+eaGg' .
+            'LVGUdiMhoP0iMo0daOhYDROUQCTAoY8lG94NN5G9xA4sg60FM6Nz/XYwMxgME/rINC1GfccqhH4BJKJlJ5CaKGibcsUHJ4pez3sH9ur+/hoBFwQ+9GCP7O+H' .
+            'YKEHsglpbCyaiAgmDJCqa8Hq7R+G0UEk7YhgdIj6JV1oX70FQWGyQqQKSIDZYs32DyOZa64cS0LC+AWsuOkDqG9bAR2UQERgAAJgBlu2uJ8BWmjpuQV1s2Xw' .
+            '7l75UsNK++Fk97psSn50sqgZKDsSBLYGrSs2wcs0gO2MY0pCwBQm0bZqC5qWdMGEfsW5EEIiLE5icfe70LxqM4wuXaSm2VqoRBrtq7eAQBVfmIhkoWRMfVpu' .
+            'PXj/hvfvxF7LC8gWXJAExNAg9/UNGt/wZwVR1tooXAxEYRcvXY+2VZth/MJspwFAZBs6iSyWbHg3AIr+I0LoF5BpXITmZd0wpfwlx5EQMKUCGpesR7qxA1br' .
+            'CnktSIQGydDYu2kAFthrsUCw4AjI/RA0AHvg/vXdKU/8XNE3psyWsvfasW4bpJOY7TBUQETQQQHpxkVoXLQGQWkazIx0fRvW7/hXcBNZwF5UiTXzt+PfLr7h' .
+            'VpigiHK9AgEy7xubScid+36veycNwO7uxaXVNPMQC46Ahxb1yKjhSN6VdGUqNFHVCxHBmBCNi9eheUnXjO13GRAR2Gp0rr8VqfpW+IVJtK+5CW6mHjoo4Qo1' .
+            'DJF9qUNk25ahbdUWGB2gTFQGW0fCSoW7H/vy4uTK9/csiGezIG6yjP7+qGGIJu0iJfHJ83ltiSrVziAAK276AJxE+opSLALBmgDp1uXoWLMVHWu3oXXlZuhi' .
+            'HkK+seCSQmJFzwegnAQ4tgYJpC4UjM0k5fspzPVsvfNQyLt7570UXFAELHuYQRj8vhtlPRiIwy6lAlqWb0Qi2wjtF68oxcogkjDFKTQuWoMVN30ARodvGKAu' .
+            'w5gQwvHQvnbrRXYmEYlQW4LFAwCAvsF5bwsuKAICwDP9Xa4gWlrhCkU5W8dLoW3VFsDaqyYSwFBushJsvlpQXKTQsnwDEtlGWDOTXbEABGHJnv5liTd1Y3MU' .
+            'C4aA3L9D7cReW0qJn25Ii5umiyYkIhllLgI0dq5FurED5vJVL1c+72UclTdGlGP2Mg1oXrYBxlRsQeEHNmzIOO2pZPbXwHGD/DzGgiEgsNfSAGyg7a5iwAox' .
+            '+bRfQq5lKVbe/DORZ/omyPdWQEJCF/NYeuN70bJsw6wMCampkpEC+NSjX1qX6Tl1yMznFs4FQUDe3StpAPbAFzZ8LJeUNxbDqGqZOZrU0r76puh7b0KNXhPE' .
+            'qrht1RZI5YGtAQlQEFqbSYolIlSfpAHYwStMYZgPmLc3VgYz6OGWEXrki+uy0sGniRAla0GwViPb1InGxWthtX9J8PjtRjntl2tdioaOlVFwGgIEINTWJFzx' .
+            'G0/es7mlfB/v6MW9Q5j3BMRgr9i5c6+RRrw7m5S3TRaNjWw/gvYL6Fi7DRDqnZd+s8DGYtG6W2BNCGIGEYl8ydpsUqwMRNDXOzTI2LVjXoZk5uVbNRsMCALs' .
+            'vnu7fpR0RbcfMhOR0KGPRetuxpINOy7yQq/XVZJwcPbFQzj+9PcglQsGsxKEUNvx7Wu629E7aBHlC+dV4eq8loB79uxQBNjH7tnQV59WawNtDQBhrYWbyKBj' .
+            '3c1XaOB9p0EAa7StvgmpXHNkCwKkrbW5lGw+8OIzdxGBsWf+ScH5TEAaHW3lPf3LEkrxXdrCtRZEQsAEPtpWbYabysGEwZsKu7xdsNZCSIWOddtgZuxR0pZt' .
+            '0pG//OgDK1sHR1t5vjWyz6ubmY3dvRB9fYMm6WTfl03I7VNFbUkIacIAXiqH1pWbYQL/0pq+6wQiAR2W0LRkPdIN7dBhCYKEKPrWphJyrQjdj/f1DZr51she' .
+            'Hav/NqClawc909/lkuT/ZgwbEdtORISOdTfDTWTAtsoyXcyQysGiG7ZDSjdqCyASUyVtJcnP7+lflphv6bl5SUDu36HeO7BXT6fETzek5MbpkrFCSGmCEhoW' .
+            'rcGiDe+GDkvX2fG4FOXAeMvqm9C2enOUkxZCBCGb+oxsTnnZXyOA51N2ZN4RsDxi7bEvb0/C2IFCyA4RJDODhMKitdtg/ULVka8MIoIpTqNt1Ra4ySys0QCR' .
+            'mipaJSU+deiLWxb1/MohPV9Gu82Lm7gclmVCAtAdagaRJKN9NC5ei3RTJ9hqVG0EighsLRKZJrQs2wCrQwghKNDMrkNLjNWJXbuq9eLfPOYdAQ892KOIwC+P' .
+            'Fj9Xl5KwYM3MBMQpN7r6lBszg9lWfqJ5u2/0Ey1p1B1n42KFNx+6Y6PRumpLFBM0FoJgCWBt7RcG5tFswXnzJgHxjL/uYVpz8oftAol9xtrO0BC0XxRrtn8I' .
+            'Lcs3QfvFK3i+XOEJAwAzlJsAhKx8Fpamo7Kr11k1ZoZULqQXl2mBYEO/rEpnj0x9/XthhnRcTI6cwPDev4VQLivJNqnk5LTWP/Ht/PDhXcO9RINze5zH/Oq+' .
+            'Gh6mvoFBs++e9b/YlBNLzk9bbU2oMo0daOhcCxMGl20yAlsI5cwUhgoBCIXzr76AoDAJISWs0XhleN/rqu+o5D5AtnkxWpZvgjUB2GjUta9Eoq4F0GGlfMsa' .
+            'HRcfXD62TESwcZ64vn0FJs4cIw2HVYIabAm/PjCAX9o1D/pG5o0ELMulff1dDU4SLwpJdcYI0kGJVm27A62re6CL+Yr0K6th6bgg5aF0YQRsLUpT5/Dqc/ug' .
+            '3CQmR08gLM00kkvHw+svGYNAsNbA6gAgAWs1Mo2L4CYzUG4SS7pvhzUaiUwDZCID6xdgo8zHZSZoWUg3iYnTL+L5R/4XpHIBWCuIhA7Eyu2fP3ysHxADUR3r' .
+            'nMS8IeDBB3ucnlOHzOOJ7t9tyKjPn5s2xoYlJ5ltwqYPfhIcq8Ay8ZTjAiQx/vIwCpNjGD85jOLUeQghYI0BwJCOF0mo+JirLj6N7cGo0YRgdRCrYAEhFawO' .
+            '0LRkPVJ1LWhacgOSuRaw1TChf4lEZDZQbgpDD/9PTJw5BieR1vUJonPT+ivfCYZ/4UOLeuRcnrY/LwjIDMIu0I8SG+sCwS8y0GCMhVQOrb7lw6hrWVLp2ZCO' .
+            'BwZjcuQEXn12P6bGTiIMSnC8VCTpeEYQcVSZMuvv8FU4MAQhZi8rx3Ixnosan9OEAYwJ4SVzaFnejZZVW5Cqa4UNirBxgDwiMYOkQmFyFEce+waC4jRLJUzS' .
+            'FUXft7ccXdn1Qi+AuTrabV54Ug/v2iFpAHbamN9MeaLRMqzVATUv6UJ951ro0IfykhDKxcTZl/DcI4MYfvirmBw9ARISXipXediR2JohWRjq+CcEW4ZSElK+' .
+            '3o+ArhyjobWdabysSNLIwXCTWRgT4NXnDmDoe3+NYwe/g9DPQ7leNIfQ2liChsi0LEX7mptgdUCWBQmirG/4s319g2Yuj3ab8xIw2o28H09k/67TZdpHhPZi' .
+            'yASG2HzHf4CXqgMgcP70UZw5chATI8cAa6HcZNQSGZOCYvVsrY17jCKyNTbVAwCMscjmUmhuaYQx9gpOLIHZ4tQrI7DWQAgBPwgxMX4BJER8DEFKir9b/tsC' .
+            'bA2MDqDcBNpWbo5Gu9W3wQYlWKujCTJg/Oi7f4mglGdXSSslfF+bm2/5zLND5Yb7t3/Fry3mAQF3qF3Ya38q0f2Zpoy6ZzxvQl2cdpZtfh8Wb3wPJl49glPP' .
+            'HcDkyAlw2a6LiVLpRLMWOtTwEh6kFGhubUQ2mwYA5OqzceglChBH5LvSskVhFykrbZYIQ42pyWlIpXDm1REUiz5834c1FspR8bkYzBS/BBbaL8BN59C0ZD06' .
+            '1mxDItMQtYm6Hkafexwv7Ps6nGQ2rE8JZyJv/lw2er8KAHPRFpzTBGREU35O/vftiVf9yTElRUJrTYl0HXWsvRkTZ4/h3MvPAkJG3i5m7DprLayN1GI2m0Zd' .
+            'fRaZXAp1dbmYnALMDGMuNq2uJoU3204kIkgZxRJt/PvRs+cQ+AFGzo5Xzq+UjI+NwkBWa1ijIR0P7WtughAKbC2cRApjLw9j+txpkHKsIyCEkSu+UXr6ZSCa' .
+            'd3gt1vadwpwm4MEHe5ytdx4K932h656mnLr7QtHCaAMnkYbRAcLSNBwvjRnjHwAIQRAimUrA8xw0NjWgqbkOjuPAGFtRrxwHka9FyphnqXkgIhsD8IsBTp86' .
+            'i2LRx/RUoaL2Z/9tZoYOigCiwUluIgMnkYZfmNRE0mSSJCfz9qu3/dfhf7cnLsJ461f8zmHOEjAqzBzA/vTaDSnh/m9rkSiGtqCkWGyNqczlK4dOotkvBsyM' .
+            'js42NLc0IJVKxjZfZPu9UwUKZUIKKSAosgcnJqZw9tQIzp27ANd1KjZpdO2xr0jR6DiwQUPWg7EMSYCxwLl8+P5/Cp7dM9eyI3PaC6YBWPgqZyz92rkLfHND' .
+            '0vl/CGxJCEZsT5URhiFSqSRWrFyMpcsXwfNchGFYIeA7WR1TzhuzZWhtoLVGQ0MOq9YuxaLOtortWL6mSj7aGggiMER4fko/OFnQf31uKvwLJegrwNxTv8Ac' .
+            'loBA3O/bN2j+6DdWe+9akniqPiXXj03pyk5FZVtPCIFlKzpRV5+F4zgIw6uf4/JOofwSKEehmC/h7NkxnDk1Ase5eFsIBmzKJRtovnvr7ww9cB0v+ZpgzkrA' .
+            'MvkeuntN547lyR8mHVo/OqmD2TsVGR2p4tVrl6GltSmWLNVHPmDGPgyDEG7CwfIVnejobEMY6oskNAGiGLBoyjpfOnBf9/8JAMf+YkeC52h9YPU9iatAmXx7' .
+            '+tc2N2TdvY6krqmi0YJIRdmvyNFYtLgVHYvaoJR4g/BJdaFMOCJCqeTjpSMnUSgUoNRM/3K8AbZzPq//4JbPDP1m7JBpzLG2zTn31vT3Q1DfoPlmf1d7Lu0+' .
+            '6kjRNVU0mmaRLwxCLOpsw7LlnZBSwJh31sZ7q5gdn0ylEli7fgWSyQS0joLb8Xecc1Ohbkyruw59ccMDW+88FO7ePfdGeMydp4Io63FoUY+0U6V2D/RtJWnD' .
+            'hYIxUkQDxpkjo76zsxVLV3RChzNzmOcqmDlO7xk89+xRFKaLUE6lio4BhI0Z5Y5Ohn98693Dn3p41w45l0Ixc+yN2SG23nko1CX++VxKbZgsWF/NIl8qnUTX' .
+            'htXoXNoBrc2cJx9QDh9ZSCVxQ9cqLF+1JJaQUVCTAed8XpuUK/7zw7u62t47sFfPJXtwzjwh3t0rdw0N8k+5Xf8i6Ymv+prBHBXURjZfgK6Na9HQkIPvX3m+' .
+            '81xF2S50PQ9HnjuKkbPn4HluFEYC26QjDIDnoemnwgb3bM+pnzU0MFD1YZk58aaUyfcBd+3abEoNhobJ2qgauOxwdC5uQyaTmpfkA2bswsD30bmkHelMquLR' .
+            'E0gUAxYJV2woGP21rXceCh/Gw3Pi2c6FJ1UplDp4f/dXXEf864Jv4u1RCToM0dHZhmUrFkVqd54jsgklwlDj+eGjKBb9cvqOiVgnXWmmS/YXbr176G/nQmqu' .
+            '2glIu3f3iszpp1RLyfur+pTqOzcdaoBUObXW3t6MpSs6L8oczHfMdkyef+4llIo+hCBYCxYClHQFJkvmE++6e/iru3sh+wZRtW9mVYvp/n5QX9+gaS56PdmE' .
+            '7BuPyQegkuFo72yFiXO/CwVR85OFl3DR2t6MMIwapYhAxrBhgD1Bv/vIF9dlW7p20Ov38V1fVDUBd2KHYIDY4n5t2WDWlFAhBNasWw6l1GU3kZ7vIBHZvi0t' .
+            'jehc0g4dv4RCkCyUbJhLqbUu1EdHh/cy+qt3rFvVErA81f7g/RveX5+WWwslY1GebKo1lq7oRH1DbsFJv9mIct0Gy1csRn19BlqXq4CgpktWGMMDfYMwu7DX' .
+            'VusKVS0By1PtQ2PvDg2SFiREbPdlsmnU1+cWlN13JTBHa9LW3jJTx8gQobEml5QrHrtn/ScHBmC/V6U7cFYlAXf3QtIA7L7f696ZScided9YQhR2sZbR0toI' .
+            'x7m+c52rBUSRPVxXn0U2l6loBGaGZdiEK3/98H0bG3Z2t3I1DjqvSgKufH+PeOzLi5NS4W5HwjLYloPNizrb0N7RUrVVLdcLxlisWbcCiYQHYyyEEHK6ZGwm' .
+            'ITcX2NxBfYMGVbjdQ9VdEO/ulT2nDhlRym7NJOX7LxSMFSSUtYxkMoHm1oYFEe97syiHZtramyv/FkSi4BtrGfcCwK6+6mvfrDoCom/Q0gCsBe4PjSWK69Gt' .
+            'tfA8F6l0ck6VVr1TKHfU1TVkZ+9bJ/zQmqas6jxwX/cvDQC22oZbVhUBd8fbk+67r/vnsknVE4Rc2TOVmdHUXA9r7GsmD9RQhrUMx3FQ15CdsQVBshiwIwTd' .
+            'deBLXe3VtvVXVRGwa2hIEsAE3Jj2pGcsDACy1iKbS6OxqeHH3BxwYaCcpmttb4aUUXcdAaIQWE661KXYEzQAW00DLquGgP39EN27hsP9929crAR+/ty0ZgBO' .
+            'Oe5XV5+F4zoLMuh8tSinJ+vqs1DOzFoJYjaWrbHBLmZQd3dvjYCXAxHYasGeI1aEhkEEspbheR4y2fSCDjq/GbBlNDTmMGviJitJQltsJAK3DI1UzSJWFQEB' .
+            'QAreGBq2sydUCSlRV5etTI2q4cqI1DBVskSxvUyhZk445O27Z0Pb6HDrG8x5fedQNQTciR2CGQQyX3AVCXAU+wMYLa0NcW9sTf2+ESKTxSKZ8FBXnyv3kYii' .
+            'b3V9Wm0hYT/SNzhoqiU/XDUEBCrzf87P1rJlB6Smeq8ezAwv4SGZdGFMeboCoA0zg8av8+VdhKrID/LuXom+QXPg/u4PZj25reAbDSJZnpUCzA5t1XA1iPae' .
+            'kzMhKyKZ9y0R8F+P/cWOb+EX9/rxLM7rurLVIQGHRqKFYCxJOKIu1MyCiLQ2aGyqRy6XnTcOSDRl9e39G+WJEIs62+A4Kpp7A5A2DIA35fOj6noTr4yqkIAV' .
+            'MBdDy1xtPGNEniUAgAAp6MciETPguhJsGcZypeOtfK6oGf2aXXZ5Y/gKiABYyk/62arJZVYVAa1ACq/xzt5pz3c2sSqT9CXBSccZLMMoFEMo+eaUBzNDeQpP' .
+            'D42huTGB5sYkwlAjm3YAFZ1L+wZaW8QbU6OyFPTju6zWXLx+RCyAySSA4o95ymuK605ABogG9uofPrAp7Yfm/umiAYgUM0MIgUw2/bZ6v7asEhlQiuAoAWZA' .
+            'CER7rUuB4mSIp54ZQTKpcOpMHklP4j3vXoziVAD5RmlBiq7dWkC6AqPjJfzN14+gqcFDsWRw+7Z2tDYnUShq3LCqHo3NqWjemo1Sa0SAsYwwnCHm1aQiZ6/f' .
+            '5IUpEBFpa3VdUqWnCuZ+AL9y6MEehes8VfW6E/BicJLL8+SZ4TgSza2N12R2HzNXjB6aNfwx4alIAgmgeCHA6HgBXlLh2IkLOPDUCBwPGL9QwPGTU1COQKGg' .
+            'cceOpTDkQ3mv3/xOBJhAgC1BKYHxkQKeGh6Dowj5ggYR8NAjr8BaRqgZSxal0dSQQD6vceP6JnStb4Rf0MhmHGQbEpF4Ngy/ZCqtguW7Ilw8vZWZ4boKza2N' .
+            'mDh/YSY1Fxnbybe0mNcQVUVAfs2GK8yA0bbiCb9ZlFNRDCDpyUiiMWANw1gL11N45tlxvHxqGqm0gyNHJ/D8SxeQ8CSsZRSDACvqO3Fjwzps6PIhIAACwjGL' .
+            '0SfrkEk78dyZmeut9JASwxqgfuU0KGkAKUHTAS5M+fA8iVLJwEYlUxCKkM0oTFwIMDZegmXGK2em8Y/fP4kgMFjckcGmriYUiyGaG5PYdmMrdGhBEvH43wil' .
+            'ko6nVM9ch7l86VrVRPSrioCXw5sVfNEAx+g4N6kqJzlx/AJKvobnSTy8/xTOjhbhuRJj50qYLoQQBLiORCqp4lG5AhnlIm+nsbppEdbUL8V0WKiQpnBKY8ry' .
+            'JdcXK1wI7aFh7SROjp1EqcAQkmAt48PvX45s2kFnRwbf+M5LKAUGUgi8eOICgsBCCMBzZdxmyUgmFUbGC/jmQ1OwluG5Eo8ePIMwNMhmXPzk7YujaxKEVSvq' .
+            '45eMERR1fOtV5tG9BlVPwDcDBuAHkXoKNeOfv3sc2lgIIvxweBwlX0MIghQEiqWhlIT6nBtJRp5xPCJ1JXChNIX/OfRtdDWvxLb2bmTdNEKrIR26bAyLALhS' .
+            'YXR6HA8ffgLPvHwahXxUQlbmQl3OxZbuZvR9aDWSWQ/QBj96dhyFYvSCPPLEaYyMFZFKKkznQ4Q6uodEUsFRhJGxIkDAuQkfD35lOLZZCVu6m6EkwTLwk7d3' .
+            'or6++tsW5gUBmQHHERgdL+JP/uoZuPGg78npoBLaSCUVkqSizAABxjCsZQghK9kCIJKcZSkKAAnXgzYGh84+ix+Nvoh3L96C2zpvxHRQjOc7z7oOMJIqgYeO' .
+            'H8ChkWcRhhZJ10FdVoGBeCo/UChofO/RV/HI42fwwfcswY53dWLjukZARir+hpX1CEIL15N48vAojp2cRCrt4MTJKRx/ZQqeIwCKXiQlo52ZHEfgyWdGAQCF' .
+            'ksa7etrQ0FTd0g+YJwQEIhJKGXmxJT/qlsukHRRLBsZYTEwGaG5IIJNxUChobFrfhBu3tOFb3z6K4yen4LoSBEAbi+lSWAnHMIB0UiGpEjDW4qGXD0CQwPaO' .
+            'jcjrImZtwIq0k8R3T+zHvlNPI+Uk4SUVgtBgejJSh4mEghQRYdKpyH78+4eOQwjCu29dhGI+ckiFICQ8CTBwW08bbrulA5ACE6MFnB4pIJlSOHZiEvufOotk' .
+            'QqFY0hgZK8JxBEolg/fduhgtrSnooPorx+cFAYmAMDRobktj++Y2fPN7J1Cf81Aoatx8YyuaG5PIF0Ns7mpCZ0cGgW/gJhS+9dBxPH90AnVZFzqO77U2J/ET' .
+            '7+qEkgKCogbwRw+eweRUACkFEuThH45+H6HVuHXRJpR0AALgSAffPPoIHn35MFpzORhrMZUP0NqcxPtvXwwwcGhoFOfO+5GatAwhgHTKwTf+6RhAjHdv74QJ' .
+            'DKSaUe5sGcWpAMyRFL9hdT0IhGWLMrh9WzscJTF+voTHnx5BKqlw6mwBuawDN6EQFqsm3nxFVBUBiejHXjEiwGpGXc7Ff/z5brS3JOH7Fm3NSQg32oRQ+wbF' .
+            'QhiN7A0Mxs+XsG5lPV4+NQ0hCJ/4yBrctLkVIuXgzLEJaMvwnMhj/e4jr0BIhiMUbmhcjvZ0MyxHe4oQCMYaFDmPDatbcPT4FLS2+NgdK3DTphZk0i6QVDh+' .
+            'agpj50qQUsJyZAIQGKmkwj/uPYnHDp3FisVZbLupDaEf2bIXORexV29CA2MiZyjUBvV1Ln7qfcsAAmxgMDEZwM8HcNQVHu9bWOdrjaohoJrW5Cco91qb+WqN' .
+            'aCKCLmls3dQCQvSsKAOE2sKTkRpSroBKSJTyIUra4N98ZA1ICnzt20fx9HPjODNawDe+/RJKvsFTQ2OV5ifPlUi4Cpo10l4Cv7DxQwiMRin0IxVHgPEF/lXP' .
+            'u5DqOY6Dh87BcwU2djXBhBb5qQBJYzGdDzGdD2FMtHFOKunEBI4azC9MBnhyaAxPHI5sOQZDCYHNsXMBAkq+wbYbW7FscRa+r0EApBJIKgFYQCiBxtYUgnwA' .
+            '8MXrx4h4DObcW35g1whVQUBm0JE/DsJ83vue69BPFENmIQQFQYhTr5zFilVLr6oPmBHbgo6AiFfblDSeeHokiotZwHEFHnniNEbHStGmgQSoeI709x47BRKA' .
+            'EoRMygHA8EMLMOCHGtYCJ4tj+MsffgcfXfceSBnnhC3BqS+BVp2EX2Bs3dIKMKNU0iAQVJz6717bgOaGBFxHItQWPxwag7YWFG9gKOLB5OlkFIYpOy4HD49U' .
+            '4nuWgeePTkQ2KwOBtmhtTuD2bR0Ig0giWwa61zQA0Dj1ytlKEFqCqBRaTaDvAcDUqcx1d5GrwkLl/h2KBvbqA/dt+FhjRn5tfCoMhRBOGGq0tDZg1Zrlb0hA' .
+            'axmJjIOnnx7F3gOnkU5F75YfGLx4/AJA5QwL4HniolxuOfUmBMEYRrGkYW0UC2xvSUVZGSXwgfcsgaMkfOuj/tUNEIUM4GrYgoPsxtNILD0P9hVs3Dg1O2XG' .
+            'DHgJGXm68Zty9NhEZAsS4buPvIKp6QCOI3F2tIBSrII9T8FzRSXIHRUwcGWfOyKCsRa+byu1VcYw7v5PW9DU4OHJQ8+Bo0oiVoIoMDx9691DWQDlrZGvKwmr' .
+            'QgJWQDZnrLxoQYQQV+XJSUnI50Psf2oEL708Cc+Lqk5IEHLZKM5HorxtNBAEppJfFRTtcOn7Gk2NCfzEuzrh+waZtIPbbmqvVJWUd8GEAHTnCAqHE9DnU0h1' .
+            'jcJdMgldkoDgS8IzQPSki4V4VmSsdlctq6t8vnxJFmwB5Qg88fQIxs4VkUw6ODw8jpOnp+G5EtpY2DhkpJSoEFNJCc+J6yYRSXoRxzrL91v+TBDs/v7Vue0D' .
+            'L05e/YN5+1BVBGSGl3CIZpcnBUH4hkOIojigxMiZaQwfPY+mBi9O5EflTmEY2XJBScMYhjYW7S0ptLemUChorFqWw7YtbfBLGqmEQn1zMo5KA35Rx/NXGH4Q' .
+            '2e4EgRA+jpeOQ080IFl4BS0ThLpscqZs6zJIJlVU7cIzL4GxXHlRgCgMtG1zKyAJIELPhmZMTYfwUgrDz57D08+OI51WGD9fwslT05G3LiI7leOMSMk3sBbw' .
+            'i/5F1USxFM2lW9yqScVVhwpm0GBfr1i0aXh5OiG+CeK1fmghSIgwDLGuaxXq67OV8WNXgiXga996CfufOgvPjfK5mbQTxcd8g22bWrBsSQ6FfIgVS7LoWJwF' .
+            'YkIYE9lilhlBaFA2ukScMfE8CVIiImZC4cQLE3jgz55EXZ3CuTGNj/zkCtzxgaUoTYWXVKtEUorwxOERdK1uiMIsHFXiVMqx4r/H2qIYp9EYgKMElBIVchER' .
+            'oATOjRXw3NEJpJIKI2NFPPLEGSQ8ianpEGtW5PBv/mUXjj93DGMj5+G6Dqy1JpNQMh+Y/6tQbP7UzuFWroZNDatCAhKB9/SP0O2fHzr62L3do3UpcYMfwCC2' .
+            'eWYn3K8EYxjJeg+tTUmsX92AjrZIur17WwdampMIAoNMyolCMpYRBgb5CR9EcQDbiSUIAUlPgWS5wgCAI3D8pQmcGS1CKYKSAiNjReRSHjyhkE4RHOfK1hQz' .
+            'QzoSTw6N4R/++QRSXpQZCUIblWM1JaGNhdaM9pYklq+sB2LzICqeiARWVFzBCEsamaSD27a2R7/XjFtvaoPjSIyOFzE55cPzFISQlReWGTbpCpkP7PejrRyq' .
+            'Y1xbVVxEGf39EAI0WtYa5Xzs6VMjSK9Z9rrST0pCmA+xYV0DdmzvgJNUgAV0EG3RmkoohNrCBgbJhISTUHASAAQhLIQ4O1qIvGIQQm3xT98/iVDbqP5OCbx6' .
+            'ahrnJkqQUlQGASUTEibe+NrG9Xs2qpG6rB3oOhJBYCHJxjFEqpRjlbvZGuo8dC7KwGpbkYCR8yMAMIxhNDcm4KScSHoTQUhEmRMAi1pTWNKRwYWzFzA5MVnZ' .
+            'f1hKUKBtKXJfQOhuve4eMFBFBHwYe+3AAOyH7rd3+Vp8FJVNcoFSwb+qc1hj0d6ajv4/iMijJKFckSQFwfMknnh6BOPnS1BCQDoCr5yexuFnxyt2VNmTLHPI' .
+            'GobrCtTXeShXuZdDJOWyJ0cRRFIhqRkkCYFv4mzHDBGNsXEBbJQTLscZlYrjlEpBG4sjRycqxhEzcOT4hUq9nx8YbFrfhMUdGegwsiGbGhLYdmMrwjA6vwBg' .
+            'rIHvB3CcSP2mE1JN5M33b/3c8N/t6d+h3ts3WBXT86uGgGUIcr2Ea8VEwbCMPU/f9zE6Mo72jtYrhmOYo4DsyFixIqmkJExNB1EWg6gSbhkZL8alT1QJsUTS' .
+            'jCvFCOCZyppUXNY1u2hhNpQkjE/4OP7iBMKihmVg5dIcEkmJUjGqwAkDg4//9KrI8wbguBLHX76A/U+NIOHJiJCW8eLxC7Czpge5jox7UDgqdkhIDL9wDk8P' .
+            'j8XNR9HL8cgTp2EtKnHA2za4cF0FY2cXrKLxmj+wt4iqIeDAAHj37l5ZOHb4jPGdr2UT4mOFkjEgktZaBEH4ulkRZoZKKDz5o1H8/UMnkMvOzEZRcZVJGY4S' .
+            's/plI5XruhIJLypI8AODVcty6NncChtafGfvSeQL4UzgeRaimj2Jg4dHsP/JM6A4lrh6eR1u39aOjd3NKOUjx6Q+515UadO0sQU9N7YivhCwiYPTJlLjjifx' .
+            '5NMjOPbKFBKx3ai1jcqzYslaLsAYPVeqXJOxjFIR8DKVjQ0pMGwF0ZcBYHR4b1WoX6CKCAiAu4aG5IaB56f237vhcDItPpYvWQNmqZTCyNlxtLY1xR7dlaz9' .
+            'qOvMc6NAsxWRJCkHbhGHU2RC4eYbWyN1KoAgsLGzkoDWFtZGNpVb7+EbXz8SB4jFFTvhyuVgrisr0d1jL0/i2MlJfMIyNm9qQXEqjIj3mpPMfqmIgC2bWmc+' .
+            'JKBrVX0U/qHoxRkdK+EHT5yG6wpwLPGefnYcQVAZw3FxPzCi8mdBJFiahwBgqKs6WjKBKgnDlMFxQ8iBBzYtd9g+DXBaaxCJqEe4ta0Ry1cuvmw4xlpGIuvi' .
+            '2/94DPufGqnEAku+waYbmtB1QyO0b8CIKo6XLa+bIQMB1rcw1laKO5US+JuvvYCDPxpFXcaNnIsYZQeDwRdlKGb3/EpBMHHs8BMfXYPNG1tQmg6j4PDrrPpr' .
+            'Xy4Rl29FsUOGFALCEzMed1zt7ccEZKPx/X3HsbzDQX1GIDRWN2QcNVnQg66Uv3h+a4P/3vfuNaj1BV8KIjD394vtvz1wbN89XX/ekFWfmpjWhhDtiFkq+rjS' .
+            'O0NEMIHFqmU5bL+pDY31kTQDIjKQpEqsDZZRnA4qZ4oyBAQGw1USloCvfOMInhwaRX3WhYnTZSQighR9HaXWXAlHCRT9KMAtJVXsORs3AHmuxFe/cQRgYPOm' .
+            'FoRxmu9KHv3lOt5mkzLUFjY0F137ss5MVGVAhLDo48JqB5YJxjI7gigIbYkt/cHmzxzOx0NAq4J8QJVJQABg7heDg8O0/OgPl6W8xH4/tI2hhRBEZIzBmhtW' .
+            'oqEhe9nsSEQKAW34kmYhnrXmZY/y4mMZXsbFD58awbf3nMBUIYTryErONQijjIrnSaxaloOQAq+ensboeBFrltchnXUxPRXg2MkpSEFwXQEpIkeo3Hze2ZHB' .
+            'v/3oGmRzLvzStdtigjnqn3Y9F0efP46xsYlyXNOkPSEni+Zbt31u+Ge5H4IGqqchCahCAgJAvP18uO/e7j+pT8tfvVDQlkDKGINcXRar1145JhjZVG9uwgAz' .
+            'IBTh8NA4Br99FEBkA2odOyoC2LqxBUs6s1CCsKmrCVACJ45N4OTpPLZ0NyPdkMD0uRJ+9Nw4kimFRx6P+jrCkOG5ApYZxZJBS1MC//bn1qGlMQGjL21q+nFQ' .
+            '7gGemirg6AvHKt4wwDqbULYQBLe+dPC5p3t7e0F91z/7MRtVScDYrMLB3+9pMmHxDIFEbEiT7wdY1NmK5SuXXJOtGso2X0kbPPhXQzgzWkRd1sF0QYMt4+c/' .
+            'thZrVtfDFQSZUICxKMWpMs+TIEciLIYwmiEVwUlEVk0xH4IAfOOfjmPfoTOoy7kIQ0Yu6+BdN3fgXT3t0OG1nXdz+KnnoLWGEAIM1nUpJSYL+u9lY7IPALZe' .
+            '5yb0y6EqCQgAvLtXUt+g2XdP1wPNOefTY1OhlkSKERFm/YY18DznmkzMZwaUQygWDP7s/3sWLxybwI5bFuHdty7CouYktI5muZQ91rKdVnY6ZledlIsRhIhS' .
+            'dlpbHH1lCv/rW0fhOgL/6d9vQDrnws9fm31OogZ+B6dfPYuXT5yuZD5AsK4k4WvevP2zQ09Xo/oFqpmA/f1iF4Cfzn59dYr4B6GxTYFhigoUNNoXtWD5is5r' .
+            'tmeItYxEQuHc+RIOHh7F+27vhJRRg9Pl0mpXdQ+x2ellXRw/OoFkQqK1JYVSUcdpv7eGyt7BWuP5oRdRKoWQUsBaa+pSSk7k9ddv/dzwv+D+flGtu6dXx3i2' .
+            'y4AGBuxOPCxu+fThF6ZK5u8cJWSUxWI4jsKZUyM4cfxUJfzxViEEwfc1clkXH3jfMmjNb4l8QDk8A5QmfSztzKC5MYHAvzbki84f7R71/PBLKBajpinLzFKQ' .
+            'ATApJf1+fz8EuoerVtBULQGBKD/M/RCZtPhv2gBKziahg9OvjqBULM2onbeIcrVxcTqYScldAwhBCMOo2uVa2XzWWriui7NnxpGfzlf2zmNmU59R7vm83n/z' .
+            'Z4YeW3S6R1ab4zEbVftmlLF7d69sGRqhtDf2c8mE+JtiYJiZFBFRpDZdrF2/Eo4jF8wOSswMx3UwNnIOx196ZXYQ3CY8AW3sEU/gJ8emmk/v3LXXzMr+VR2q' .
+            'WgICQF/foNmJnfbmu4f+dqpofr0x4ziWEUahB6BQKOL54ZegtYmbb673Fb+9KJsgYyPncfTIiSjGGZGPXQVrDRcgwts3fnro5MPYa6uZfMAcIGAZBx/scVKu' .
+            '+nq+ZIbqUsK1zJY5KmEqFkt4bvhonKK7+lbOuYZoaJLC+PgEjh45ASllJY4oCDaXUqoUmj/d+ukXxnh3rxyoQq/3tZgTBKSBAdtz6pDZ/NuHR85NBTsLvn0m' .
+            '4Yg44xXNEcxPF3FufAKu58Yq6Xpf9bUFM0OqqML57Omob3jG3GCdcAkTefOl2z737G8dfLDHQd9g1ZMPmAM24Gzwgz0O3XkofPSe9R9d3Jj4+tmJoMSAh/g+' .
+            'iKINWjqXtMH1XJg36CGZKyir3fHxCZw9PYr8dDEKNkeq1yRcIUuByW+/ezhTLui43u2WV4s593T29O9QLRgV+YS4pzErPz0+GWoiUsBMF10mk8Ta9avgOBJa' .
+            'z+3dNdkyHM/B+Mg5vHjkZQCoeP2W2bpKkCupkA/Mh1Vj8gc9D6201dBsdLWYEyp4Nt47sFd3Y1jf8tlnfvvctP6DxqyjmDkEEI+ldVAolCqOiec5c9ImrASx' .
+            'Ey7GRs7hxSMnIKW4iHyOEkIIhOen+We2f3b4e/9w6pCZS+QD5qAELKOcqnv8/u7/3phRd41P6YABJyrNi3bYTKWSaG1vRks8Z7pcu1ftiKYySARBiLNnRjF6' .
+            '9lxlCgIQdbg5ioQjUZgsmTtu/9yzPygXcFznS3/TmHMSsILeQbu7v8u9+TNDv3lh2jzQmJEuopn0tuwtlko+jh45gZMvn4bjqGuWgXi74XoOtNZ44bljePXk' .
+            'CADMIh8bzyHhShQmS+HP3v65Z3/A/TvUXCQfMIclYBllSbj/3q4/zCTUf/S19QJtrSCKExnxHrp1WbR1NKOuPhvX5127rMS1QLmkipkxcmYco6Pn4Jd8KCXL' .
+            'BakWAHuOkMx8rlSyH7n188OPzFXJV0b1PIEfEwzQ4G6Ivj6Yl/5ky7Lx6eAfs0m5bqJgLOIxLWWVTCSQq0tj9doVkPGQyDh9dV3IWCYdEMUzJ85fwNEjL1fK' .
+            'zMpTrRiwkiDqMwrnJ/WXnzp+7nfv/NPThWqtcHkzmPMELGP37l7Z1zdoHu3f1JrK2r83hm8GiI21FiBV3vrVGAsv4aKtvRl1dTk4roJUEjqusH67yTj7/I6j' .
+            'UCz6MMbgzKlRTJyfhDEmngTB5SyH9hyhHEWjhZL965s/O/RbALC7F7JvEHPK4bgc5g0BgaipqZx6euL+ro8nXDkIAHnfBmA40fi9SCWX28tzdTm0dzQiV58D' .
+            '20giGWMqnvO1qtkDEGcuIpIbYzA2ch4jZ8dQKgVx5YyY1UbABgRqyihRDOwzBv4dW37ryKvxzqJ2rsT53gjzioBA3Fm3a4ekgb36sXu6PtGQUr9JAj153yI0' .
+            '0a7XQghZlkQ61JBKwnEU6hvrUN+QQzLhwUt6sMbC2jJZUVHXb4Qo7hhLU0GQ8Yi5qak8dGhw+tQIAj9EsRg10Jcn+ce9KxpMKpeSyJcshODvjuXlz39w4PDI' .
+            'nv4d6r0De6tiosG1wrwjYBm7d0P29UUq6uD9Xf9eW+xKJ+RyMDDtG00gWZaIzFwZY2aMQV19DomEByklOjpbUVaHURxO4fWEDwMI4yZ6KQSKJR9nTo/CUQrn' .
+            'xi8g8IPItgMqc2biaW1MzJxLKamNDQ3T1wsh/sdtn/3RQ8DF0n0+Yd4SEAC4HwIDYAL45S9vT57RU7+YcsQvuI7YNl00CLU1TEQ0KxxVVtHR/nQCjqNAFM1x' .
+            'yWbTaG5tnKXCL0Y0R9Di1CsjsBxtLmMtIwwjoaXUjAquXCOzFoJU0hUwluFI8RWGfmDDXcM/BKLMz86BvWa+qNzXYl4TMAbt6d8hy6pr912Lk5uXN//MhWJ4' .
+            'X9ITq7VhFH1mEqi4w2LWYKSyZCxvAm1NueXsSnygeJJq9J1IvV6kwmPHgQSDuSGtRDG0QRDyP1vie2/9zPAjQNm77xV9VVxMei2wEAhYQTlmWP73vnvX/2dX' .
+            'iV9JOLI7NAxHUrRfSGBCIiBuiJ+9RnQ1Tkks4XjWvy0ACyKZSQhBIPjaQgmCo+gv8yX+862/86MfAJHEK08Ku1b3Xc1YUAQE4mmsg72id2iQaQB2T/+N9Svb' .
+            'bOPZC/YzCZfWFQLb2JpzN4TGouBbaFM2vhjWsi4PV7ic/COUx+CSkCKSopYZKVcg4QrkSxalwOzJpZScKNr/0ZTy9q39L4eOApG5MDgMmg+hlTeDBUfA2bic' .
+            'V3nwwZ5U2td9U/lAW4jf8hys8QO2IMi6lEpFYyKvDEGEvG/ghzZPRCblkiyE/P96Dh7XAU1t/ewzX5/9/YVKvDIWNAGBctgGNDgMaunaQbMJuad/h+pqGU2c' .
+            'LiouCO0JH19UUrjGXF47MsjWpYSYKtgDriP/sjRdkLesShn6d4fzs88JADux1wLAXM9k1HCNwQzi/h1qzzWcodzfD3GtzzlfsOAl4BuAZqvbQw/2XBWBehpW' .
+            '2tkl8fM1hFJDDTXUUMNbwf8PjgkaSEyFNIAAAAAASUVORK5CYII=',
+        'image_width' => 160,
+        'image_height' => 160,
+    ],
+    'katumia-love' => [
+        'emoji' => '😻',
+        'label' => 'Katumia Love',
+        'image' => 'data:image/png;base64,' .
+            'iVBORw0KGgoAAAANSUhEUgAAAKAAAACgCAYAAACLz2ctAAA3HklEQVR4nO29eZwdV3nn/X3Oqaq79L29qRdJLVm7ZHXL8tLyikEiECAJEJygfjMZMoEhiQOB' .
+            'BCfOBMyQVk/wwpZtmPfzOiFvFjIkqJM4G4QJBFtgW5ax8ILVXmVZXrR0q6VWL3epqnPO/FH3XrUsyZZs2brd6p8/99NW9626Vef+6jnP/sAc5jCHOcxhDnOY' .
+            'wxzmMIc5zGEOc5jDHOYwhznMYQ5zmMMc5jCHOcxhDnOYwxzmMIc5zGEOc5jDHOYwhznMYQ5zmMMc5jAL0d+Pcv2oN/rYOcxhDnM4d3D9/Qrgvt9bv2zn59Zt' .
+            '2LoZXf3d6Rzr+lEP3Lzuwp03r1s//XxzOIa5BXk59AwJgPjxdbF1d/UNYmAAOa2DB5ABbIT9RqTsR6afbw5zOC04kDv7l6Tvu7X7xSf++GJ3z2fX/leAO/s3' .
+            'ei93XPXv93y2551Df3hR8b5buuOhWy6fB4jjNPl7nmBOAp4CD9ze6+Mgm8l/tDnrdZQjE2dS+uOP3HpRy6aeDufcKYkk+YWTsufPN6Z9LTcYQzqf0RylMAC4' .
+            'nbf3vix5zzfMEfAkcA7p3bfT3PP5NTkFnyiE1psqO5tL60sKzrxL+gYNg5tPunZbN6M2XL8z2vvcoYtyGfXOiZIxpdCST6u++29dtfyZluXWuTldsIq5hTgJ' .
+            'Bgc3KxnAqsj7cC6jFpcja7XgFcrGWsctAPQNupce5/r71a5u3N2fu2jNvJz+h1JoIiWiIuPwPGk31vt4X9+gYcsbfUf1izkCvgTVrfWHN1/Sng7Ux6PYGgEc' .
+            'qHJkzby817Xj1p5fErAP3N7rH3dwz5AMDGB1bH4pE8iicuxEBBFETZWMDXz94e/f1n2BDAzYl9nCzyvMLcJL4Po3erDN7kh3f2Rezv/yofEoUkp8AAc27SsV' .
+            'GTeU1u5d6y7o3sfmQSuCcyBb+pH35HtbTVQ8IIiqiEgBcM5FrXnfOzIV/2Gh2Pbf8gsnZcP1O6Nzd6f1gTkJOA0OhC3bDD2bxVm2HC0YJ0pqRoOAKpSNaWnQ' .
+            '3RNl9xXpGzR/cn1iVOy8vdcbGMBGYWlLY9YTizNMe8BFxD88GaNFPpJtGGnr3bfT9M9FSOYW4DjcuVGL4HY8/egNjVndFltr5SW7hFaijkzGYUuDd9X9t/Vc' .
+            's2/BTvNof3fwL/t2mvtvXfv2hpT0FUrG4USfcH7nbCYlaRPxGRnAbmLjeb/+5/0CVOH6+9XgSIe75wvLOzK+/uXYOsvJVRQx1mmg0Rh348AAtqenxwwMYI2T' .
+            'P9dK2iODiJzkWEHKoTX5tH7/ji+uX30Xm+z5Hh05r2/+OPQMSV/foFFR8P5sWq8ulq0V5KTrIyJ6vGRsOlDX3X9Lz+XSN2juu7X7V1pzfsdkyYYiJ19XQVQ5' .
+            'di4dqA5bjn95YGDAnu/RkfP65qfDgfzbH60M5hWCvb4n7XGcWL6nfr+LW7OejJXMHVf8zq7ND35x3S4R6S6F1srLP9gusaqdzTvb2X3T46MOROAEt875gDkJ' .
+            'SBL1EHCtxdRvtOS8eWHkzHHkE0le0yCId6RglIJ377hl7f9nDN2lsuUE8p14rFicacx6Mu7UZyExYF63m6tzzBEQ6F2dcw/c3uuLY7F14jF9ZxDBmRgbRyeQ' .
+            'EBDrSDdkvOuNdfaEP7/Msc6hlJYF935pUaZ3de68lH4wtwVTdYW8L33xBXhmTzl2brrla60h29iG8nwmR/ehPR/njueLc86InGj1OmvITDtWaZ9jO62Lm7Ke' .
+            'NzYZveXK8LF76Nks0jdoXsdbrUuc9xJwExvVwAC2aONbfE/AOVv9m4hg44jlve9k9dXXAQ5rTxRWJyOfiMJE5cqx7zuJ9BRVji0WbpMBLLtODO2dDzivCeg2' .
+            'b9Z3sc3u+Hz3JU0Z/a5yaA0Vy1eUIg5LtHatItvUgZ/KMH/VBpyLkRO34uMgoohKk7QvW0+msR0/3UDH0ouIwyJyzLCWKHZxU9bv3XFbzztlAPtKaV6zEec1' .
+            'AQEGBrA25mOeJy2Rca7qv3POobRP58rLEM/HRGWWXvZOGpo7icLiKUlYlXztSy9m1ZXvBefAOTpWXIKfyhwnYI11iJBSIjc8+UcrU9Xfv/53XT84bwnYD0oG' .
+            'B819v7d+ma/lw0cLsRVJwm6iFHG5SK51AS0LVmLCEiIKF5VZvO7NBOn8CXpgFc5anHN0rb0K5xwOh4nK5OYtonnBCqJyAVHJsgvijRVimw3UO8eKqd63DmyL' .
+            '+/vnCHhe4D239+r+fpRT8UA+rY2tiCYRwUQh2aZ2Vl71XkwcJtJOBBNHNC/uZv7KSwkL4zUi1SAK5yyrrnovmca22rGiNKZcYNll76C5cxlxWEJEcIAC53DW' .
+            'WW5zIOdbeO68utkq3NbN+pmW5fa9mZ41+ax+33gxdlA1JARnDR3L1pPKteDsMcNUlMIUxulccSnzFndjonLNuFBKExXHWdTzJtpWXIKJS8dt085avHQD81de' .
+            'iiA1W1hEdKFkTHOD3vDAbevevolt1p1HuuB5SUB2Dbq+vkFTNu5TSiRvbeIuhsTtkmpopnPFJZhyYbrRACS6oZ/Os3jdmwFJ/hMhKhfItS6kbUkPpjR1wnGi' .
+            'FKZUoHXxWhpaF2DjuEZei6jIkImMvUkGsLDNcp7gvCOg60fJAHbHbWt7sin1s8WyMVW2VK3XBWsuR/vp6QZDDSJCHBZoaF1I68JVhKVJnHM0NHeyduPPEaTz' .
+            'YI/LxDr22ZXfLrrwakxYpJqvIKCnysbm0nrT9t/r2SQD2K2bOTGbZhbivCPgzoW9Oik40jdkAp2NTJL1IiIYE9G6aA1ti7uP6X4ngYjgbEzX2qvJNndQLowz' .
+            'f9VlBLlm4rDEKXIYEv0yjsh3LqFzxaWYOKRKVIezvsZqj5vu/dKizPK3954X3815cZNV9PcnBUMybhd6mg8fmYqtSC3bGQGWXfYO/HTDKaVYAsGakIaOpSxY' .
+            'tYEFqy+nY/klxMUplH5lwaWVZlnvO/D8NK6iDQriHS0Ym8vot0vU2Lvh+p2R27p51kvB84qAVQszjMIvBknUw0HF7VIq0L70ItL5VuJy8ZRSrAoRjSlO0Lpw' .
+            'Fcsuewcmjl7RQV2FMRHKTzF/9Ybj9EwRUVFsBcsXAOgbnPW64HlFQIBH+7sDJXJBjSuSxGz9VJbOFZeCtadNJHB4QabmbD5dSCVJoX3pOtL5Vqw5Fl2xgBIW' .
+            '39m/JH1GNzZDcd4Q0PVv9DaxzZay6idbGtRlk0UTiYhOIhchrV2raWhdgDl51supz3sSQ+WVkcSYU7kW2pasw5iaLqjKoY1acv78bCb/UVylQH4W47whIGyz' .
+            'MoANY7ulGDqPCvniconG9gtYfsVPJZbpGZDvtUCUJi5OccHFb6V9ybppERLxJkpGK/jEPZ9fk+vdt9PM5hLO84KAbutmLQPYHZ9dd11jRl9cjJKsZeeSTi3z' .
+            'V16WvO8MttGzgspW3LniUrSXwlmDKCSMrM1l1GIVeR+WAezgKbowzAbM2hurwjnkrvZhuftza/La50YRkmAtgrUx+XldtC5ajY3LJziPX29Uw36NHRfQsmB5' .
+            '4pxGIUAUW5MO1Md/ePMl7dX7eEMv7g3CrCcgg5vVpk3bjDbqzfmMvma8aGyi+wlxucCC1ZeD8t546TcNzlgWrrkSayLEOURETZWszWfU8lCFfZt3DTq2bJyV' .
+            'LplZ+VRNhwMlYLff0v2jTKB6ypFzIqLiqMzCNVeweN3G46zQc3WVonwOPr2TZx/+LtoLcDjnKSGK7ehVq3rms3nQksQLZ1Xi6qyWgHfeudETsPfevK6vucFb' .
+            'HcbWAMpaS5DOsWDNFaco4H2jIeBiOldeRraxLdEFQWJrbWNWt+14+tEbRHDcOfuk4GwmoIyMdLg7+5ekPc/dEFsCaxFRChOW6VxxCUG2EROFZ+R2eb1grUVp' .
+            'jwVrLscc00clts5mfP3L93xhecfgSIebbYXss+pmpmPrZlRf36DJ+Pm35dP6qolibEUpbaKQVLaRjuWXYMLyiTl95wgiijgqMW/xWhpa5hNHJZQoVSxbm03r' .
+            '1SoK3t/XN2hmWyF7faz+64D27o3yaH93INr9D2OcURXdSURYsOYKgnQOZ+ss0uUc2vNZeOFVaB0kZQEiaqIUWy36M3f2L0nPtvDcrCSg69/ovXVgWzyZVT/Z' .
+            'ktUXTZaMVUprE5ZoWbiKheveTByVzrHhcSKqjvH2lZfRufKSJCatlAojZ5pzui2byn9UwM2m6MisI2C1xdq9X7oqg7EDhcj5ImjnHKI8Fq6+HFsu1B35qhAR' .
+            'THGSzhWXEmTyWBODiDdRtJ7WfGLn5y5d2PsrO+PZ0tptVtzEybAkFwnQE8UOES0mLtO6aDUN87pwNqZuPVAiOGtJ5+bRvmQdNo5QSkkYOxf4stjYOL1lS71e' .
+            '/Jlj1hFw5+29ngjuuZHip5uyGouLnXMClZCbnH7IzTmHc7b2SvrtvtIrWdKkOs5WkhXO3HXnTEzHiksTn6CxKMEKuNjazw7Mot6Cs+ZJgkqPv54hWfX8Q/MV' .
+            '6e3G2q7ICHG5qFZd9R7al64nLhdPYfm6Gk8cgHN4QRqUrv0tKk0maVcvs2rOObQXoFOVNC0EG5WrW+n0lqkvfy/Oof2A8eG9DG37OsoLnKedzXh6fDKOf+yb' .
+            'U0OPbBnaLDI4s9t5zK7qq6Eh6RsYNNtvXvuheY1q8ZFJG1sTebnWBbR0rcZE4UmLjHAW5fnHEkOVAuVx5MUnCQvjKK2xJuaFoe0vu30nKfch+bZFtC9djzUh' .
+            'zsQ0zV9Ouqkd4qiWvmVNXEk+OLlvWUSwlThx8/xljB3YIzG+89LSYkt8bGCAX9oyC+pGZo0ErMql7f3dLX6Gp5WWJmOUxGFJVlz+LjpW9hIXp2rSr7oNaz9A' .
+            'vBSlo8M4aylNHObFx7fjBRnGR/YSlY4Vkms/xcsvmUMQrDXYOARRWBuTa11IkMnhBRkW91yLNTHpXAs6ncOWC9gk8nGSDloWHWQY2/80T9z992gvAKxVIioO' .
+            '1fKrPvPInn5QA0ke64zErCHgA7f3+r37dpr70z2/25LzPnN40hgblfxMfh7r3/lhXGULrBLP8wMQzehzQxTGDzH6/BDFiSMopbDGAA7tpxIJVTnmtJNPK/pg' .
+            'Umgi2DisbMEKpT1sHDJv8VqyTe3MW3whmcZ2nI0xUfkEieicwQuy7LrrfzN2YA9+uiFuToscnoy/9q1w6IPvWdirZ3K3/VlBQOcQtiA/Sl/UFCr3tIMWYyza' .
+            '82Xlle+lqX1xrWZD+ykcjvHhvbz42H1MHHqeKCzhp7KJpHPHBJFLMlOmfY47DQNGUGr6srqKXKz0Ra2c00QhxkSkMo20L+2hfcWlZJs6sGERW3GQJyR2iPYo' .
+            'jI/w1L3/SFicdNpTJhOoYrlsr9y9vPvJzcBMbe02Kyypu7Zs1DKAnTTmN7Mp1Wod1sahtC3uprlrNXFUxktlUF7A2MFnePzuQYbu+hvGR/YiSpPKNta+7ERs' .
+            'HSNZFMWVV4SzDs/TaP1yL0VcOyYmju2xwsuaJE0MjCCTx5iQFx/fwa7vfpU9D3yLqDyFF6SSPoTWViRoRK79Auavugwbh2KdEiWSLxv3qb6+QTOTW7vNeAmY' .
+            'TCPv5wf5v+sKnGwXYX4xcoJDXfKu/0oq2wQojuzfzYGnHmBseA9YixdkkpLICimksj1bays1RgnZWuc1A2CMJd+Ypa29FWPsKYxYwTnLvheGsdaglKIcRoyN' .
+            'HkWUqhwjaC2V91Y/W+GswcQhXpCmc/klSWu35k5sWMLaOOkgg+NH3/5LwtKUCzxttaZcjs0VV37ysV3VgvvXf8XPLmYBATd6W9hmfyLd88l5Oe/m0SkTxcVJ' .
+            'f8klb2PRRW9h7MWn2Pf4DsaH9+Kqel2FKLVKNGuJo5hUOoXWiraOVvL5BgAam/MV10viIE7Id6plS9wuWtfKLImimInxSbTnceDFYYrFMuVyGWssnu9VzuVw' .
+            'TioPgSUuFwgaGpm3eC0LVl1OOteSlIkGKUYev58nt9+Bn8lHzVnlj02ZP9OtqY8AzERdcEYT0JF0+Xn+969Kv1geP+RplY7jWNINTbJg9RWMHdzD4eceA6UT' .
+            'a5djep21FmuTbTGfb6CpOU+uMUtTU2OFnArnHMYcr1qdTghvup4oImid+BJt5fcjBw8TlkOGD47Wzu95unJs4gaycYw1MdpPMX/VZSjl4azFT2c59NwQk4f3' .
+            'I55vfYVSRi/7x9LDz0HS7/BsrO0bhRlNwAdu7/U3XL8z2v7Z7pvnNXo3HS1aTGzw0w2YOCQqTeKnGjim/AMIYRiRyaZJpXxa57Uwr60J3/cxxta2V1dxIp+N' .
+            'kLGbts1DQjYHlIsh+/cdpFgsMzlRqG370z/bOUccFoGkcVKQzuGnGygXxmMRbXIZ0eNT9m+u+e9D/+XOShLGa7/iNw4zloBJYuYA9zWsXpdVwb9ZS7oY2YKn' .
+            '1SJrTK0vX9V1kvR+MTjnWNDVSVt7C9lspqLzJbrfG5WgUCWk0goliT44NjbBwX3DHD58lCDwazppcu0VW1GS1nE4Q0s+hbEOLWAsHJ6K3v7v4WN3zrToyIy2' .
+            'gmUAS9lrNFY+eviou6Il4///grOilKOiT1URRRHZbIZlyxdxwdKFpFIBURTVCPhGZsdU48bOOuLYEMcxLS2NrFh9AQu7Omu6Y/WaavFoa1AiOFR0ZCK+fbwQ' .
+            'f/XwRPTnnpKvwczbfmEGS0Co1Pv2DZo/+vjK1JsWpx9szuq1hybi2qSiqq6nlGLJsi6amvP4vk8UnX4flzcK1YfA8z2KUyUOHjzEgX3D+P7xYyEc2GwgNozd' .
+            'TRt+Z9cXzuElnxXMWAlYJd93blrVtXFp5qGML2tHxuNw+qQiEydb8crVS2jvmFeRLPVHPjimH0ZhRJD2WbqsiwVdnURRfJyEFlDF0Kl5ef/zO27t+Z8Ae/58' .
+            'Y9rN0PzA+vsmTgNV8t3Zv7qtJR9s87V0TxRNrES8JPqVGBoLF3WwYGEnnqdewX1SX6gSTkQolco889TzFAoFPO9Y/XJlALZ/ZCr+gys/ues3KwZZzAwr25xx' .
+            'T01/P0r6Bs2/9nfPb2wI7vG16p4omlimkS8KIxZ2dbJkaRdaK4x5Y3W814rp/slsNs3qtcvIZNLEceLcrrzHPzwRxa0N3g07P7fuCxuu3xlt3TrzWnjMnG+F' .
+            'JOqxc2GvthOl+Snkm56WdUcLxmiVNBh3LlHqu7o6uGBZF3F0rA/zTIVzrhLeMzz+2G4Kk0U8v5ZF54CoNecFI+PRH19909An7tqyUc8kV8wMe2I2qg3X74zi' .
+            'kvtAY9ZbN16wZW8a+bINGbrXraTrggXEsZnx5IOq+8iiPc2F3StYumJxRUImTk0H/pGp2GQD9et3benufOvAtngm6YMz5htyWzfrLbsG3U8E3T+TSam/KccO' .
+            '55KE2kTnC+m+aDUtLY2Uy6fu7zxTUdULg1SKpx7fzfDBw6RSQeJGwtmMrwzwBLH8RNQSHOzd924jAwN175aZEU9KlXzvCFavzme9wcg4sTbJBq4aHF2LOsnl' .
+            'srOSfHBMLwzLZboWz6chl61Z9IKoYuhUOlDrCib+hw3X74zu4q4Z8d3OhG+qlij1wG09Xwt89Z8KZVMZjyrEUcSCrk6WLFuYbLuzHIlOqImimCeGdlMslqvh' .
+            'Oyfi4kygzWTJfvDqm3Z9fSaE5uqdgLJ162aV2/+g115K/VVz1us7PBnFIF41tDZ/fhsXLOs6LnIw2zHdMHni8WcoFcsoJViLUwrJBIrxkvn5N9009DdbN6P7' .
+            'BqnbJ7OuxXR/P9LXN2jaiqnefFr3jVbIB9QiHPO7OjCV2O/5gqT4yZJKB3TMbyOKkkIpEcQYZxy4lJLfvftza/Lt3Rvl5ev4zi3qmoCb2KgciLPcFltnmNYl' .
+            'VCnFqjVL8TzvpEOkZztEJbpve3srXYvnE1ceQqVEF0o2asx6qwO8940MbXP0129bt7olYLWr/QO3rXt7c4PeUCgZS7WzaRxzwbIumlsazzvpNx1JrNuwdNki' .
+            'mptzxHE1CwhvsmSVMW6gbxCzhW22XleobglY7WofGXtTZMhYRKmK3pfLN9Dc3Hhe6X2ngnPJmnTObz+Wx+hQkbGmMaOX3Xvz2g8PDGC/W6cTOOuSgFs3o2UA' .
+            'u/33ejbl0nrTVNlYIXG7WOto72jF989tX+d6gUiiDzc158k35mo7gnMO67DpQH/skVsvatnU0+HqsdF5XRJw+dt71b1fWpTRHjf5GutwtupsXtjVyfwF7XWb' .
+            '1XKuYIxl1ZplpNMpjLEopfRkydhcWl9ScOZd0jdoqMNxD3V3QW7rZt27b6dRpfyGXEa//WjBWCXKs9aRyaRp62g5L/x9Z4qqa6Zzflvt30pEFcrGWsctAFv6' .
+            '6q98s+4ISN+glQGshdsiY0Uq+ejWWlKpgGxDZkalVr1RqFbUNbXkp8+tU+XImnl5r2vHrT2/NAC23ppb1hUBt1bGk26/tedn8xmvN4xcbWaqc455bc1YY1/S' .
+            'eWAOVVjr8H2fppb8MV0Q0cXQ+UrJDTs+3z2/3kZ/1RUBu3ft0gJO4OKGlE4ZiwHEWku+sYHWeS2vcjjg+YFqmK5jfhtaJ9V1AqoQWpcJpNtzKSUD2HpqcFk3' .
+            'BOzvR/VsGYruu+2iRZ7iA4cnYwf4Vb9fU3MeP/DPS6fz6aIanmxqzuP5x9ZKiXPGOmtsuMU5pKdn8xwBTwYRnI2VS/lqWWQcIoi1jlQqRS7fcF47nc8Ezjpa' .
+            'WhuZ1nHTeVpUbLlIBNe+a7huFrGuCAiglbsoMs5O71CltKapKV/rGvWaINWOp/bYq/b7Ux6U/H36Mc4mv1fe2T3faxyYmGzDUosSVfRliWLn0r6ktt+8rnNk' .
+            'qOMV+ry+cagbAm5io3IOQcxnA08ULvH9gaO9o6VSG/tatl9JvLbhkSSfwcuCl0l+AoRjFdK85HsRBc5AePTY+6s/bYgrHTqr5yOaegXyvsJdihDHlkw6RVNz' .
+            'Y7WORBXLNm5u8C4VZX+6b3DQ1Et8uK7CMyK47TdzZPouWzVAXvPWa8uAQnW9Db18M5KdnxBBNO7oU8R77sANP5BINDVtWaJJSDWjFv043qqfB+Un0koUZv/3' .
+            'ccM/QK/+AJLpeG3nQzD7v4994VvYI08gXvZVlxQ450ilU2QyAUfHJtE6OVVsnHPI6Gtax7OMuhDDbutmTd+gvf+2nnfkU/rrhdA0xBYtSU97Vq9dTi73anXA' .
+            'yramU+jlP4Ne8t5TvtM88ReYF7+bSCLnQHmIn0Nf9Buolu4zvq9XdT4bEj14G+7oU2BCXlWHfefwPI/n9r7IgX2H8DyNdc6mPKXKsX2oc37b1Us/tK0MnPPp' .
+            'm/WxBe8aThraOhanfdUUxc4pEYljQ+u8Zhob86/eAHEWwnH8q7+QkM9NL511x95jY/SaD+JfdhOURsEUEb8R/y23J2Rx06Mv04472+cTD7/3d9FL34MrHqym' .
+            'P54Rqh0hFnZ14vte0vcGJDYOcOunpka8c028KuqDgFU4V4ysc2fV0HUxuucjSKqlskV6HBP8lZ+iknEMziCNy1GrPgA6jbfuY4nkqmytxzDtuLN+PgFn0Yt/' .
+            'Er3wx8AUeLUblXuJqZGo1DI1Xm6sm1hmXemAVpHlJav96i1fAVtCGlehl7z79N4vGkSjV/wsKB9p7TkJWc7g81/V+RLDCz+HXv0LmLvvA51GXqUBZs3x6yfi' .
+            'FIxngOKrOuFZxjmXgA5EBrbFD31hfYOycttk0YCI55xDKUUu3/DqrF8RsAZv1X8GGyUvZ054WRNj4umvCOt8ZMn7MHGYOHONefUvGyMqwFt2HdgIY9xLPu/E' .
+            'V3JNES6cIAg8tEhynHWn7Yg/yfpJbG3cmPEavLLcBslUqTNf2LOLc34Bx8NlXLWfvHP4vqato/U19O6zkG4H5R+n8FTP5KgMQnodcSwtIPlcfSaPfEMrLx6Y' .
+            'pGlemlxTkGzfxlEumVqpoKt8gsBxa+ScIwg82jpaGTty9FhoLlG2M2fp9l4z6oqA7iUDV5wDE9ta+9ozO5nDEhDt+SdItxOkFFRHdJmkIaUKNI8NjfL8/kmC' .
+            'QNeSSCqpTIQmYlnzIpY3dTEZFtAVtlY2yRM0Mzftb+CwBhqXT0LKAIqoGLH9hwdx1lEqG6YLs0xKI5Uki8TgUowNv8j37niM5cvauOjCVorFiLbWDJdf3EEc' .
+            'WURTaf+boFSKa9dQJag5eepa3QTU64qAJ8OZCr6kgWNyXJBvgNF/B2fY++xRimVDKqXZdt8+DowUSAcehw4XmSxEJ82wsc6S9TK8f/XbWN26hMmwgK21+j01' .
+            'HA4VB7SsHmfvviFKBdAa4tgRHpykqSFg1cIcd3zrGcqhQSvF088epRwmki0VeInvTvk0tbRwcGSKvS+MY60jFWjueeAAUWTI5wJ+/NpFWOdQSlixrBlUwryw' .
+            'GFfWry48badE3RPwTOCg9iVGseM/vv0sximUUjw0NEqxFKOUoJVGJM94CF62gZacnCDRKl2aCU3Iv448RLcd5/IFPTQGDUQ2PqkTw1Fpn6E9RibH+d5TT/Lo' .
+            '3hEKUxalBSWglNDUaLmknONXPvRm/HwKYsPQ0CiFYkQq5XH3D/YzfKhI4CvGxwtEsUWJkM54+J4wfKgIAofHytz+taHExaiES3va8LRgHfz4tV00N9d/2cKs' .
+            'IKBz4PuKkdEiX/6rRwkqjb4npiKichHnIJvxSalKrqYBYx3OOqyqNAM/xbkFYcoVuXf8fn6w94e8edFlXLNwPWUTVdwatTcmepf2+dazd/PD4ccII0sm8ElV' .
+            'p305wMLoyCT/9u1DfOeuJ3nnWxbzY2/qont5ClQaBFYtWkwYWYK0zw9/dIQ9z4+TbfDZ+/wEz74wQcpP3DVaCZ5OJjP5vuKHj44AUCjFvKm3k5Z59S39YJYQ' .
+            'EJIvWGvB9xSlcowoIZNSzF9yEZ7EFX0rIVupbFi3ppV1F3ew4759PPv8OKlpOuDJoEQwzvIjc5hOv8SajiWUTUh1AKvDkdIBPzz4GLu9IguWXIgSqY1mqF0n' .
+            'iXqgKl2vdjxpWLC0gQvXtBKWYgTBaxQ8HDYOuabX55orF4BWjI0U2D9cIJP12LN3nPsePEgm7VEsxQwfKuL7ilLJ8LarF9HekSUO6z9zfFYQUASiyNDW2cBV' .
+            'l3Tyr9/dS0tzhomxMT504/tZtvFXT3ns0p868887mQFSxUZg0xmez5L4w04wTcvP4b73UYqlLM5ashmPC1c2IwhLFua49vL5+J5m9EiJ+x8eJpvx2HewQGPe' .
+            'J0h7RMW68TefEnVFQBF51SsmAjZ2NDUG/OoHeuhsyxDFjtyRvyN8LI1e80EUMYiuWaqVAUintGpfimMWphw7+Lg3uNrfTvt8AmraFThrESUUxo/w/De24IcR' .
+            'y5f7CUMrZrOJDMYklnoUG5qbAn7ibUsS33toGBsPKU+F+N4pvt7XsM5nG3VDQG8ylnJaGl+6DZ6uEi0ixKWYDevbEZLvSgBLFv/Fv4WmPCz82WTOhtI1V0Xt' .
+            '+NP5jOM/sHqBx/5/2s8zPh+CqwzUicpl/uTG97PnsYfI5Fu4ZO1hvEpqRqlsuPziDpYsylMux4lv0VNkPAUWlKdo7cgSToVJmuLxHfZRiZO18TQu7w1BXRDQ' .
+            'OeSpPw6jqanUdwNffqwYOaeUkjCM2PfCQZatuOC06oCrUk37ClVZbVO2PLCrRPz4X7LuAxvJNbdVBgmeBQ90lXwnk4av5nTGoLTH43d/m/27H6Gtcz5xVOaB' .
+            'R4ZrEtU6eGL3GEGgEQdhbOloS3Pt5QuIwmTKk3XQs6oFiNn3wsGaE1ojUopsLMh3ASb25c65iVwXGqrr3+jJwLZ4x63rrmvN6X8YnYgipZQfRTHtHS2sWLX0' .
+            'FQlorSOd83n44RG27dhPQzZ5tsqh4em9k8ThFMvWdHP97/8j2XwzzpoThkOf2UVbnChcHCGeD9bWJqu/utPFoDxeeOjf+cPf/AWcpBEgSGlSgTqmLlTCctU5' .
+            'dyKCsZZy2daseWMcN/3apcxrSfHDnY/jkkwi5ymR0LjJq2/alQeqo5Hn0rFqENto7PELopQ6LUtOa2FqKuK+B4d55rlxntxzlCd2j7H3xUkaGzTz2lo5sGeI' .
+            'P73xOgpHDx03xuuMYQ2Iwu16lIkv/0+kXK4Mu36V36UziPKwB+5j/vCX+bmf7uHH37KY97xjKQvas0wVYoxJoidTUxGlUoy1jsBXeFpI+ZrGnE++IXk15QKU' .
+            'EkQdrwpUNgV7X//KuS34ZHCOVNqXWuJHtf3uKzUhSvyAmuEDkwztPsK8lhTWulqD7yi2iAlRQRNPPPIQf/Br1/ErX/oH2jvaznhMl7MWJ5rS83fx1N/+L6ID' .
+            'WRq++uss+JlbaG5urTmjz+CEWNHYffcQP3QrotNcftkCEAdK6F3XxsRkRCrrMfTYYR5+bJSGBo/RIyWe3zeJpxVKScWNlERESmWDtVAulo/LJqpI0caG9qBu' .
+            'QnH1sQU7ZLBvs1q4fmhpQ1r9K+JWlyOLEqWiKGJN9wqam/O19mOnghX4h288w30PHiQVaKx15Br8xD9WNly+vp1lS1s5OjLC4jXrWfq+/xcnXmXrPI2lcAaL' .
+            'QkWP8+zXPsqX/vIJGpszHD4wyk9f9zbe9d++jrGCPoPzIQoKQ7DjJvAbcLGjWEzG/jrA9xSep2rkEhHwFIcPFXh89xjZjMfwoSJ3/+AA6ZRmYjJi1bJG/vP/' .
+            '082zj+/h0PARgsDHWmtyaU9PheZ/FYptn9g01OHqYahhXUhAEdyd/cNy7Wd27b73lp6Rpqy6sBxiqOg80wPup4Ixjkxzio55GdaubGFBZ5ZCIebNly+gvS1D' .
+            'GBpyWR8VKFjbhpk8QHRwB3rhW3AmRumXX4qkyFtQIjx4x1cYfuYo+WwDKaChcR7e1DNwdCfSdOXp5RDWDBfhgTu+gowME5FjflvA0uXNENmaf6ia05ekYjmi' .
+            'Ukwu43PNhvnJ72PH1Zd14vuakdEi4xNlUikPpfS0gYfYTKD0VGi/l4xyqI92bXVxEVX096MUMlLdNZLtUbF/3zANq5a8rPTTWoimItataWHjVQvwMx5YiMNk' .
+            'RGs27RHFFhsaMmmHzjWjn/pDyKchfwXOxog6+XIkkyodojVf/9zHufufvkqmsY207zBWsHGM83LYBz9HvOoG/K43IxWj4hQnrAzF1mz9/Me555//mlRuHlH4' .
+            'Ii1NKboW5rCxrUnAd7xlMb6nAIcxjrbWNH7Wh9iCCEpDOpUQfmFHlsULchw9eJTxsfHa/GGtkTC2pUpGodDTcc4tYKgjAt7FNjswgH3PbfaGcqzehxwrkC0V' .
+            'yqd1Dmss8zsakv8PLQJ4WqhmJGklpFKaHzw8zOiRMoEvlL79qyx/9y1ceNW7MCZGnyAJK90FtOZvb/sYO77xVdo6F2BNVPM1OpcQReUa8Ia+iDSkofnyU5Da' .
+            '4XBY0fzNZz/Kvf/yVzS3LcCamHTaIzaWp3aP1XZw5+CpZ4/WHODl0LB+7TwWLcgRRwZjHfNa0lx+cQdRZJPMGMBYQ7kc4vvJ9tuQ1t7YlPne1Z8e+rs7+zd6' .
+            'b+0brIvu+XVDwCqUBKl0YNVYwTgtoLWiXC4zMjzK/AUdp3THOJc4ZIcPFTk8VkJrhdbCxGTIt+9+IUnTcklK4PBokTC0KK1w1vK9HR/k5z/zFda/5d3HuWeS' .
+            'QdYxSjRf//zHuf8bf01T2wLiODrusz0tjI6VePbpo4TFELfnRta87zak4+pKZKP6LFXqQdDw+B+xwruPifWr8T0LLkmQePrZo0nKV+WIwNdolTScdDgyac3Q' .
+            'k4d5eOhQpfjIEQSKu3+wH2up+QGvWRcQBB7GTk9YpfX1+dZePerCCKlAtm7drBbueSSbwv+LtC/XFUrGilI6iiIWLupk8QULieOTW8TWOtJ5n2/9+17++Tt7' .
+            'acwf643iaXXcnXo6sRQBRBRRHJOSMh/63N+x+rJrkw5cWmONQWnN3//+jXz/72+nuaML8xLyJeeAKLLEcUI2ay3LF3q84xN/wYpLrsXZ5HxV3dA8+mXM3n8i' .
+            'yM8H4tpJnLE8tOsQsXFJWUhK88OHh9nzwkRi5QJxbJl6Sf5iOqWTYyow1vHOyzM05VSyS4MNfCGK+MUrPvXoX9fT6IZ6koCue9cuvW7giYn7bln3SKZBXTdV' .
+            'sgbntOd5DB8cpaNzXsWiO4X64iAIEsetpxVWJZKk6rhFEqLqtMcVF3fU7IDICNesb6Dd3InjzSglxFEZz08xuu9ZHr7rH8m3tmPik+9a1XSwIEjyrrSX4vFn' .
+            'Rmi44yusvPTNSRZWHKK8AFfYj9n/PQhaKJfKx4XKRODS9R3HTizQvaKZcmhAkm1+5FCJ7/9gP0GgkipOgYcfGyUMa204UFofR1ALKBHltPkOwK7u+ijJhPqS' .
+            'gFQMTXZ8Yf1S39mHwTXEMSIqqRHu6Gxl6fJFJ3XHJBIw4Jv/Zw/3PThc8wWWyob1F86j+8JW4rLBAalAs2Rp03GOYxsLpngEt/Dt+Bf/JgIMP/cUf/Lb76cw' .
+            'fgQvSOEq1pGqWpa44yIUzrlK3p/DCwImDo+w4Sf+Ez/3O18GwEw8j/nBf4doIumIcBIevPThUirJ96NS/6GVQqXUtDxEYW8lm1opwZmY721/lqULfJpzisjY' .
+            'uCXne+OFeDDQ+kNHNrSU3/rWbeakH34OUE8SEBGc6+9XV/32wJ7tN3f/WUve+8TYZGyk4tMoFcuc6pkREUxoWbGkkasu66S1OU0cJ4TRShAtx9JZrKM4GR5f' .
+            'nCSA10Rw8D+IH4zY/mSW7d/4ayZGD5LONeFsjNaJzlUsxziXENn3FMVyEqnQWkindNK5PorINbfxg2/+b8qFIpdfezXdjTux0RGsyiKnKMs4aWnANFJGscVG' .
+            '5rhrX9KVS25AhKhY5uhKH+sEY53zlUgY2ZKz8geXfPKRqUoT0LogH9SZBARwrl8NDg7J0t0PLcmm0veVI9saWZQSEWMMqy5cTktL/qTRkYQUiti4ypDqY793' .
+            '09a8llJ13LGOVC7goYdG+ea3hzh8ZIJUtgnPDzAmJowsUWRJpTQrljSitOLF/ZOMjBZZtbSJhnzA5ETInucn0EoIAoVWgu/7TB4dw9cxiy6Yzy/8TDf5vEe5' .
+            'dPZGTDiX1E8HqYDdTzzLoUNj+L7GOWcaUkqPF803rvn00LtdP0oG6qcgCeqQgACV8fPR9lt6vtzcoD9ytBBbQTxjDI1NeVauPrVPMNGp5IySU5K2LcIju0YZ' .
+            '/OZuEEUm7RNHceKvU8KGi9pZ3JXHU8L67nngKfbuGeP5/VNc2tNGQ0uaycMlfvT4KJmsx933J3UdUWRJpwOMg2IhpL01xS+8fw3trWlM/MoFTqd3/UkN8MRE' .
+            'gd1P7qlZw+DifNqzhTC8+pkHHn948+bNSN+5j35MR10SsBojeOCLvfNMVDwgiKoo0lIuhyzs6mDp8sVnZVRDtaCnFBtu/6tdHBgp0pT3mSzEOOv4wHWrWbWy' .
+            'mUAJOu2BsZQqFWeplEZ8TVSMMLFDe4KfTrSa4lSEAP/478+yfecBmhoDosjRmPd50xULeFPvfOLo7DbcfOTBx4njGKUUDhc3ZT01Xoj/Wbdm+gA2XL/zRBP+' .
+            'HKMuCQjgtm7W0jdott/c/YW2Rv/GQxNRrEU8R0KYtetWkUr5Z6VjvnPg+UKxYPjK3z7Gk3vG2HjlQt589UIWtmWI46QrQdVireppVaOjmnXiAGePvcfTiji2' .
+            '7H5hgr//xm4CX/Frv7iOhsaA8tTZmXOSFPD77H/xIM/t3V+LfCDYQIsqx+6Sqz616+F63H6hngnY36+2AD+Zv2NlVtz3I2PnhcZJkqAQM39hO0uXdZ21mSHW' .
+            'OtJpj8NHSjzwyAhvu7YLrZMCJ/UqiVI1slP5gGd3j5FJazras5SKiUHzWlGbHRzHPLHraUqlCK0V1lrTlPX02FR8x9WfHvoZ19+v6nV6en3lA06DDAzYTdyl' .
+            'rrzxkScnSubvfE9p53DJE+9xYN8we5/dV3N/vFYoJZTLMY35gHe8bQlx7F4T+aDqnoHSeJkLunK0taYJy2eHfMn5k+lRTww9Q7EYJuRzzmklBhjXWr7Y34+i' .
+            'Z6huBU3dEhCS+LDrR+Ua1P+IDXh6Ogl99r84TKlYOrbtvEZUs42Lk2GtdPJsQCmpRErOMFfwZWCtJQgCDh4YZWpyqjY7zzlnmnNecGQqvu+KT+66d+H+Xl1v' .
+            'hsd01O2TUcXWrZt1+65haUgd+tlMWv11MTTOOfFERJJtM2D12uX4vj5vJig55/ADn0PDh3n2mRemO8FtOqWIjX0qpfjxQxNt+zdt2WYq3UrqEnUtAQH6+gbN' .
+            'JjbZK27a9fWJovlYa873rSNKXA9QKBR5YugZ4thUim/O9RW/vqiqIIeGj7D7qb2JjzMhnws8rDWugIquvejGXc/fxTZbz+SDGUDAKh64vdfPBt4dUyWzqymr' .
+            'AuucdQ48z6NYLPH40O5KiO70SzlnGqq9n0dHx9j91F601jU/ohJsY9bzSpH5kw03PnnIbd2sB+rQ6n0pZgQBZWDA9u7baS757UeGD0+Emwpl+2jaV86BrfYR' .
+            'nJoscnh0jCAVVLakc33VZxfOObSXZDgf3J/0gDmmbrg4HQhjU+bz13z6sd964PZen77BuicfzAAdcDrc7b2+XL8zuufmte9b1Jq+4+BYWHKQonIfIsmAlq7F' .
+            'nQSpAPMKNSQzBdVtd3R0jIP7R5iaLCbO5mTrNelA6VJopq66aShXTeg41+WWp4sZ9+3c2b/Ra2dETaXVza15fePoeBSLJK3kq1V0uVyG1WtX4PuaOJ7Z0zWd' .
+            'dfgpn9Hhwzz91HMANavfOmcDT0mgpTAVmvd6rZnv935nua2HYqPTxYzYgqfjrQPb4h6G4is/9ehvH56M/6A173vOuQgq7dECn0KhVDNMUil/RuqENSd2OuDQ' .
+            '8GGefmovWqvjyOd7SilFdGTS/dRVnxr67r/s22lmEvlgBkrAKqqhuvtv6/n91px3w+hEHDrwk9S8ZMJmNpuhY34b7ZU+02epg8brDmsdnqcJw4iDB0YYOXj4' .
+            'uPpl57C+J8rXFMZL5l3Xfvqx71cTOM7xpZ8xZpwErGHzoN3a3x1c8cldv3l00nyhNacDknJuW7UWS6Uyu5/ay/PP7cf3vbMWgXi9EaR84jjmycf38OLzwwDT' .
+            'yOdMyhcVaArjpejd1376se+7/o3eTCQfzGAJWEVVEt53S/cf5tLer5Zjmwpja5VIJZBRmaHblKdzQRtNzXmMsWfcEeH1RjWlyjnH8IFRRkYOUy6VkzFbSYKD' .
+            'BVzKV9o5d7hUsj999WeG7p6pkq+K+vkGXiUcyOBWVF8f5pkvX7pkdDL8P/mMXjNWMJakhR7VLVlE0djUwMrVy2rZzZXw1TkhY5V0kPgzx44cZfdTz9XSzKpd' .
+            'rRxYLajmnMeR8fhLDz57+Hev/5P9hXrNcDkTzHgCVrF162bd1zdo7ulf35HN2382xl0B4oy1FsSrjn41xpJKB3TOb6OpqRE/8NCeJq5kWL/eZJx+ft/3KBbL' .
+            'GGM4sG+EsSPjGGMqnSBcNcoRp3zl+Z6MFEr2q1d8atdvAdRTZdtrwawhINQalDqAH9zW/f50oAcBpso2xOGLJAaKMYZq34vGpkbmL2ilsbkRZxOJZIypWc5n' .
+            'K2cPqEQuEpIbYzg0fIThg4colcJK5oyaVkbgDILMy3mqGNpHDeV3XfpbT71YnSw6U/x8r4RZRUCoVNZt2ahlYFt8783dP9+S9X5TFL1TZUtkkqnXSildlURx' .
+            'FKM9je97NLc20dzSSCadIpVJYY3F2ipZqW3Xr4TE71iRpippViQiTExMEUeG/fuGCcsRxWJSQC8itT6XDhfjxGvMaqZKFqXctw9N6Q+8c+CR4Tv7N3pvHdhW' .
+            'Fx0NzhZmHQGr2LoV3deXbFEP3Nb9i7FlS0NaL8XBZNnEguiqREw6ICSqlDGGpuZG0ukUWmsWdHVQ3Q4TP5zHywkfB0RhlITOlKJYKnNg/wi+53F49ChhOUx0' .
+            'O5LzVXQ8BzhxzjVmPR0bGxkndxQi/vSaT/3oO3C8dJ9NmLUEBHD9KAZwAu65L12VORBPfCjrqw8Gvrp8smiIYmucSNInvILqFp3Mp1P4vocIGGPJ5xto62id' .
+            'toUfD5EkT2/fC8NYlwyXsdYRRYnQ8rxjW3DtGp2LlRIvEyiMdfhafc0Rf2HdDUMPQRL52TSwzcyWLfelmNUErEDu7N+oq1vX1hsWZS5Z2vZTR4vRrZmUWhkb' .
+            'R7HsnChq5rCa1hipKhmrQ6CtqZacnYoPgtbV/oCusr0et4VXDAdRDudaGjxVjGwYRu4/rLhbrv7k0N1Qte43q746TiY9GzgfCFhD1WdY/ff2W9b+euCpX0n7' .
+            'uicyDl8LsXEUQhOJQKUgfvoayekYJRUJ56b92wIWEZ1LKyUI5djiKcH35C+nSu7PNvzOj74PicSrdgo7W/ddzzivCAiVbqyDm9XmXYNOBrB39l/cvLzTth48' .
+            'aj+ZDmRNIbStHY3BushYCmVLbKrKl8NaF1ebK5xM/lVbtYmI0iqRotY5soEiHSimSpZSaO5szHp6rGj/dF42tX31b+zcDYm6MDiEzAbXypngvCPgdJzMqnzg' .
+            '9t5sQznum5gKY4v6rZTPqnLoLIJuynrZpE3kqaFEmCobypGdEhGTDUQXIvcXKZ/741AmNnzq0Tumv/98JV4V5zUBoeq2QQaHkPbujTKdkHf2b/S620fS+4ue' .
+            'K6g4pcp8ztMqMObku6NDbFNWqYmC3RH4+i9LkwV95Yqskf/yyNT0cwJsYpsFmOmRjDmcZTiHuP6N3p1nsYdyfz/qbJ9ztuC8l4CvAJm+3e68vfe0CNTbstxO' .
+            'T4mfrS6UOcxhDnOYw2vB/wW+raiDrJ6qbgAAAABJRU5ErkJggg==',
+        'image_width' => 160,
+        'image_height' => 160,
+    ],
+    'katumia-celebrate' => [
+        'emoji' => '😸',
+        'label' => 'Katumia Celebrate',
+        'image' => 'data:image/png;base64,' .
+            'iVBORw0KGgoAAAANSUhEUgAAAKAAAACgCAYAAACLz2ctAAA4vklEQVR4nO29eZxcV3nn/X3Oube2rqpe1ItarX21FtuyW/KGiUQgtoGEXc0bh5DwIeAAIYkD' .
+            'eSfAQKsz2DghJJN582bGhCTvkLxkUM9gwpJMAkRWMN6QvGHJxraszdbSrW71Wsu995wzf9yqVrcW25JlVN3qnz76SF1Vfercc3/3Oc9+YBazmMUsZjGLWcxi' .
+            'FrOYxSxmMYtZzGIWs5jFLGYxi1nMYhazmMUsZjGLWcxiFrOYxSxmcQEgF3sC0w1uOx65yrp9GyM92Is8pVlcCnDdKOdOf2BdN+pizGcWlxAmk6zwbX7NfZ9u' .
+            '9+90j36bdZPen91NzgOzi/YycN0o6cEOf5NViTT3JITVqi5+LyoxbCK+lbyfX2crDkAk/ncWrwyzBHwJuG4Um1HjY6xNpvlnT9M+NoaBWO9Tgp9phNETfD2n' .
+            '+DXeTCgyqxOeC2b1l5fCVpy8gcjB1z1N++gokQhaBF8E3zrc2CClXBvvHYn4mAjW7cSfPER3N2pWTzw7ZiXgWeC248kbiIa/xQcyef5reQwFU8kF4BxO+1hl' .
+            'OWwCrsu8nSNsRWat41eG2SfzbKi4WpRiueeTtGfR7ESQKED5PgtUgnRVB3Td3cp1o3bese6yXXesu6L62s9q+tMFswvychAUAmczLSpbiFMKKp+soAfpwYbY' .
+            '74bKfgSAtXtmd5xTMEvAs6ET4xxSLnjfDAsc9320OwMNjSVK51DFEv+SSnLUOTRsUtKD/dHn195cX6fn4fjQnjs3zpGuXutm1Z4pmCXgWbDry50aYPeTV14V' .
+            'jjY1aIVxTqaQxzkiTyMCBJY/kzcwxr3Irnljsu9vN6V8LbcbQyqX1gxT6AHcrrs7vYtxPbWKWQKeAc4hz39/l/3RH6/KZjKl//j0M/O9vv56L5k4KQCtxWaz' .
+            'eOkMeuwEtzb8Ev/iHGrrvdgNt+0KDxw8fnk2rW4eLRlTCiy5lOp6+Asrlj7fuNQ6N6sLVjG7EGdAb+8W1dWLUaH3wVxKd5SjyL54aL4cOjiXMPTwNGRzoiz8' .
+            'Y2GMtze8i39wd+OztRuA+/7o8lVzsvobpcCESkSFxuF50mKs9/Gurl7D1ot7fbWEWQKegmq895E71rekEurj5cgaVVmlo0daw8Ejq3juucV3Sotb9L/+csu7' .
+            '636Jb7ltaLmNkLV7pKcHqyPzG+mEzC9HTkQQQdR4ydiErz/4w+6lC6Wnx54prnwpYpaAp2LrJr1ld68LVNCVS6ulhZK1gigAPxHp4XHtCmP5m3vvvrG4ZQvs' .
+            'vBtfujAOZOvuXrfzTzqbleL2wbHIKRENgCBh5Ew2rbPpfMvvOue8XV+e1QVhloBT4EDYusOwdos4y9bhgnGi5CRRnKhyENrmeulc2D74/0tXr9m1qxOAXXd3' .
+            'ej092DAobc1nPLE4wySLV2nf7+vrY/51v/IRoLnzwzuNc+6SX/9LfgGmYPsmLYJ76Lknb89ndHNkrZVT3CZKKTUwEgX1Ge/ah+9ae8Ph9l3mye41iW8f3mUe' .
+            '/sLqN9UlpatQMg5XkX4AAtYEJOpabPOVXSngsyJimV3/2QWownV3q97+VvejLy5tTfv6Q5F1ljP77MRYp4G8Me6TPT3YtWvXmp4erHHyt1pJS2gQkZO/K6Ix' .
+            'pRHaNtwquq7NYM17nHMrAXupS8FL+uKnYO0e6erqNSpMvCeT0iuL5ZO636kQET1SMjaVUO98+M61G6Wr1zz4hTUfbsr6rWMlG4hMWlcRnAlJZFuZu+FXFOBQ' .
+            'uhX4UEUKXtLGyCwBq+jqtf/058uTStTnRkuRVXJm8lXhnLN1CWXQ/N8ASV/9TjG0CQdTjAsRTVQeo2X9e0jWz8eaUBNHVG53zjUTS8FLloSzBAR23t3pC7im' .
+            'YvJ3GrPenCB0xjFVijE1CIIg3omCUQp+8aE7V/83Y1hTKltkyprG0s9L19Nx40cBUNoToGqgbBURxymkvZQwS0Cgc2XW7by70xfHAuvEY/K2KIIzETYKTyMh' .
+            'INaRqkt7txnr7Klvi9KExSHar/0gXroeZycM46oU7HLOXQlEl6oueEle9GR0d6O23rvD6sGoI+HJbw2NR07kpOvFmoh0vpnsnHnYKEROYZlzMFY0hjOspbOW' .
+            'VLaBlss2c4qqV82vaQEaKj9fktvwJU/AzWxSPT3Yoo3u9D0B5yYSSUUEG4Us7byZlde/E3DYMyQGikxyuVRfUx5RaZiVb7iN1NwrwFlETflYbJDAHRVj5JKs' .
+            'JbmkCei2bNH3ssM+9Mdr1ten9S3lwBoqlq8oRRSUaOpYQaa+FT+ZZu6KDTgXnSYFT4WIEJbGaFm0mszKt+BQZ5JvVV1wg3PuZhGxzrlLThe8pAkI0NODtRG/' .
+            '5XnSGMYJVwLgnENpn7blVyOejwnLLL76Zuoa2giD4llJKKIwUUjLostY8YYPo/NLiZOkT9cfK/8miS3iZOV7L6mt+JIlYDco6e01D/6nK5b4Wj44XIhsVfcT' .
+            'pYjKRbJN7TS2L8cEJUQULiyzYN3rSaRyOHfmHdNZi3OOeauuhTlXxgLVnZGAEFu/FrgZ6BSR6GwfnKm4ZAn4S3d36u5ulFNRTy6lja3ofiKCCQMy9S0sv+5t' .
+            'mCiIpZ0IJgppWLCGucuvIiiMIOqU5ROFc44V17yFTOsqXHbZxOsvAUdMwruIyXdJ3ZNL6mKrcNu26Ocbl9q3pdeuymX0O0aKkYOqISE4a2hdcgXJbGPFdVJ5' .
+            'RylMYYS2ZVcxZ8EaTFiecM0opQmLI8xfeyPNSy7HNV0Vv3UWSTkJmpO64Jtg6yWlC16SBGR3r+vq6jVl4z6lRHLWxq5mAGsNyboG2patx5QLnBoQcc7hp3Is' .
+            'WPd6QOI/IoTlAtmmeTQvWoMpl5Bk/Sufj7UKSB9+6G8+LdJj4dIp6bzkCFhttfHQXavXZpLq3cWyMVWWiSjC0hjtqzai/dRkj8wERIQoKFDXNI+meSsISmM4' .
+            '56hraGP1pltJ+D7kliDpFnD2TM7r0xG7cey8q9+z+YEvdG4WUXbbti2nuXZmIi45Au6a16l33t3p4/Tt6YTOhCbOehERjAlpmr+K5gVrTup+Z4CI4GxEx+rr' .
+            'yTS0Ui6MMHdFJ4m6eqIoQrddA5wevjsr4s9Z/Ly97G2f/fSX5rv00qX/4ZK4N5fERVbR3Y3acNuuUEbsPE/zwRPjkRURH5hwlCy5+ib8VB3YKfmkp0CwJqCu' .
+            'dTHtKzbQvnIDrUuvIho/jm66DFJzXsryPTOc9QCbn7/+TW/s+UDnhg0bQ+e2zXgpeEkRcDObFEAQBn+SiKMecUcrpYhKBVoWX04q10RULr6c5Rrn+BVHaZq3' .
+            'giVX34yJyohOInOuIKbzOQY2RGGtVSq/SFrWvO6L8e9vmfG64CVFQIAnu9cklMjCid1RwFmDn8zQtuwqsPZlIx0n4fAS6fi/pozkFiOZuRVxeu5Lq5QCZ5l3' .
+            '3QcX7Nu3L3XOA0xDXDIEdN2bvM3ssKWMektjnbp6rGhCEdEiChMGNHWspK6pHXPmrJezj+tsZbtVqLbr4hfP35WsEBWCnbt48eKPIoJz7rSGSDMJlwwBYYeV' .
+            'HmwQ2a3FwHlUyBeVS+RbFrL0mrdiXiLE9pJwDrwM6OSrnqU1kQdKn3jqu7/71zfckIW4RcirHrhGcUkQ0G3boqUH+9Dn170zn9ZXFkNrBZRzcaeWucuvjj/3' .
+            '8k7j0yEKTBnVfAX4dbHr5dWIwDhh1TaufuuCG35r3QdFtIVtM/Y+zdgLq8I55N6WPrnvj1bltM8nRYiDtQjWRuTmdNA0fyU2Kp/mdH55CLgIknmk6fLKS69+' .
+            'Sa21AGbxpg9/fNsttgW2MFObGs14AtK7RW3evMNoo16fS+sbRorGxrqfEJULtK/cCMo7T+knEJWR5vXx9ns+Y5wBlXoUm25bubTz45/p2rpVHNu3z0iXzIx8' .
+            'qibDgRKwD9y55ifphFpbDp0TERWFZeatuoYF6zZhzcvn+J2OivTzMujlXaAzlZcvzJJaY5zSmsGn/mVgzppb5jrnLHGu2IxKXJ3REnD79k2egL3/jnVdDXXe' .
+            'yiCyBlDWWhKpLO2rrplawHsuEAFnkKa14NUR91W4cM+z0koA27T65uanvv6R20WUY3v3jJOCM5mA0t/f6rZ3L0p5nrs9siSsRUQpTFCmbdl6Epk8JgzOjzjW' .
+            'gE6hmq+qfNuFXkrBWiOAXXzD+z/01etdK5u3upnW8HxGXcxkbNuC6urqNWk/98ZcSl83WoysKKVNGJDM5Glduh4TlE/P6XtFkNjaTTZysr7owkPFBe425bNy' .
+            '2S3r3yOiDGu3zSi1acYSsGXNJnmye01CtPtDY5xRVA+SEdpXXUMilcXZ84x0Saz/qZbYgLlQxsfp36PjVK2262zL5Zs+u/1v359iy8wKz81IArruTd4benZE' .
+            'Yxn1lsaMvnysZKxSWpugROO8Fcxb93qisHR+TmcRsGWkrgPJLYjJd8G33ynfpwCz7M23N8tz//xREeV23t05Y6IjM46A1RZr93/pujTG9hRC54ugnXOI8pi3' .
+            'ciO2XDg/8lVhLap1YyyhXusNUQSs8VSqw1t8w2/87leucvM6P7wz6p4huuCMuIgzYVE2FGBtGDlEtJioTNP8ldTN6cDZ8639qfj9sgsgO//cU67OFyICnuvY' .
+            '+H8tWHXzG1NbtyLQ/dp/788AM46Au+7u9ERwB/uLn6nPaCwuqpY6zl1+dWw/vEKdzTmHc7by18UuG+0jzVdWSkh+Ri65eIu3XsvlbsFNb/l8T4+2W7dunhH3' .
+            'bkZcRBWuu1s937jUPvqlFR2ZtP7VYmgFREVBkeXXvJV8y8K4XuOMOpuLJZpzMfGsxfOTeMk6vGQGL5HGhAVCq5H8K6p2u6CwxijALtr4jlu+c6tdD5ut28K0' .
+            '9wvOKAKyJ+7xVyp5H0gn1IIwwtooVNmmdho7VmLC4IxFRs4aRGmU56M8Hy+RxEtnOXH0eY49t4v+fY/T9/xjPPrd/8rhg/uJyfqzNUaVimvsULqx/YY3/lbc' .
+            'zmPbz3QOrwVmjE+pGqx/oHtNo5/mOaWl3hglUVCSZRtvoXV5J1FxfMLvV92GtZ9AvCSl4T6ctZRGB3nx6QfwEmlG+g8QlgoTPV2053PFh79Dunkpzp7W6+U1' .
+            'hzURSnv2xR/+P2rXV7+y9O1f2b2vG6N6pnEV3YypP911d6fXeXiX0Sn57fo6r35wzBgbFv10bg7Niy7HlAqIUhPE8/wEiGbg4B4KI8cZOLSH4ugJlFJYYwCH' .
+            '9pMkMnlENGFhgJYrukjPWVqRmD/7pVNaA9iO13/EHd31tR7nol/f9eUNuue2XdOWgDNCAjqHsBX5Sery+kC55xw0GmPRni/Lr30b9S0LMJXWatpP4nCM9B3g' .
+            'xaceZPT4IcKghJ/MxNJxUki3anhALH3Wf+z7JOs74My9Xn42sJFDeWbsib8rfucT779Wf3jbM1voRbp6zcv/cu1hRuiA927dpKUHO2bM72WSqsk6rI0CaV6w' .
+            'hoaOlURhGS+ZRnkJho49z9P39bLn3n9gpP8AojTJTD4mmqsWE520biMDxZF+Wq/qIlnfgXMvVS33M4AoASS78qbcqrff8qmuri7Dlm3TNkNm2m/BcXB+s334' .
+            'T44vSDj5QBhZ45wT5SVpX7UBojJ+so4Th/dy9NmdDPXtA2vxEmlcxfJ1Nm5r75zDWlsxhh2e59HakidqmUPb1b9MTWRCiQJrFKk2M+/ad737h3cd+SMRvbta' .
+            'cH+xp3eumPYEhE1qKz32zeHaX63L6o6BcRNGpXF/0fo3ksw3M/Tisxx++iFG+g7gKnqdIMTpdXHxuLWWMAhJppL4vkdzaxO5XB2IIp8BaV6PtF0WN5k8vRfl' .
+            'zx6xFLRtG96deeabn7nd7fyNj+zatQuYfrrgtNYBHXHrvUN/el3qxfLIcU+rVBRFkqqrl/aV1zB0bB+DB58CpWNrl5N6nbUWa2OfXy5XR31Djmw+Q319foKc' .
+            'DoUpDqHX3Ia3+G0gcfXbRUdFVYiKI/b5ez6qnv/eN5Y8uLh0EISeaSYFa2A1zx/VqMeLxZH/OCfrZQAliFhjOPiTHQwc3BM7kf3ExE0TEYIgxE/45OvrWLJs' .
+            'AavWLGHBonby+RxRZLDWERmLCUuo3AK8hTdXHtUaeV4r6oKXaXAd132AuoVtd/T0KFstvJ9OqJEVPXe47m4FPTxYt3JdRiX+2VpSxdAWPK3mW1M5qkjpiQZD' .
+            'ce8Xg3OO9o42mlsayWTSFZ0v1v2mJCiIxgVDeOs+hl741kqjoRrYfqfAOlBm/9e6Si/s2fHOGz/f9wO6tijpnT4W8bR7YiZDerCUvbyx8tHBYXdNY9r/G8FZ' .
+            'UcrFUuLkbhSGIZlMmiVL57Nw8TySyQRhGE4QcGp2TJxypeoWoOffXHmp1shHtWG6LLzlc+Olob4InLCmtwYspVeOaSsBoVLv29Vr/vzjy5OvW5B6tCGjVx8f' .
+            'jWz1sJiqrqeUYtGSDuobcvi+TxieftzCFIiG8gDeFZ9ELbipIv1q8ll1xM0tTwA3i8ijzjktIrMS8LVGlXzf//SKjk2L04+lfVndPxIFk08qMlG8FS9fuYiW' .
+            '1jlxI8mXIx8CpoQ0rkO1XfuqC81fY1TPF2nB2m7nXApw06nR+bR0w1TJt717ZXNjLvGvvuKy0aKJtEjCwYShMW9+K+3z2vA8RRDE/f5eNhFVFJgiklsCifq4' .
+            '9FJqepniB06ptwPlizuVc8e0k4Dd3Sjp6jXf6V4zN1+X+JGv1ZrRoolExKuSLwxC5nW0sWhxB1orjDlVx3sJOAsqhZq3idjRU3u63ymonjdSBj5QOXuu5idd' .
+            'xbQR1RBHPXbN69R2tDQ3ifyTp2XdcMEYrWKWOOeIIkNHRysLl3QQhdG5lVyKgnAcad2I3/k5LmrM99xQPSrsceDngVHAVMhY05hmEnCT2nDbrjAqufflM966' .
+            'kYIte5PIl6lLs2bdcjoWthNF5tzrfR04UXhL3l5JTp02Pt1qp/31wC2V80amxb2dFpOEWO/byg774B1r3lOXUn/YPxJGSpGsbrtRFDF/YTuNTfXV5j7nBlFg' .
+            'xlHN65GmSpfT2t9+J0MR5wXeWfm55qUfTBMCum1b9Nbdve6mxMqVuYzXGxon1sZ6TtXg6JjfRjaboVw+e3Pxl4U16OW3ck4NxmsHilgKdjjnfqNy9lzNl29O' .
+            'BwKK6uo1PT3YpPY/Z6wjMg6RuFVPUI6YN28uCxfNj911ToETsBL/+8q+AReOozp+HpVfWuuul5eCBnzis+cy9PbW/GnsNe1fAGTbti0qe+RRr6WU/Gp9xusa' .
+            'HAsjEfEEISKgY1kTi5a0EIbFeMecvNxG4cJXUrurYt9ffjEoH9y08eOeiuo2vGbP//jIu9f+8t1/59yEfliTqOmno7sb1dODffiutTfk0/pHQ4UoEsQTp4i8' .
+            'AvkjV7Oo9AYiPQ6TDxxXDlfy8ZcdJXn9U7hiAtRLqETOgk7i3/Bn8QEzQI0vzVlhLEaAkee3P3PndT9/7fy/eyYYfOhFs2fPZscW6N2CpYas45qWgJvZpLay' .
+            'wz1suSuyzuCQal2vn1Q0JxdSfrIVlypM3W6VwxVS6PoC6JdZa1EQjqIXvQ1Jt9Zy2O0VQSunQcKG5Vev+tw9t78993Mr/37izd6LOLGzoGYJ6Lo3ebDD7rxr' .
+            '3Zsa0mrDcCGyiPgiQhgZVizpIBdmGPVKqFQY63xVKAdGgR+9jC1YbbHbhF54y3Ryu5wV+49YhkdCz0/k5HDfDXdu+diHjpGZHxg75lLZdkZPHPvpt//L3GPx' .
+            'E3vxJWHNErDa1f7+O+ynQ6PSFjGqklKVzdVR35AnCExFJJ5icDhOf+1MqEg/teQtkG6Ndb/p5XqZgLWgFPy/28Z46MlAshnw/FsWZJpS/xofCOvhp8BL+h8C' .
+            'vrKpG72jh+hiz7smCbhtC1p6MA/8p7Wb61Jq83jZWKmEl6x1tLQ24fse5VfbFs1G4OXwlr0n/nmakm8yMikhXyfUZQQTFV1YLBsAJ4RBMe2LtTUVL65JAi59' .
+            'U6e6/7pjCR3waV9jCzirRKkgCOiY305bewthOPrqOlyJwoWjeKveD35u2ut+VVgHxsYS0aEEqd5j5xA896oW7cKj5lbcbduiOw/vMqqU25BN6zcNF4xVojxr' .
+            'Hel0iubWRkxUKY0UB8rGOt9pf+3LqDgq7vGcnc9r2eV0Fi+N2pOAXb1WwN1/B3eFxopUmrlYa0km02Tq0oRFg1LgQg83nibOYD7dCnZl/8wkFAXRONK4CjXn' .
+            'qhpNt780UFME3LZti6ar1z7whbXvziZVZymw1SwPnHPMaW7AGotohyt7+CsOo/Lj4J3BejUK1Th2FhIK2ABvybvjI7amVyHZS6JSaTrxd8p7gMhr1U/4/FBT' .
+            'BFyze7cWMA/ClXVJnRwv2UAEba0ll6+jaU5jXOchQKRQbSfQ84+fefesfMYF3ik+ZYGoiDSsQrVe+8pPNZ8mCEIoBw7fi/XAKhwuPktHaiu7tmYm092NWrt1' .
+            'T/hg+vL5ntj3DY5FDvCrafT1DTn8hD+R2YwAoRcT7GwQTpd+IjgXxnW+OlkJu9WcKnzeaGtSLGr3yKQEW71053DiRHmUDvcx7JyTrt7aUHprhoAQc+P+zyuX' .
+            'zLBkrGSdEsRaRzKZJJurw1TKLU/+wrmeoBbXe6i6haj2TeBCqsbIdIeq2FG335oG0pPeccQXqDwIfijS/A3+yHm9XXLRfYBQYwQE0MpdHhpnqwcYOedQWlNf' .
+            'n8OYV0kUEbAh3rqPVoyOS8bw0EAE+nrn3LuAe2qleq5mCLiZTWqr2+Eevst8PuEpFYTWiFIaLC2tjVP6NJ83nAOVxBz8Jzi8o/LizNH/TsKhtabv2AAjI2N4' .
+            'WmOtdflMIjUamMZlb7nDue3dNXHhNUNAiLfgB+7gxGSOVQ2QC+M/daB87JF/nxFx37PBOofyfU48/TzHjg6QSPhYa4lyPn0j5WEA7r334k6ygpp4ClzF/fLw' .
+            'XWtvyiX11wuBqYssOjY1HCtXLyWbPYMOeL4QRY1c+msC5xy+73HwwGGOHu7H8zTWOZv0lArC6LGWtjnXL/71HWWqC3wRURsScHefCLiHHAtSvqofLkSh1krC' .
+            'MKK1rYl8PvcKCsrPARdR+rnK2SKvpedHABOFtLfP4fix49XusBKGFuvsFePj/Z4IpVo4BLs2CFiFc8XQOnex3HITjct13KrX4SZqiifOFhHQSl7R8XBTxiNO' .
+            'pPB9DQ5MpRmSMXZirLhw/gJfz2SngQBWxkfKuYtufFRRUwS0igynPJXnVeF2Pt9tHYmERilhdCz2NWolpOt8osDgJStLZRyFYoinX9p3eOp4OEjV+Tz93Aly' .
+            '2QQtc9KEYUSuzgcvHisqG6IodrTHi1BZCjl/UWXN1PUTcQpG0kDxPIe8oLjoBHQg0rMjeuyLV9SVQ3PXWNGAiOecQylFNlf3ik82Oh9Y6xCBVM6n/2iBHz/W' .
+            'x0OP96GUUJf2eNPr5rOwI8tzTw6TTvocPlYgldRsev18iqMB8bnSUy8IBamsR/+xk+MBtDSlyGUTEyQslQ03bpxLa3OaQjHismUNNDVnKuksJ+dmrCMMTxJT' .
+            'nfqdZ8Dk9RsZHkVEJLI2qk97daMFcxfw4V13d3rctiu84It6DrjoBJwKl65k3VcUaU1za9PpvfvOZ2TnJrRtqehgzjpSKQ/nHN/4zl52Pz3IieGAuoyHMZbB' .
+            'suHvv/kMc1syvHhsnMAGjBci3rx5IUbKeMnTi9/jbVu457sHePLpgYnxnIMXj43D0XE8TzFeiHXa79/3AtZCGFkWzKtjTmOK8fGIK1fPYc3qJsqFiFzWJ9eY' .
+            'it1IxlEuGao91atXFcd5Zcr1JhJxu+GhE8NorStuLHC4NDWCmiKgOyUrwDkwkcXzzs9hXOmfhwPSSR2HCxxY4zDW4qc8nnruBA8+coyfPD1IOq3JZ32MjaWH' .
+            'Ug7f9xk4UaIxl2Lj3E5EoHQ84vgj9dTV+RUdMf4+Yy25dB2PPLePH9x/kMZsZtJ4gpo4JCeWYiLgaYUVRy6bZGg44PhACescLxwd41/+/RBBYJjfnuWKNXMo' .
+            'FkOam9JsvLKVKLSIBq1Prk2pFE00E6kSNE5dO31pzmtBXwPUFAHPhHMVfEokvgkCibQ3MciB/cOUyhHJpObeBw9zrL9IKqnpHyhSKhvyOR9rHE7ioIExEdrz' .
+            'cUDC15TCgLGgyE2LrkMpReFwxKg9ST4HKFE8XTjB9uf30phPITiceFPGiz9s463VOOa2ZqjLeDzz/DBhaFEKkhXdMc6B9OgbKPCd749irSOZ0Pxo51HC0JDL' .
+            'JviFG+fHfj8lLFvSUHnIHEExqlz6RTd0XxI1T8BzgQPKQbw9hZHjB9/bT2QsSoTH9gxQKkcoFRsXooThEdBaqMtUJZlibKifTK6RVCbH2Il+RCkS6Tp87XHf' .
+            'i4+yomEhC/NzcV6AmrLlWXLJLN87/BP6gn7qEzksnHU8wVEODF1vXcbcRXke33WUUtmQTGru+/ER+o4XyaQ9xsZDwii+hlTaw/eEvuNFEBgcKnP31/ZMSNSr' .
+            '1jbj6TgJ4Rdu7KChwXtN9ecLgRlBQOfA9xX9A0X+4qtPkvBifWdkLJhwbWTSHmnxMCZ2TRjjEMDzYkmDCCYKWHfjW/m59/wm81deyf3/+Dc89m/foO/gcyRT' .
+            'GdJeiiPjx1mQn1speDpJQI3HieIYw6VxUjqJEzDhS4yXzqAV7Hn2BC1zUly5pjmWXgKXLW0gCC2JpOaRJ/rZd2iETJ3PgUOj7H9hlKSvoGKle1pQSvB9xSNP' .
+            '9gNQKEW8rrONxjm1Lf1ghhAQYhJqLfieolSOEBGydT7FksEYy9BIQHNjimzWpzAesuHKVhrrk2z7zl4y6djoSGay/Mpnv0wimcZawxt++bfJz5nLP3zhoxWp' .
+            'JTza9zQb5q45TeFPegkOjh5l79AL5JN1hCZ62fGUEh567Bg/d007pTDW36hIs1Qy9hfe0NnGDde2g1YM9Rc40lcgnfHYd2CEBx89RjrlUSxF9B0v4vuKUsnw' .
+            'xuvn09KaIQpevfH2WmNGEFAEwtDQ3FbHdevb+M6/HaAhn6RQjLjmylaam9KMF0PWr5lDR3uWcjkimUlwcP9wrLtpj5HBw7z5g1/C95OEQRk/kcRGIZ03dfGj' .
+            'b/wVh5/fg0omSXqJM87B4fCUxtceojwKg8d4ywc/ffbx9u1B6RTplIfnCSIqnouSKW4WZx3F0QDnYil+2fIGBGHRvCw3bpyL72kGTpR4+PE+MmmPw8cK5HM+' .
+            'iZRHWKwZf/NZUVMEfDXpQSLxOX71+QS/+b61zG1JUy5b2prTqEQc2YjKhmIhjG+wsQShreZ84flJjh14BussSmlMFKI9n+H+IxRGh9CeVzlB/aRlfWqitbUu' .
+            '3s5fwXhKa7QWTgyX+dOvPIFIrL8uXVjPxqtaCcuxLjvFuKhY9SY0GONQlSL9hvoEb37jokqlgWFoJKA8HuB7Z7m9NZCGVUXNENAbi6SckvxkndkgRPFJBGeM' .
+            'mOtJr4oIUSliwxUtCPG9kmzsX0vqmCpeQuGlNIWxgHI16gBYa0jnGnjw21/lurf9OvOWro1fNxH3/+Nfc+zAT6lv6SAIiiAOTyvEQOTsxPk1zghaxzqlMeEr' .
+            'GG8eJgpxDo6fKE2kBDzyZD8/rjiuY6mqWF8xLhAolQ0br2xl0fwc5XKEANpTpD0FFpSnaGrNEIzH0ZfJRkhsqQPO5V/t/bpQqAkCOoc8+1+CcHw8+W8JX36+' .
+            'EDqXEBFdHGP80Au0rVgUFzuccpZHcEoqvaOiC/oq7kWkBFOK+PHjfRXHM/gJxX0/PkL/QAld0bVif6Ejk2vgLz/+i1zz1vex8LKrue+ev+LYvqfJNbVhTYCn' .
+            'PV48Mci2J7fztpWvR+v4+8QqwswYl28qsse28MiTA2TS8jLjxQGIUsnE8WUtCFKxdmM3jCOWqjuf6JuQuNbBT/cOkUhoxEEQWVqbU9y4sZ0wiN071sHaFY1A' .
+            'xOEXjk04oTUipdBGgvwbwOjh7EU3kWtCQ3Xdmzzp2RE99IV172zMed8oDBXCZ7PN/n+b10m9diTT6YknWYAAoUMC/sx7kbASObHWkcr6PP54PzseOkJdJn62' .
+            'yoHhuf3DINUICySTaiKWW3Wl2OrW6hxBcYwoDElmsni+Hx9uSCxN33XLUuqbFNkDa9GFLCQibMEns+YwDWtH+c4/vsD37z9EQz6JMe5lx3vnLUtobc7wv7cf' .
+            'ZGw8wPc1x/oLlCpbcDLpkUyomOhCJYHBTZxzJyIYaymXbSXKEVv4n/7YVcxpTPLIrqdxcRqb85RIYNzY9Z/enQOqRyPPpmNNQGw+sjgPx5hOsLOhg1xYJjIn' .
+            'szoUUEBYSXnK06O1MD4e8uCjfTx/cIRkUuOsQ5SQzyXi1VYyUYIeBGYivuocpJJV5y+ksw2VQ25MpSRAKJUN7/3F5Vy1vg2MIWrro/BEiuhEhsyafhKLRykP' .
+            'wC1vXMjwWJnHnx4gk/Iw5izjlQzv/aXlXHVVK4SWD9+6GmfB8xU/fryP44NF0mmfJ/YMcOjIGMmEJjIWa2K+eJ6aIKanNUk/jog4YkmvKr5OhUw0B6yEqd0z' .
+            'f35NfsXvPDxKDVTk1xQBnSOZ8kXGHGjnyEYBWRviRFFdJwUkEHKTokmxH1DTd3SMPXtPMKcxWQnkx+lOYRi7I4JShDHxQYRzWzK0tmTiUJ8Wnj84wngxIpP0' .
+            'gDhFqrrlDQ6XWbYgz7rLmiiOlEAUIWX2l/YTDTWSLrxAy5CQr0ujlPC6jXN55MnjFIoRqYSeGI9KLHZoJGD5ojxXrWumNBJgOVlqEBnLxvWtxOm4Que6ZkbH' .
+            'QpIZjz1PDfL4UwPU1XkMnChx6PAYnlYoJSQTupKAED8s1kK5WMa4aKJ4y+Fw4nLHo4fDlZxyMvdFQm1swQ7p7dqi5l2xZ3E6o7+TjYKVD6Tb+NSKN6lcFGAn' .
+            '6X4KKCIslzI/8J8jqGzBEDdH+MZ3n+fBR4+RTMS6XbbOj/1jZcPGK1pYtCBPYTxkyYIc7fNzEBjwFM/uG+KhXcd48ukThJHBOodWQrYuwes2tHFD51zq6pMQ' .
+            'Gkj7HHhmiC9+5RHq6z0Gj0e8/ReWcMtNCykMBySTmv1Hxnjwx8d48qeDhJGZImVft2EuV1/eQibtU5fSiK8mzGoXWYqVMJoDfE/heWqCXCICnmLweIGn9w6R' .
+            'SXv0HS9y34+PkkpqRsdCVizJ8yvvXcP+p/cxeHSskpLvTDaldaEgf730hfd8wo6nnQm0/cve/kIPPRctNlwTElAEt727T2787O69P/zCuv6mhFzm3Lm1lTXG' .
+            'kW5I0jonzerljbS3ZSgUIl6/sZ2W5jRBYMhm/NglYx1hYBgfKsd6lRJWLGtkxdJGDr8wyv27juL7imzGZ/N189ANSQ799ARPPDWA78f6Y9/xIvlMkqTyqMsI' .
+            'vi8TTuQosiybn2fZ/DwHXhjlRzuPkkppnnl+iJHRkCd/Osiju2MJ+XPXtNMyJ01kLFHkmNuSZvHSBqioB3HyRNVaj4VWWIrIpn1u2DA3fj1yXH91G74fx7ZH' .
+            'RsokUxrPpVj0xK0kVAaHVUqBhOl3WKL3Io6kaPmD99at6/k6+113t5Kenz0Ra4KAVXR3oxTSfz45qFoL4XjIulWNbLquHT/tgYUoiPWuTMojjCw2MKRTGj8V' .
+            '98tDCWEh5MVDo3haSKc0b3r9fP51xyFGx0L+9n/+FIAXj4xzYriE1rE00lqRTmlM5eBrW8nfsy72z5VKcTRmwbwst75rBaQ9/uZvf8LgUJmh4QBHLNG+d98L' .
+            'E+pCFFka65N0zMtiIzshAW/6uQX4XqyGGONobkrhZ3yI4q4OSsfSFWBea4YF7TmGjw0xNDRCXtIokwSsOOPQ2s5xTk04zsthdFGr8muGgPeyw/b0YG/8z4nb' .
+            'y8XgHSqB0s6ina3k78UbrSKetHcG9cUay9zWuvj/Qeyj87RQzUjSSkgmNT9+vI+BEyU8pdC+4oUjYzzx1MDEtm2tw1QyXZQSrImzmxvqkxO6YdVFUk178j1B' .
+            'pT3SkUO0EJTjg6/D0BKVLGnjCEKLsScHiKJYN/W8ip/S84iM5dm9QxPKkXPw7P7hiXy/cmC4YvUc5rdniUKDsY45jSk2XtlKXPPh4vMajCEoB4hyOGtB4qc6' .
+            'si6uNgAXOXvRVbCaIWAVPl6yLiEqQNwJP00kGls5dtVWMluKTmg8xZnvXOyQ7TteZHAollRax+nw37vvhThNy8VdRPsGigSBjX1tzuF7VWnmUCqu4VAmzlax' .
+            '1pGppHUZc2ad3dPCwFCZ/c8NERYjrIOlC/Ok0ppSMcL3FCaybHnLstjyBvyEZv/BYR58tI9UUse5e9bx3P5hrHMTem3C15UaFIfDkU5p9jwzyON7jlcsa0ei' .
+            '4tu0lTY31sEN6zySCW/igZkMAXG4aoO7i4qaIWBPD27bti16aN+LRwetfGO1P/7O/7h3h0nidGQMDU31NDU14GzcBj6HxUwyQJxzeCmPR37Sz7e+fyDO76uE' .
+            'rjytptwF31MTZIp7TlsSCU0qqRFi3+GyRXk617diQ8v/3nGI8UKI1qcXI8U5e5qdT/Tx4CNHERX76ZYvrufGjXO5fG0zpfE4/NeQT0zkKwLMubyFzitbqUwE' .
+            'ZyyP7T4eu50c+EnNI4/3se+FUVLJWOZHkY3Tsyrx4moCRv9gaWJOxjqKpSSpdM0kPp8VNUNAwK3ZvVuv69kzev+d657okPI7397/tEGUds6hhxWr6i+DhF/N' .
+            'RSc4tbWGg0RCk0zEhoJVsSSpOm6r8Vqd8rjmytZYOigIAlsxVlJEkcXaWKdKNCT55j3PMjoW4PvqrJVw1XSwREJPeHf3HRxh36ERbrWO9Ve0UBwNK9ku7pTf' .
+            'nRxOhKuuaD35psCaZQ2Ugzha4nuK/uMlfvjjIyQSaqKx1+NPDRAEZoKUSutXVDdSC6glArJ2657Q9SCP++qrA0X7CZvK1EURThQShQZeGGTxsvlExqBEpsSC' .
+            'ARChVI7IZRMTvsBS2XDFZXNYc1kTUdngiDOOFy2uP0kGAVu2GGtRfnzzPE/x93+/h50/6ac+m5iIlMDJ6InDTYlQxMkKQCVzxVjH1775LADrL2+hNBbGznCZ' .
+            'POWpRCkVptYIKSWkU95EmWjH3Dpufc/Kkx48ETZe2Uq5QkBnIv79gQPxdlwR+85hkdM6tk+qkrl4qCkCiuBcd7da//s9+x64Y81fN+a83x0KI6Oc0g5HVCpV' .
+            'JuxO12tEMIFl2aI8113dRlNDaiLZQCtBtJxMYbGO4lhwcvummsrvSHgaK/C1bz7LI7v7acglYt1QBFGxBC2Wozikl9D4nqJYjh3cWsuEPmcrTudkQvMP33wW' .
+            'HKy/ooWwFE1YvWfCmSRXVZWAOHxnQzNl7os6spVkViEslhle7mGp6KxWkfY9ZU7hn8NJQvkEUemiisqak9POdave3j2yeO9jizLJ1IPl0DaFFqVExBjDisuW' .
+            '0tiYIwyj025iTApFZNyUYqHJ1WNwegVZ/BlHMpvgsUf7+KftBxgthCR8PRFzDcI4opJMapYtyqO04sUjY/QPFFmxuJ66XIKx0YB9h0bRSkgkFFrFhlC1+Lyj' .
+            'PcuvvmMFuXyCcun0+Z//msX104lkgr0/3c/x40P4vsZZZ3M0qlJB/2Dpnvd/uKytSho1ycmV4rkDY4c27LrtopVm1hwBAXbe3elvuG1X+MCda/+ioU5/ZLgQ' .
+            'WUE8Ywz5+hzLVy466807n9YXzoHyhCd2D9D7T3uBWAeMooqhomDD5S0s6MjhKeGKNXPAUxzYN8ShI+NctbaZusYUY4MlfvL0AOmMx30Px3UdYehIJhTWOYol' .
+            'Q8ucFL/67lW0NKUwkTuneZ59/nEV3+hogb3P7JuwhsFF2YyzJ+zxa2+8vf+xV/9NFx41ScCKWsXOP+mcY8LiUUGUBZSIlMsB8zpaWbx0wQXpF1Mt6ClFhru/' .
+            'upuj/UXqcz5jhQhnHe9750pWLG8goQSd8sBYSpVQWTKpEV8TFkNM5NCe4KdiJaE4HiLAN/91Pw/sOkp9PkEYOvI5n9dd087rOucShReo2VIFTzz6NFEUoZTC' .
+            '4aL6jKdGxs239P7XdeXXHlQrBq89TdJdjOjHlO+/mF/+UnDbtmjp6jUP3LHmi815/5PHR8NIi3jVtPXV61aQTPoYcyGK1sHzhWLB8JX/8RTP7Bti07XzeP31' .
+            '85jXnCaKYsd01WKt6mlVo2Nylo2zJz/jaUUUWfa+MMr/+u5eEr7iY7+2jrp8gvL4hWm2FBfw+xx58RgHDxzBqxRkIdiEFlWO3PrrPrX7cdeNkp7aqQeuonYJ' .
+            '2N2ttgJvyd2zPCPuh6GxcwLjRIlSYRgxd14Li5d0EJ258PqcYStdEgZPlNj5RD9vvLEDreMCJ3WeRKkazslcgv17h0inNK0tGUrFCK0vDPm01oRRxE93P0ep' .
+            'FKK1wlpr6jOeHhqP7rn+M3vedbHivK8ENdudW3p67GbuVdd+8olnRkvmf/qe0nFJRtz77ujhPg7sPzy1c9WrgFJCuRyRzyW46Y2LiCL3qsgHVfcMlEbKLOzI' .
+            '0tyUIihfGPLF4wtBEPDTPc9TLAYx+ZxzWokBRrSWP+nuRrF2T80KmpolIMTxYdeNytapP4wMeHoyCX2OvNhHqVg6ue28SlSzjYtjQRwHvkD6mVISx4SjV9li' .
+            'eBKstSQSCY4dHWB8bBzfnyiaMg1ZL3FiPHrwmj/Yff+8I51aunprpgjpVNTsk1HFtm1bdMvuPqlLHn93OqX+vhgY55x4IiLxtplg5eql+L6+IPrgdIBzDj/h' .
+            'c7xvkP3PvzDZCW5TSUVk7LNJxS8cH20+snnrDiNnrumqCdS0BATo6uo1m9lsr/n07q+PFs1vNWV93zrC2PUAhUKRn+55nigyleKbiz3j1xZVFeR43wn2Pnsg' .
+            '9nHG5HMJD2uNK6DCGy//5O5D97LD1jL5YBoQsIqdd3f6mYR3z3jJ7K7PqIR1zjoXpzAViyWe3rOXKKq2LavpNT9vOOfwPI+BgSH2PnsArfWEH1EJNp/xvFJo' .
+            'vrzhk88cd9u26J4atHpPxbQgoPT02M7Du8z633+ib3A02Fwo2ydTvqpEvOI+guNjRQYHhkgkE5Ut6WLP+sLCOYf2NCLCsSNxD5iT6oaLUglhaNz88Q2feeoT' .
+            'O+/u9OnqrXnywTTQASfD3d3py227wh/dsfod85tS9xwbCkoOklSuQ0RoaMzTsaCNRDKBiS6so/diobrtDgwMcexIP+NjxdjZHG+9JpVQuhSY8es+vSfrKh0+' .
+            'L3a55SvFtLs727s3eS30q/GUuqMppz85MBJGUjmAL3ZLhGSzaVauXobva6JJuXPTEc46/KTPQN8gzz17EGDC6rfO2YSnJKGlMB6Yt3lN6R92fn+pld7atXpP' .
+            'xbTYgifjDT07orXsia791JO/PzgW/VlTzveccyFQaUvrUyiUJgyTZNKfljrhhBM7leB43yDPPXsArdUU8vmeUkoRnhhzb73uU3v+7duHd5npRD6YhhKwimqo' .
+            '7uG71v5pU9a7fWA0Chz4cWqeEEURmUya1rnNtFT6TFdz92od1jo8TxMEIceO9tN/bHCiCwLE+X2+J8rXFEZK5pYbP/PUD6sJHBd56ueMaScBJ7Cl127rXpO4' .
+            '5g92/97wmPliU1YniGscbNVaLJXK7H32AIcOHsH3vQsWgXitkUj6RFHEM0/v48VDcaOik+RzJumLSmgKI6XwF2/8zFM/dN2bvOlIPpjGErCKqiR88M41/zmb' .
+            '8n6zHNlkEFmrRCqBDMEYQ319jrb2ZuobcpX8vAsXlbgQqKZUOefoOzpAf/8g5VI5PmYrTnCwgEv6SjvnBksl+/brP7vnvukq+aqonTtwnnAgvdtQXV2Y5//i' .
+            'qkUDY8G/5NJ61VDBWOJEZqpbsogiX1/H8pVL0Fomkk0vFhmrpIPYnzl0Ypi9zx6cSDOrdrVyYLWgGrIeJ0aiLz26f/Bzt335SKFWM1zOBdOegFVs27ZFd3X1' .
+            'mh91X9GaydlvGeOuAXHGWgvixQRzcSveVIK2uc3U1+fxEx7a00SVDOvXmoyTx/d9j2KxjDGGo4f7GToxgjGmcvSCq0Y5oqSvPN+T/kLJ/t01n9r9CYBtW9Bd' .
+            'vefWPaIWMWMICJXeP5XQ04/vWvOeVEL3AoyXbYDDF4kNlPjg65iQ+fo8c9ubyDfkcZXzQYwxJ9vBXaCcPaASuYhJbozheN8J+o4dp1QKKpkzalIZgTMIMifr' .
+            'qWJgnzSUb7nqE8++WD1ZdLr4+V4OM4qAEJOQrZu09OyI7r9jza2NGe/3RNE5XraEJj71Wqm41FNEiMII7Wl836OhqZ6GxjzpVJJkOok1FmurZGViu345xH7H' .
+            'ijRVglYKEWF0dJwoNBw53EdQDikW4wL6aif/Su1KhBMvn9GMlyxKue8dH9fvu7nnib7t3Zu8N/TsiF7bFfzZYsYRsIpt29BdXfEWtfOuNb8WWbbWpfRiHIyV' .
+            'TSSIrkpE59zEoYjGGOob8qRSSbTWtHe0Ut0OYz+cx0sJHweEQRiHzpSiWCpz9Eg/vucxODBMUA5i3Q4m+sxUW2WIcy6f8XRkbGic3FMI+asbPvWT78NU6T6T' .
+            'MGMJCOC6UfTgBNzBL12XPhqNfiDjq19P+GrjWNEQRtY4EZFJ7qjqFh2fT6fwfa9yqpEll6ujubVp0hY+FSJxnt7hF/ri5uSV1hlhGAstzzu5BU/M0blIKfHS' .
+            'CYWxDl+rrzmiL667fc9jEEd+NvfsMDNlyz0VM5qAFcj27k26unVtu31+ev3i5rcOF8MvpJNqeWQcxbJzopgwh5XIBCGrklEm9adBqhUgZ/y6yvnA8Wfi7XXK' .
+            'Fl4xHEQ5nGus81QxtEEQuh9YcXde/wd77oOqdb9FddVwMumFwKVAwAlUfYbVnx+4c/VvJzz14ZSv14bG4WshMo5CYEIREEQzdY3klRglFQnnJv1sAYuIzqaU' .
+            'EoRyZPGU4Hvy38dL7q83/Ief/BBiiVftFHahrruWcUkRECrdWHu3qC27e530YLd3X9mwtM02HRu2f5BKyKpCYJta84l1obEUypaoemI6DmtdVG2ucCb5J/H4' .
+            'iIjSKpai1jkyCUUqoRgvWUqB2Z7PeHqoaP9qTib5wMrf2bUXYnWhdw8yE1wr54JLjoCTcSarcufdnZm6ctQ1Oh5EFvWJpM+KcuAsgq7PeJmT3arPDCXCeNlQ' .
+            'Du24iJhMQnQhdP9f0ufhKJDRDZ968p7Jn79UiVfFJU1AqLptkN49SMuaTTKZkNu7N3lrWvpTR4qeK6goqcr8kadVwpgz744OsfUZpUYL9qGEr/97aaygr12W' .
+            'MfL+J8YnjwmwmR0WYLpHMmZxgeEc4ro3eVWiXAh0d6Mu9JgzBZe8BHwZTOkguuvuzldEoM7GpXZySvxMdaHMYhazmMUsXg3+D9uJ4PDTM74OAAAAAElFTkSu' .
+            'QmCC',
+        'image_width' => 160,
+        'image_height' => 160,
+    ],
+    'katumia-insightful' => [
+        'emoji' => '😼',
+        'label' => 'Katumia Insightful',
+        'image' => 'data:image/png;base64,' .
+            'iVBORw0KGgoAAAANSUhEUgAAAKAAAACgCAYAAACLz2ctAAA9QklEQVR4nO29eZgdZ3Xn/znvW1V36b69qrvV2ndZLXmVvAKWCARIWMKmniQwCQlJPJCQAcIM' .
+            'SwZaTcAYCD8m80tm4mxMQgKJmoyTMIQEiG0F71jY2JYsr7IsW1tLLfV2t6r3PfNH3dtq2ZIs25LVLfVXz30k3Xurbi3fOvs5L8xgBjOYwQxmMIMZzGAGM5jB' .
+            'DGYwgxnMYAYzmMEMZjCDGcxgBjOYwQxmMIMZzGAGM5jBDGYwgxnMYAYzmMEMZjCDGcxgBucg+vow2od5pbedwQxmMIOzB+3rMwB3/d5Fi7d+cc26zRux9fdO' .
+            'ZVvtw9z7+TUXbP38mosm728GRzFzQU6G1dsFQMLkHYnXW3sHcNCPnNLG/Ug/PsZ/Jzb+A5P3N4MZnBIU5Ja+hdm7vtDz7CP/42K9/XOrfhXglr71wcm2q39+' .
+            '++dWv3H7f7+wdNf1Pcn26y9vB0Q5Rf6eJ5iRgCfAvTeuDVHI5wofbMkHnZXYJbmM/dADX7iwdcPqTlU9IZGkMGdMdn5tfTa08hHnyBZylmGK/YBuvXHtScl7' .
+            'vmGGgMeBKrJ2z1Z3+5dWNhr4cLHqg/GK+sasvaSo7k3SO+AY2Hjca7d5I2bddVvjXU8fvLAxZ944WnauXPUUsqb3ni8sX/Jk6xKvOmML1jFzIY6DgYGNRvrx' .
+            'Jg7e35gz8yux91YIihXnvXI9AL0D+tzttK/PbOtBb/vihSvbG+3/KVddbERM7JQgkA7ngw/19g44Nr3SZzR1MUPA56CuWn/8+Us6spH5UJx4J4CCqcTetReC' .
+            'uXd/YfWvCfh7b1wbHrPx6u3S34+3ifu1XCTzKomKCCKIGS87H4X2/T+8oWeB9Pf7k6jw8wozF+E50L71AWzxd2d7PtDeGP7hwZE4NkZCAAWfDY2JnW7PWn3T' .
+            'mgU9e9g44EVQBdnUh7y1sLbNxaV9gpiaiBQAVY3bCmFweDz578XSrP9amDMm667bGp+9M50amJGAk6AgbNriWL1R1LNpuOhUjEw4DQKmWHGutcH2jFb0z6R3' .
+            'wP3JdalTsfXGtUF/Pz6uljc15QPxqGPSAy4i4dBYghX5QL5hcNbaPVtd30yGZOYCHINb1lsR9O7HH/pIU97OSrz38hwtYY2Yw2NJtbUhuOqeG1Zfs6d7q3uo' .
+            'ryf69p6t7p4vrHp9Q0Z6i2WnqNjn7V/V5zKSdTGfln78Btaf99f/vL8AdWhfnxkY7NTbv7ykMxfaX0+8eo5voojzaoEm5/Rj/f341atXu/5+vFP5mjXSETtE' .
+            '5DjbClKpelfI2nff/fsXrbiVDf58z46c1yd/DFZvl97eAWfi6N35rF1RqngvyHGvj4jYkbLz2ci8457rV18uvQPuri/0/EZbY9g5VvZVkeNfV0FMJVHNRqbT' .
+            'V5Jf7+/v9+d7duS8PvnJUJDv/sGyqL0Y7QoD6UiS1PM98fc1acsHcqTsbrri49s23vf7a7aJSE+56r2c/MHW1KtWX1Df1fOpHYcUROB5YZ3zATMSkDTrIaBt' .
+            'pcx/bm0M2quxumPIJ5K+JkGQ4HDRGQNvufv6VX/sHD3liud55Hv+tuJR15QPZETN5yB1YM7YyU1xzBAQWLuiUe+9cW0oynyvEjBZM4igLsEn8fNICIhXsg25' .
+            '4Drn1T/v45Nsq4oxVrrv+Mq83NoVjeel9IMZFUw9FPL27MULCNzOSqI62fP13pFvmoUJQsYO7cEGIarH8kVVncjzvV71jtykbY0NOappNWnOB8GRsfjaK6sP' .
+            '387qjSK9A+4MnuqUxHkvATew3vT340s+uT4MBFR9/TMRwScxS9a+kRVXvwNQvH++sDoe+UQMLq7Utn37caSnmEri8XCD9OPZ9vzU3vmA85qAunGjvZUt/u4v' .
+            '9VzSnLNvqlS9o+b5ijEk1TJtc5eTb+4kzOSYvXwdqgnyfFV8DEQMcXmMjsUXkWvqIMw20LnoQpJqCTnqWEucaNKcD9fefcPqN0o//oXKvM5FnNcEBOjvx/uE' .
+            '3woCaY2daj1+p6oYG9K17DIkCHFxhUWXvZGGli7iaumEJKxLvo5FF7P8yreBKqjSufQSwkzuGAHrvCJCxoh85NE/WJapv3/mz3rq4LwlYB8YGRhwd/3eRYtD' .
+            'K+8fLiZeJE27iTEklRKNbd20di/DVcuIGDSuMH/Na4iyhefZgXWo96gqc1ddhaqiKC6u0Ng+j5bupcSVImLSyy5IcKSY+Hxk3niklFn72v4tSV/fDAHPC7z1' .
+            'xrW2rw+jJukvZK3zNdEkIri4Sr65g2VXvQ2XVFNpJ4JLYlrm9zB72aVUiyMTRJqAGFQ9y696G7mmWRPbirG4SpHFl72Blq7FJNUyIoICBlRRr54bFOR8S8+d' .
+            'Vydbh27eaJ9sXeLfllu9spC3bx8pJQp1R0JQ7+hcfBGZxlbUH3VMxRhccYSupZfSPr8HF1cmnAtjLHFphHmrX8WspZfgkvIxalq9J8g2MHvZpQgy4QuLiC2W' .
+            'nWtpsOvuvWHN6zewxet5ZAuelwRk24D29g64itNPGpGC92m4GNKwS6ahha6ll+AqxclOA5DahmG2wPw1rwEk/SNCXCnS2DaHWQtX48rjz9tOjMGVi7TNX0VD' .
+            'Wzc+SSbI6xETO3Kx85+Sfjxs8ZwnOO8IqH0Y6cfffcOq1fmMeVep4lydLXXvtXvl5dgwO9lhmICIkFSLNLTNoW3OcqrlMVSVhpYuVq3/eaJsAfwxlVhHf7v2' .
+            '7rwLrsZVS9TrFQTseMX5xqzdcOfvrd4g/fjNG3l+Nc05iPOOgFvnrLVpw5H9SC6y+dilVS8ignMxbfNWMmt+z1Hb7zgQEdQnzF11NfmWTirFEWYvv4yosYWk' .
+            'WuYENQypfZnEFLoW0rX0UlxSpU5URX1o8TbgU3d8ZV5uyevXnhf35rw4yTr6+tKGIRnxcwLL+w+PJ15kotoZARZf9gbCbMMJpVgKwbsqDZ2L6F6+ju4Vl9O5' .
+            '5BKS0jjGvrDgssayeO0bCMIsWrMGBQmGi8435uzrJW5au+66rbFu3njOS8HzioB1D7MaV38/SrMeCrWwS7lIx6ILyRbaSCqlE0qxOkQsrjRK25zlLL7sDbgk' .
+            'fsEAdR3OxZgww+wV646xM0XExIkXPF8GoHfgnLcFzysCAjzU1xMZkQUTXJE0Zxtm8nQtvRS8P2UigRJEuYlg86lCakUKHYvWkC204d3R7IoHjDD/lr6F2Rd1' .
+            'YtMU5w0BtW99sIEtvpw3P9vaYC4bK7lYRGyauajSNncFDW3duONXvZx4v8dxVF4YaY4509jKrIVrcG7CFjSVqo9bG8PZ+Vzhg2itQf4cxnlDQNjipR9fTfym' .
+            'UlUDauRLKmWaOhaw5Io3p57piyDfy4EYS1IaZ8HFr6Vj4ZpJGRIJRsvOGvjw7V9a2bh2z1Z3LrdwnhcE1M0brfTj7/7cmnc05ezFpTitWlZNJ7XMXnZZ+r0X' .
+            'oUZPC2qquGvppdggg3qHGKQae9+YM/NNHLxf+vEDJ5jCcC7gnD2xOlSRWzsOyG1fXFmwIR8TIU3WInifUGifS9u8Ffik8rzg8ZlGPe3X1LmA1u4laXAagwBx' .
+            '4l02Mh/68ecv6aifxyt6cK8QznkCMrDRbNiwxVlnXlPI2WtGSs6ntp+QVIp0r7gcTPDKS79JUOeZs/JKvIsRVUTEjJe9L+TMkqqp9m7cNqBsWn9OhmTOyadq' .
+            'MhSMgL/z+p4Hc5FZXYlVRcQkcYU5K69g/pr1x3ihZ+soxYTsf3wrT/3kZmwQoagGRogTf+iq5atns3HAk+YLz6nC1XNaAt5yy/pAwN/x+TW9LQ3BimriHWC8' .
+            '90TZRrpXXnGCBt5XGgKa0LXsMvJNs1JbECTx3jfl7ay7H3/oIyIot5x7UvBcJqAMDnbqLX0Ls0GgH0k8kfeIGIOrVuhaeglRvgkXV19U2OVMwXuPsQHdKy/H' .
+            'HbVHJfHqc6H99du/vKRzYLBTz7VG9nPqZCZj80ZMb++Ay4WF1xWy9qrRUuLFGOviKpl8E51LLsFVK8+v6TtLEDEkcZn2+atoaJ1NEpcxYkyp4n0+a1eYOHp3' .
+            'b++AO9ca2afG1T8D6OhZLw/19URi9bPOqTM120lE6F55BVG2EfVTLNOlig1C5lxwFdZGaVuAiBktJ96K/fQtfQuz51p67pwkoPatD17bvyUZy5ufbc3bC8fK' .
+            'zhtjrauWaZ2znDlrXkMSl8+y4/F81APjHcsuo2vZJWlO2hhTjdW1NNpZ+UzhgwJ6LmVHzjkC1kes3fGVq3I431+MNRTBqipiAuasuBxfKU458tUhIrjSGF1L' .
+            'LyXKFfAuAZFgtOQDa/nw1i9eOmftb2xNzpXRbufESRwPCxtjAVbHiSJixSUV2uatoKF9LuoTpmwESgT1nmxjOx0L1+CTGGOMVBPVKJT5zifZTZum6sG/eJxz' .
+            'BNx649pABH16sPS7zXmLRxNVFail3OTUU26qiqqfeKXzdl/olV7StDvO14oVXnzoTl1C59JL05ig8xjBC2ji/ef6z6HZgufMkwS1GX+rt8vy3ffPNmTvdN7P' .
+            'jZ2QVEpm+VVvpWPRRSSV0gk8X53giQKoEkRZMHbis7g8lpZdneSqqSo2iLCZWpkWgo8rdVU6eWTqyc9FFRtGjBzYxfYtf4cJIg2s+lxgR8aS5Kf+eXz7A5u2' .
+            'bxQZmN7jPM6t7qvt26W3f8Dd+flVv9LeZOYfHvOJd3HQ2NZN69wVuLh63CYj1GOC8GhhqDFgAg4/+yjV4gjGWrxLeGb7nSdV32nJfZXCrHl0LLoI76qoS2ie' .
+            'vYRscwck8UT5lndJrfjg+LFlEcHX8sQtsxdzZN9OSQg1yEqrL/Nb/f382qZzoG/knJGAdbl0Z19Pa5jjcWOl2TkjSbUsSy9/E53L1pKUxiekX10N2zBCggzl' .
+            '4QOo95RHh3h2x50EUY6RwV3E5aON5DbMcPJLpgiC9w6fVEEM3ic0ts0hyjUSRDnmr3413iVkG1ux2UZ8pYhPMx/HmaDlsVGOI3sf55Hb/h4bRID3RsQkVbPk' .
+            'qk8/sLMPTH9axzotcc4Q8N4b14Zr92x192RXf6a1Mfj00JhzPi6HuUI7F73x/WhNBdaJF4QRiOXQ09spjhzk0O7tlEYPY4zBOwcoNsykEqq2zSkXn9bswbTR' .
+            'RPBJtaaCDcYG+KRK+/xV5Js7aJ9/AbmmDtQnuLjyPImo6giiPNtu/RuO7NtJmG1IWrIiQ2PJN/6luv19b52z1k7nafvnBAFVETYhD2YvbK4afVyh1TmPDUJZ' .
+            'duXbaO6YP9GzYcMMijJyYBfPPnwXowd3E1fLhJl8Kun0qCDStDJl0u/oKTgwgjGTL6vW5GJtLmptny6u4lxMJtdEx6LVdCy9lHxzJ75awtcC5CmJFbEBxZFB' .
+            'HrvjH6iWxtQGxuUiU6pU/JVPLOl5dCMwXUe7nROe1K2b1lvpx48599F8xrR5xfukKrPm99AydwVJXCHI5DBBxJH9T7LjtgG23/pNRgZ3IcaSyTdN3OxUbB0l' .
+            'WRwntVeMeiUILNae7GVIJrZJSBJ/tPFyQpKmDkaUK+BclWd33M22m7/Oznv/hbgyThBl0jmE3tckaExjxwJmL78Mn1TFqxEjUqg4/WRv74CbzqPdpr0ETFcj' .
+            '7+NHhW/NjVTuFGF2KVZBMZe86VfJ5JsBw+G9T7DvsXs5cmAneE8Q5dKWyBoppKaevfe1HqOUbG3tLQA45yk05ZnV0YZz/gROrKDq2fPMAbx3GGOoVGOOHBpG' .
+            'jKltI1grte/Wf9ug3uGSKkGUpWvJJelot5YufLWM90k6QQblwe//JdXyuEaB9dZSqSTuiis/8fC2esP9mb/ipxfnAAHXB5vY4n8mu/oT7Y3B5w+NuzgpjYUL' .
+            'L3kd8y68liPPPsaeHXczcmAXWrfrakSZ6ETzniROyGQzWGuY1dlGodAAQFNLoRZ6SQPEKflOdNnSsIu1E22WxHHC6MgYNgjY9+wBSqUKlUoF7zxBGNT2pahK' .
+            '7SHwJJUiUUMT7fNX0b38crKNrWmbaJRhcMc9PHrnTYS5QtySN+GRcffnti3zAYDpaAtOawIq6ZSf3f/fVdlnKyMHA2uySZJItqFZuldcwZH9Oxl6+mEwNvV2' .
+            'OWrXee/xPlWLhUIDzS0FGpvyNDc31chpUFWcO9a0OpUU3mQ7UUSwNo0l+tr7g/uHqFaqHNh/aGL/QWBr26ZhIJ8keJdgwwyzl1+GMQHqPWE2z8GntzM2tBcJ' .
+            'Qh8ajHF28T+Uf/I0pPMOT8e1faUwrQl4741rw3XXbY3v/FzP59ubgk8NlzwucYTZBlxSJS6PEWYaOGr8AwjVakwunyWTCWlrb6V9VjNhGOKcn1CvWgsin46U' .
+            'sU5S85CSTYFKqcrePfsplSqMjRYn1P7k31ZVkmoJSAcnRdlGwmwDleJIImJdY07syLj/5jX/bfsv3VIrwnj5R/zKYdoSMC3M7OeuhhVr8ib6rvdkS7EvBtbM' .
+            '885NzOWrh07S2S8OVaV7bhezOlrJ53M1my+1/V6pAoU6IY01GEntwSNHRtm/5wBDQ8NEUThhk6bHXvMVJR0dhzpaCxmcV6yA8zA0Hr/+e9WHb5lu2ZFp7QVL' .
+            'P55K0OS8fHBoWK9ozYV/IagXY5SaPVVHHMfk8zkWL5nHgkVzyGQi4jieIOArWR1TzxurV5LEkSQJra1NLF2xgDlzuyZsx/oxTeSjvcOIoJj48Ghy40gx+frQ' .
+            'aPy1wMg3YPqpX5jGEhBq/b69A+4PPrQs86r52fta8nbVwdFkYqWiuq1njGHh4rk0txQIw5A4PvU5Lq8U6g9BEAaUxsvs33+QfXsOEIbHLguh4POR+Gqin1r3' .
+            '8W1fPouHfFowbSVgnXw/+NTyuesX5e7PhbJqcCSpTl6pyCWpKl62YiEdne01yTL1yAdH7cO4GhNlQxYtnkv33C7iODlGQguYUlVNeyH80t1fWP3/A+z82vqs' .
+            'TtP6wKl3J04BdfLd0rdiVmsh2hJa6RktucSIBGn2K3U05szrpHtOF0FgXiB8MrVQJ5yIUC5XePKx3RSLRYLgaP9ybQHs8PB48tUrP7HtozWHLGGatW1Ou6em' .
+            'rw8jvQPu//b1zG5qiG4PrekZLblEJpEvrsbMmdvFwkVzsdbg3Ctr471cTI5P5vNZVqxaTC6XJUnS4HbtO+HQaJy0NQQf2frFNV9ed93WePPm6TfCY/rcFdKs' .
+            'x9Y5a60fLc/OIP8cWFkzXHTOmnTAuGpq1M+d28mCxXNJ4qNzmKcrVLWW3nPsePgJimMlgnCiik6BuK0xiAZH4v9x9ae2f/jWTevtdArFTLMnZr1Zd93WOCnr' .
+            'e5vywZqRoq8Ek8iXb8jRs2YZcxd0kyRu2pMP6uEjjw0sF/QsZdHS+TUJmQY1FcLD44nLR+a3b93U0/Xa/i3JdLIHp80d0s0b7aZtA/ozUc87cxnzzUqiqKYF' .
+            'tanNV6XnwhW0tjZRqZx4vvN0Rd0ujDIZHtvxBAf2D5HJRGkYCfW50DjgERL5mbg12r92z1uc9PdP+bDMtHhS6uR7Q7RiRSEfDMROxfu0GrjucMyd10VjY/6c' .
+            'JB8ctQurlQpz58+moTE/4dELYkpVNdnIrCm65P+su25rfCu3Tot7Ox3u1ESh1L03rP5GFJpfKFZcbXlUIYljuud2sXDxnFTtnuNIbUJLHCc8sv0JSqVKPX2n' .
+            'IprkIuvGyv59V39q299Nh9TcVCegbN680TTuvS/oKGf+qiUf9A6NxQlIUE+tzZ49iwWL5x6TOTjXMdkxeWTHk5RLFYwRvEeNQXKRYaTsfvFVn9r+zc0bsb0D' .
+            'nNKTqarHLtZde1tEzhiJp7SY7utDensH3KxSZm0ha3sP1cgHTGQ4Zs/txNVyv+cL0uYnTyYb0Tl7FnGcNkqJIM6pU9CMkc/c9sWVhY6e9XKiPj5VNapqVVVU' .
+            'VUQkEZH4Oa+k/nnt+6eVM1OagBtYbxREPTckXh2TpoQaY1i+chFBEBx3EelzHWJS27ejo42582eT1B5CY8QWyz5uygcrIoK3D27fovQ9f6ybqgYi4kXEiYiK' .
+            'iKrqL6vqJlX9TO21SVV/u/557fu+JilPz3mcrh2dbqQL9m3x9+bWvK4pZ/5xuJgEHglNLZ22dMUiOjvbqFanZmrtlYMShhE7tj/GkcNjtVIv9aExppK4nVd/' .
+            'avuSvj7MZ/vxCqhq3XlzqtoBvB34OGln3fIT/MhjpMLqz4FvishTNUkoIvKyDO8pLAHTqfax85+KHTmPGFOz+xoLDbS0NJ1Xdt+JoJpek67ZHUfrGBUTO++a' .
+            'cnbxHZ9f9f7+fvzNfesD1c22JvGcqn4a+CHwJ8BSUvJ5IH7Oy9U+WwpcD9yhql+pS886oV8qpiQBN2/ESj/+zt9bvaExazeMV5wX0rCL90pHZxtheHbnOk8V' .
+            'iKT2cHNLgUJT44Q9rKp4xWcj+1s//MKC1o6Nv2lEep2qXqGqfwR8FlgJ1PPHnpQP4XNetvaZkpKxG/ioqv6dqr6uRsKXrJKnpPi498a1YXVsfxBUm/+xkDOv' .
+            'Gy45b8QE1WqVufO6Wbh4zozqPS6EbQ88QqUSpzlw75P2QhCMxg2/tPajd35d4/h1BMG3gRwp8QwvXgjViVgn3XtE5BuqGorIi+5JmXISUDdvtGv3bHWmXFjX' .
+            'mLOvHy6m5PNeyeWyzOpsPS/ifS8W9dBM1+xZtf+DETEVF/jSoSc+rqrXeGPq5ItJCfRS7r/UtnWkkvFvVPXdIhKravRidzblCEjvgJd+vIcbYudFavXo3nsy' .
+            'mYh8Q25alVa9Uqh31DW3Fib6m8UEZnz4kGm94A2LgZuNMTlS0pyOAZd12y8BBlT1F0Wk+mJtwilFwM215Unv/MLqdxVywdpqrBNrpqoq7bNa8M4/Z/LADOrw' .
+            'XgnDkObWAs6Dr46R676Inl/40zxophavOp333JAS0ZFKwje+WJtwShGwZ9s2K6ACFzdkbMZ5HCDeewpNDbS1t77ExQHPD9TTdJ1d7Wl8NKnSfeWvgM3ivdMz' .
+            '9OSmjc0pPlKTgFKfyfhCmDIE7OvDrN60Pb7rhgvnBYb3Do0lCoQiQpIkaT9HFJ6XQedTRf1atba3o+WDzLn2w3Rc9A7UJxgTnEm1UbcJ3wj8Uc0ZOSVVPGUI' .
+            'CLWuw8RoJjSLY6eIIN4rmUyGxkLDeZdyeylIl58t0738UjovfkfaxvnKrIEnpM7N21V1DakUfMEfnlIEBLBGL4yd+skTqoy1NDcXJqZGzeAkEINWR5n/9j8k' .
+            '174YMUfHBp9h1O3BLuD7NSmoL6SKpwwBN7DeqCKI+1wUiEHV1+emdHS21npjZ9TvSSEGjccw816PRrMhXZnslTwCQ+oVd6nqb01676QbTBnU5v8cnqxl6w7I' .
+            'jOo9FRhwRaRpEWIzZyvNkM4VgWtERHkBW3BKzIjWzRstvQPu7htWv7GQsZcXKy5BxNZnpcDEFLUzfyyk+dXnQuTFLdjrT6B5jJypExHwZUxhMWb2taSjm86K' .
+            'fKk7JOtV9WLgAVU1InJc+2lKEJBtB0RA71bmZ0PTPFxMYmuNxHFCZ1cbTU2FM95QroDzhsB4MpnqpO5aAVGSOKDqLFZONBswhVfBq5CPYjD+6H4EUKFYiRBR' .
+            '7JkgonqwOSTXyVFB9IqjHpaZAzTXyrxO+CRMDQLWoVqKveorqW3rkiqyjky+RFzKcfeuOYTGowgGpeIsq7sOUWgaQ0sZqi6dbjVZmjkvBEbJRjFEMY8/28lQ' .
+            'KUtg0gffqSEfxqyetw+cJYkDVIJ0PNuk6Vkv+dxFwMfY5e+B+uDNs2e2mPQguAG4hpMMUZ9SBPSGPM95bM+k5+u9pIQR5alDLXzzwXUcHMtzy5PzyFifloeI' .
+            'Uo4Drlm4l66mUd656knWdB8AgVI5wphUNedyVcqx5R8fWMG2wTZ+tLubvaMNhJMI2JSpsH7xMyxoGaX3oh1QHSbfWIAgBJSk4kgST21h6qOXQk5FlimIRbId' .
+            'HBsbPmsQYEEtP3zCIoWzbtnXnlO9/8sXNVRi93RgpS32qkIaA1ywqJuu2R0kyemt/Uu8IZ+psGOwjX/atpzvPrqI8WqINZ6mTBWvMnEbjSjj1ZCKs2SDhNcu' .
+            'eYa3X/gol3UPkiQWr8K/PbGAv77/AnYONVNxluZsldC4if0gKeGPlDNE1tPRMErn6A9418XPMrddGC0LFyxtpm1WPp235tPUmgg4r8TxUWI+L6EhFqrDmPlv' .
+            'Iljzm0ffO7uISSXhZ0Tk+hNVy0wpCQia0/o8eVXC0DKrs+2Y2X3pKNuXsPSV6oRV5NWSz5W575nZfOTbGyjGIYVMlZZcBVVIvCDpBGkAEhVyYUI+ivHe8P3H' .
+            'F/Cvjy7i+jf9kNeu3Mlnv3stN21fRnuuREMUU5AqzgvOA/X91HbWni/hVRguZzmYfQ+7t97H6rE/xjnPvDkttLdGjI8nXLyqnZ5VbVSKCYXGkEJrNlWrTqmU' .
+            '3USroNaGqov6tF1GLOiUqRayQPZkX5hSBNTn2Aqq4BI/4QkDZIKEchLgVSbsqxOhnrZTIJexYASvBiPj/GT3bH7nOxtAoDVXJvEG70FweMmihEDdDnSIllEV' .
+            'FChkYqqJ4UtbLud7jy7k5icXMLdpLN2H1ucSConkJx2NYLWE8x7FYA2Eeohy04XszP82Fxf/mMOHxzh4KB2q+cy+Mf7133dTrTrmdTdyUU87pVLMrLYcl1/c' .
+            'SRJ7xJKO/xULEpBMHeJNxklrBKeUCi7Hyf7AmgbnVVVVrLWsuXgF1lq8V6z1PDtcYGHbMFhHUolQhNgZTM2zFJH6+jAEmRpxRdj11DClipKLKnz7x438/b6f' .
+            'RxVC62tq0pNIBh800Vh5nEwyiAQ5BEdF8wyHy7BaIdASSjrx3iuU44DGKMZpXWELsRSwlGmJH8UEIT5JwFcZza6iKk0E7giGlIiGhKoUaE0e4aLxGxkvxWQy' .
+            'IdakD1B9sle54vBeyUSWro48cewoNEa8/jWL8C4mCAIWvevPMfmz6gFPRl2BHAEuBp4h7SE5RmpMKQl4MngVwjDha1vXMFyOWNU5xC9ctANrPPmGEsQB45Uw' .
+            'XX9NIEk8N3//KWLnMSLcv32IammcYjiP+5veTxjKJBvNUZUm5iR3k9l/B7NzR2iLjjB84AhWHL5hAYeqyxmzC3g68zoiHUtNAaBhEvm8RFhf5oLyXxP5UTqT' .
+            '+xkfOUyu0EouG/Hk4Bxi28K+1ndS1BYCyngCQh3lkF3Jw02/waY3f5db7znE/oNF8rmAsfGYOEnPIZsLCALD/sESKoZDR6r8xdfvIvZgG+fy2d5mXnRF6JlD' .
+            '/YlsBaJaOOZ5T8W0IKDzQjZT4cdPz+EHj88ncYa7ds/mWw8tZ3HrMG9d9ThL20ssa3ic62/cQRBYnAYMj3mMpITM5UIKjQHPZjcQRHkCP4pXWyNfM93xPawY' .
+            '+QtWXnE1V2/8LN0r1nHnP/4Z99/8Dww+vYO5mbvR6p2A4+notURUUKQWxtFUKvoSa4pfoz1+AG9ylF2GC67dyGve9Z+Yu+Ji7vmH/8lD//YNHt/zB2xv/xhV' .
+            '8litoARkGGOQpZhZl/CB9+5iZNySzRl+/JNBdu4eIZOLeGr3GPv3HSaXMQQmJpEGDjW8ijE6GGr+6UnB77Mu/Sbj2JV/noNpQUBgQtok3tCWLxN7Q+wMDw+2' .
+            'cefTr2FByyiL29Ywau+kM36QUMdoz40yUskSe8voSAmfm83+cB3WF/EEE5JvdnwPF4z9BbahjXd/5m9rQ38cP/ULH6K5vYtvfuE3iXMdxL7EWv8D5jVezL+P' .
+            'NNNgkwkCisnwc9kfMTS8jYqdhfqEbD7De/7bHxNlcnjvWP+LHyM3azFPX//LXDr+R/w490Gq0oglnWxQLMGNdyzii2/dTSYTgIdr1s3mmivmQEMMh8a4Y8dS' .
+            'Sj7Ln9zdQ9E3MByuRF1MQV+xqpcXi5M+DdOCgKlXLHz74SWUE4uvLWFgRbHGM6dpnPFqyI+e6SLf8Dae4p10xfcRVp7hLWufYU7TOLlgjG8+9WaKgyENYeqJ' .
+            'JmTprt7Fmuo3GBoe5V2/1k8UBsTVCmGUwScxa9/Qy+3/50959snt5LIR+5M8W8ebyNbUd/34EoUfjrVyoRisNYwcPsDPvv8rhGHmmP1d8YZ3ccdNf8rBx+/h' .
+            'Uv0jfpL/darShPOO1myVO3fP45F9nVy0cB9UwMUGMZ7v3LGEwXIT331sOUPFDM4IGCXyR/AKhsxZvUcvFVOKgCdqchZRvLMMFbNcvWAfW/d0oCo0RjGi4EUJ' .
+            'rScwFbxCQMyB8BKqwRV8Z2SYqJjw4VffR+PhVtw+D5FBNCGRHG3JDsTHmCjPgV2P4NVjjMUlMTYIGR7cS3H0CDYIAM+Y6SJRg2GiWyA9RhxFmqhIC4HG2DDD' .
+            '/l2PHnd/5ZGDuLCFQrKLrD9MKegg1HF8baHDJw9E5B2MBt3887aF3Levk8GxPMPliJZsGSsVgolQVNqCWZ2SDvALY8oQMBhLpJKVpucWHdQXmElU+MKbt4Cz' .
+            '3Pz4fPaPN/D1+1bhvOHgeI5smNAYxROhEqsl8hR5ajDA+YBf/caryEWeQjbGe8VLlia3i6ZkJxUfkS+E3PXtv+Kqt72POUtWA+mi0nf845+zf9cjNHXMQ+Jh' .
+            'dje8DpUA0erEpBDFYLXEiF3Kwehi5lRuJVdoO8n+HqWpYy5xktCd/IhhuwRFUBVyoeO/33YxgVvEsF1KZEoYETKBo6uxiPMyYVAphioNhGFCV8v0ZOCUIKAq' .
+            '8tj/qMbj45mbo1B+qhSrGmOkWo3Z88x+Fi9dgI9jyuVUzfzUyqfAG9626nF2HW7mW9uXsX+kkduf6qaQjQkDA5o29WeCdMVJg8MjaYoURQnJ6iEa/R4q0ox4' .
+            'R77Qwv/80Fu44s3vZcEFl3HbTX/K/p07KLR14V2MAcRVTlBglP6Gumpt8UF/0v2pixEgO/4wkknjhgCiCUGmAZUmWnU0JSYC6nGqOCIQwRESUaSzdAcLW4b5' .
+            '+ZVPY/TNTJFbOhnp4ssnwFk/WgHVTeuDFf1bKnd/Yc0f5jPmp0pV55jUjllHPflfKmUQgYz1rOoY4jNv+iFHDhfYOdbMbY918/c/nkXU0EKJVkI/hlF3nPlk' .
+            'iifAS5rPVQ+utqj1bX9/I0kck8k3EoRhevO9EBrIZE7cl+IV8rmQ+IhDwhfYn4JReN21y3lwu6CuXjyQBrKNJqjUyack0oBKQIPfS+iLLCj/C6EfpdU9TuVZ' .
+            'zz8d7OCKD+Ynzm0KecKWk/DsrBPwGIhvct4ec3eNMc/LAVuTfsWr4FRIRhpozCZc2rCHB/79Nq4ZG2RELmdMujkQXUbRdGGI05vK0VCFxeHiCkUfkstIfcYe' .
+            'ucaW2iI3rtYSIMRVz/s3LufPnmzkqUcdmawcU6NojFAqxrzlZxZQeqyTW+8bp5A3OHf8/ZVLjve9YxkLlrXxpZ84IisT8YrQeCqJpZwEhNaBCegu306UDNJZ' .
+            'votIRwgtRFFAbJqxWcUnRR667TusefWbX/GVn06A+qiPLcDBWrfc81JXU4qAqmSyoUj9xtbH755sCJEAgfEYa9m9R9m6fZi2liY64/uZw910Ve/CqeXx3EaG' .
+            'wtVEjFFXlyVtoKljLguaYefOEUqVmHwmdTZU63ljGBqusHBeM0svaOPAfRz3WIwo5cSQaMhVV8zm3370GMWSJxvZif1Rs2ePjFRZPL+Zngs7uO3RBtL7lMpo' .
+            'K8rgeI4lrSPMKozzcxfs5MLuAzQwzCM7dnPvjoB8w2yGDld4es8YoS0ThCGV0SF+cus/sebVP4v3fmLJ2LOIupf2bRE5XCtGeJ4imhoE3LTFbd6+0SbJ9n87' .
+            'PO52ZDNmRSX2PgisOTw0zOjoGC0tBZLk+F1xIpDEjo7OLFdd0sld9+0nigKcD2nOjxGFjrXJ17gvvI7DLMJSJZISe+PFXPEzP821q5/k0e0V7rlvDw/tOEyc' .
+            'JHhVrBEaGyLe+rqFXHVZN2Qs71n7FH3fm3VM1bSIUoxDLp49xOqO3TQ3t/Jbv7qGu+/dx0OPDBEnCaqQzViMEd60fj4Xr+4irozz11uXEXtLJkgQhEpied9l' .
+            'D/G2nidY1DGEVtPchpccV1y5iquu8hAYhg4W2fHEEfK5gIOHY/71e0M0tXcxhVQvpAfTfbLGpClBQBH0lr4D8upPb3vijutXDzbnzQWVKg5h0nq7J4dzSq4l' .
+            'Q2d7jlXLWunuylMsJrzm8m5a2xrJhMN87vsx333C0JIFr4ZsUOXHu5u4dlGVFUubWbGsiT3PjHLH1n2EoaExH7LhqjnYlgxPP3KERx85QmDKWHP5sccPVJ2l' .
+            'o6HI/FkjFMeyLFvQyLL5y9n1zCi337uPbNby6JNHGBmt8uAjR7j/wT2UfQPP5kOyYSohrXiKSZa3rNnHorkjuLFmbJAuIQugPsEBcTmhMRdyzbrZQNp7dOWa' .
+            'RsJZMVQOY6NmzrIdWJ/AcAS4vZaGm8Il+TX09WEMMlj3O1JbxrB3zwEali88qV1jrRCPx6xZ2cr6q7oJc2kmIam6VCWZBv7DJbv4t52L8V7wQGMm5uv3ryIM' .
+            '4OdX/ZBKNUs2G/H618zne1ueZnQs5mvfegQFnt1X4vCRMhn7GB3tFzMYXjxRmIAKgSg/u3IneEExlIoOY2D+nEZ+8Z3LIRfwZ3/xEIOHY0aGR6hKAw80fpCi' .
+            'dhGSrgdclTxz7GP833/4d7K5CLwjDAxvuHZ+6tmjOKfMassS5kNIah6+UbINTejhe9HyEJJpTcvzz54dWG9GqojITbXxv8eNE00ZAt7KFt/fj3/rDf4jlcS8' .
+            'fXIza7lYOaV9eOeZ3dmQ/rvqU/vQCg7FO0PPnEHeuHIv390xn4aogveGtlyZv/7Jhdz+o70sK30LxRJrRNWZNABiDKKOfJjQ1ZTwVPTTHApWE2g5JR9pJjiw' .
+            'jj/70YUs6zjMks4hqAYU4xBXUZKiIxsLVmMKQZEknMWD+Q9SMt2EWsST9pq4xLEguY1DBw5R1jxSsx0fe2oYIdUGlarjolXtzOtuJIkdzivtrVnWXdKFcw1w' .
+            '4A60kPYDn0XU5w3+Tc35OGE+eMoQsA4jUSYbeXOk6NQKWGuoVCoMHjjE7O7OEzYnqYINDAcOlhg6UsZag7XC6FiV79/2DIghpIzaUWzwAcRYxHm8GhqDMZ4J' .
+            '3kRgoT3ZRt4doF0H8YQICbE0MWIWMGoX8ljmnVitophJgWgIjLJ7pMB/+b+v4b9u+BFNUcyqeYNHL31Q4ZIrL2N+j+XP7r+c0dJssjqOwxIYx2gly+KmAxQO' .
+            '/5jRJMJIAgpRZLFGagW1Si5r2f7oED/ZfrDmWStRZLj93v2US+PMnjfC+776H5nwos4O6hO4/vaFpqhOJYtVNm/eaObsfCCfIfzf2VDeUSw7L8bYOI6ZM6+L' .
+            '+QvmnLA033slWwj5l+/t4p9+sIumwtF4XWDr9XuGUEocyq7lR/xHCtmkFpROK6CdRCTkaEsepsHtScurtELJzGJv5mqsVgm0SORHeP6lUzABRW1mrBLSlCnz' .
+            '5mXbcZoSNbCe23ctYP94Iw1BGUOCxxIax3Alw7LWI3z1rTezd/d+ytX0eMKM5cc/OcDOZ0bJRGkjVJJ4xovxMWX52YzFuTSyKWJ57+/+EauuegNedWJxw1cQ' .
+            'dVvvNuAXgP2AlxOUsU8lCag927bZNf2PjN51/ZoHcg3mHeNl71C1QRBwYP8hOrvaiU42oKgmMTKRIbAGX2sYck7TbcRT9Rk6uZtfu3QW39j5FkTLhNbjvMFq' .
+            'FUuZkWAxw8FSPJZE8mT9IZaU/olEckQ6yoLK9yfUbwrBaJWimc2z2fVEQYly0sjfbrsaQ4KhiqinIeNoDsdwmtqJGZtwuJRladswf/BzN9Oeq9CxenYaoa75' .
+            'ED1LW6hUHQiEgWHwYJkf/mgvUWQmzLyfPHyISjUhymQ4tO9pnnl8B6uufgOaOHjlCehI7b+nRWSPqkYnG2Q+lSQgWmsIufvLFy0K1f8EtCFJEDEiSeLo7Gpj' .
+            '0ZJ5xw3HpBIw4p//dSd33XeA9tZ0HF654rjognZ6Lmgjqbg00BuGLF5m+f6DC/n0914NQFO2mvZY1Bo4YsmT8cPMjn9Ed/UOGt2emsoVnMnVjxeoB30FIcH4' .
+            'CuDxkmUkXMbTmddzJFiGlwDrSqm0lZRfg+N5Luw6yB++7WYKuQrVaog8J2djTBogp9b/YY3BZMykfuO02rtSdRhrcdUi23Z6fvrj36GxkK995RW9zXX3ey1w' .
+            'H8epgp6MKUVAAO3rM9Lf7+/8fM9XWwvBh4+MJc4YY5PE0dTUwAWrlx1XDatCEFkef/IwHe052lqyaYsjYI0gVo5eGq+Ml5WGfIXbd87jpoeWc9tTcxE8YRgQ' .
+            'SZnZ1TuYW7mNvN+PlwhvshhJiV6ppGTNRJYwMJQqCc6lI3IzmbBGZIf1FQTPwXA1e6JrORStIa7GOJ/2lbxt1RP8h4sepbNxnHI1xJgXbrZSBa9H8zmT+10Q' .
+            'Iakm3PPvd7D4zdfTfcV/RL1HzCvWIVcPPv+9iPSebCJCHVOPgNpnBga2y6In7l+Yz2TvqsS+LfYYIyLOOZZfsITW1sJxsyMpKQyJ09oi1UffP9rjxoRH6bwh' .
+            'l62AM9y3p4O/2baOg08/StfId8nrQbxkcISoKnGcEMeeTMaydGETxhqe3TvG4KESyxc101CIGButsnP3KNYIUWQxxmCMEPhxVEIOsYTRue/i0kVF3r3qAea2' .
+            'jeGqAbGzL2tkh2qaM48yEU888hRDQ6O40iBr3n8TzYuuRn2CmDNubdVV7w4RWaWqIZCcyParY8oRENIp+euu2xrfef3qP2xpsB8YLiZekMA5R1NzgWUrThwT' .
+            'TCdonfqEAecFI0om63nk4QNs/s5OYm/AZvAuVYdiYN2FHcyfWyAwwkU97RAYdu08wu6941y6ehYNrVnGhso8uOMQuXzAbffs5cDBEknsCaK0AEGTMt0dGd7z' .
+            'zpU0NzdQLBus0ZcdrtOaszE6WuSJR3eiGHxcpHnxq1ix8X8lNsiY1Bs5o7fbkU7G+hUR+aaq2lNZxGZKErBeF3Lv769td3FpnyAmnVIgUqlUmTO3k0VL5p+W' .
+            'eTGqtUKC2PO//mo7+waLtDaFjI/HqCrvfccKli9rITKCzQbgPOVSunZfJmOR0BKXYlyi2EAIs6mkKY2n5Vb/8L2nuHPrPpqbIipVpakQ8aorunn12i7cCVKL' .
+            'LxUP3LeDJEnSAg4bUh562vf8zMdM+7WfxLvYGRueKV1cATLAV0XkozXHo3oqG571jPXxIKC6eaNZ97GtB73nq62NgaiqQ5UoChk6dIRSKY31vdyZgVKz6xqy' .
+            'ht987yoWdufZd2Ccy9bM4sO/cTEXrWojFCFxSnmsSrmUTDgG1aqjPFZNS+KtpG2a4zHl8ThVw6HlnW9czH/6pTVEoaW9JeLDv7qGDdd0nzbypRPEAgb3HyKO' .
+            'k4m0pfpEG9vmmKFDgxuAH9TIdyZWvUxIybcd+GptQPkprxcyJSUgpM7IJuBnCzcty4v+MHa+vepUjBgTxwmz53SwaPHc07ZmiPdKNhswdLjMvQ8M8rpXz8Va' .
+            'Q7mSYF4iUerPRqYQ8dQTR8hlLZ0decqlBGtPD/mstcRJwiPbHqdcTheo8d675nxgRyt60xUff/CdqpoFvge8hpQcp2OZBkjJFwDbgJ8Wkb2n4nhMxpSUgADS' .
+            '3+83cKu58mMPPDpadt8KA2NV0XRkR8C+PQfY9dSeiWWpXi6MESqVhKZCxBtet5Ak0ZdFPkilqwiURyosmNvIrLYs1crpIV+6f6FarfLI9icplaop+VTVGnHA' .
+            'COp/X2/pCwZ6e2Pg9aS1eenIh5cPT0q+R4ENNfLZF0M+mMIEhDQ/rH2Yxgbz2cRBYCeTMGTvswcol8r1FcNf9u+li2ArpbEqIrws8k2GMUIce5Lk9BWKeu+J' .
+            'ooj9+w4xPjY+sXaeqrqWxiA6PJ7cdcUntt1x6623snHzZiWVfG8Gbq7v4uX8fO3vB4D1InLwVJ2O52LKquA6Nm/eaDu2HZCGzMF35bLmr0tVp6oSiIikajNi' .
+            'xaolhKE9b1ZQUlXCKOTggSGeevKZCS2gis9mDInzj2UMP31wdNbeDZu2uPTjVDWqagNwAMjz0mu26tstF5HHa2sPvyT7ckpLQIDe3gG3gQ3+ik9t+7vRkvut' .
+            'tsYw9Eqchh6gWCzxyPYnSRKHtfYVG+V7tlA3QQ4eOMwTj+2qBb0VVTQK8N5pERO/+sKPbdt9K1u8TGqim1QYerqukqtNP33J0nTKE7COe29cG+aj4KbxstvW' .
+            'nDeRV/WqEAQBpVKZHdufqKXoOC3qeCqi7vEeOnSEJx7bhbV2IoZoBN+UD4Jy7P5k3ccePaibN9r+/mOJ8UJB4ZeAk6bZTgXTgoDS3+/X7tnqLvkvDxwYGq1u' .
+            'KFb8Q9nQ1LJS6RzB8bESQ4eOEGWimko620d9eqGq2MAiIuzfOwhMzvFqko2EI+PuS9f87sO/c++Na0N6B6bFoirTymDSG9eGct3W+PbPr3r7vLbsTfuPVMua' .
+            'xqAE0hvS0trE3PldRJnotAd6zxbqavfQoSPs3zvI+FgJY0xd9bpsZGy56sav+tT2xnpBhzxHzdaqkrVmA+4HGnj5NuBSEXnyxYZeJmNaSMA65Lqt8S1964Pm' .
+            'qvzzviPx77cWgqzqsVMZD+w/xGM7dhJXk1pMbHqLQvWpw3Fo8DCPP7KL0ZHiBPm8qg8DMVYYR3hbKvk2mueSbypjWhEQ4LX9W5LVbE+u/ORD/2VoLPlqWyEM' .
+            'VDWGVFJEUUixWJ5wTNLqlGlzPyYwEcTORhw8MMTjj+3CWjMRckrJZ4wxxIfH9M1XfXL7zd/es9XJwMC0mtEx7QgIIP143bzRXvmJbR89Mp58dVZTGALV1CHU' .
+            'mmOSesf79h48mp6aJjxMp8EaksSx88ndPPXkMxOVzfVwSxQYE1mK4xX3+mv7Htpy741rw+c6HdMB05KAAGwc8Jv7eqIrPrHto8Nj7sttjTaCdFhWnYTlcoUn' .
+            'HtvF7qf3EobBactAnGlEmZAkSXh0x06e3X0AOOpwqKrLhGIiS3GkHL/l1b/78A+1b32w7rqtp5x/nUqYSiX5LwppfGt7VTdvtNI78F/vur4naswG/6mS+Ew1' .
+            '8d6AMUbIZCL27x2kXCzT1T2L5pYCzvmpMr5iAvWSKlVlz+79DA4OUSlXyGYnWhA8oNnIWlUdGiv6n3v1px+57d4b14Zy3ZZpST6YZl7w8aAgA5sxvb24J//w' .
+            '0oWHxqr/WsjZlUeKzqNpNq2+kLOIoam5gWUrFmNt2lFWS1+dFTLWSQdpPPPI4WGeeOzpiTKzNLCuKHgrmJbGgMMjyVfue2roM9f9yd6i9mHkFNXuVPWCpz0B' .
+            '69i8eaPt7R1wt/dd1Jkv+H9yTq8AUee9BwnqS78658lkI7pmz6K5uYkwCrCBJalVWJ9pMk7efxgGlEoVnHPs2zPIkcMjOOdqNqvWsxxJJjRBGMhgsey/fsUn' .
+            't/0OwOaN2N6B4wz9OvHvzhDwTEOPrtLAj27oeXc2sgMA4xVfRQlFkLTgoN66oDQ1NzG7u42mlibUpxLJOTfhOZ+umj2glrlISe6c4+CBwxzYf5ByuVqrnDGT' .
+            '2gjUIUh7Y2BKVf+Qo/KmS3/nsWdrK4v6FxtqmaoEnLY24PFQF2BsWm/lE1u+dcfne97Tmg8+2pK3a8crntipV+/VWmvrYz+GDw8zNjpGGAa0tDXT0tpELpsh' .
+            'k8vgncf7o6N46+r6hZD27NYOxgiBSYk3OjpOEjv27jlAtRJPFNXaWt9yrXclQSVoygd2vOwZKbnvHxy3731j/2MHbulbH0jvwJkoKj1rOKck4GRs3ozt7U1V' .
+            '1L039Pxy4tnUkLWLUBiruEQQW5eIqjoxCNM5R3NLE9lsBmst3XPThV9UqcXhAk4mfBSIq2k5vzWGUrnCvr2DhEHA0KFhqpVqatvBREV3rQtYRVWb8oFNnI+d' .
+            'yk3FmD+95pMP/gCOle4vBVNVAp6zBATQPgz9qIA+/ZWrcvuS0V/Jh+Z9UWguHys54sQ7FRGZFI6qq+h0fTpDGAbpgoHOUyg0MKuzbZIKPxZpeb9nzzMH0uHk' .
+            'tdEZcZwKrSA4qoInjlE1MUaCXGRwXgmt+YaSfHnNR7bfD3BL3/pgQ/8W93KzGzMEPHuQW/rW29f2b0kANn9kXu6SRbPePFyKv5DLmGWJU0oVVTFMuMNm0mCk' .
+            'umRM57B4vKtPnToRH6Q2HDL9jqRiFphQ4TXHQYyi2toQmFLsq9VY/82LXn/1J7bfBnXvfqPp7T09mY0ZAk4B1GKGEzf0zutX/XYUmN/IhnZ17JTQps1HxaqL' .
+            'RUDSNU8nXyM5FadE6yMTjv7fQzq4pTFrTDqI0hMYIQzkL8fL+ufrPv7gDyGVePVJYafrvGvHUCdgI7CP00PAZSLyxAwBXwRUkYGBjWbjtgGVfvwtfRe3LOny' .
+            'bfuH/SeykawsVn1bZ1O0JnaeYsWTuLrxpXivSf3KH0/+CbWhVCLGmtqQdVXykSEbGcbLnnLV3dKUD+yRkv/T9nzmzhX/eesTkJoLA9uRFxNaeXHnPUHALHCQ' .
+            '00PARSKya4aALxG39K0P6qq5jntvXJtvqCS9o+PVxGN+JxOyvFJVj2Cb80G+vhb9iWBEGK84KrEfFxGXj8QWY/3fmZB7kqqMrvvkQzdN/v6ZJt7E76TV0AZo' .
+            'B57k9BDwQmAH6fSrGQK+FKRhG2RgO9LRs14mE/KWvvVBT8dgdm8p0KJJMqbCFwNrovrI3OftC/HNeWNGi/7uKLR/WR4r2iuX5p380gPjk/cJsIEtHtLCijN8' .
+            'itQbhlT1VcC/ktZQvtwQXFx7/bqIfOPl9IXMYBJUEe1bH9SJcjrQ14c53ft8MdDagEhVXa8pYn35qNb+/uXavl/SuZ33EvAFcEwTxdYb157SRV7busRPLok/' .
+            '2wWikyTgtcCtpHNcTocEDID3ichfvVQJeE5lQs4Ajl1f4JRLnraeiWM5XTidQudl72v61gPO4JzA/wNpmRQbruwNzQAAAABJRU5ErkJggg==',
+        'image_width' => 160,
+        'image_height' => 160,
+    ],
+    'katumia-support' => [
+        'emoji' => '😽',
+        'label' => 'Katumia Support',
+        'image' => 'data:image/png;base64,' .
+            'iVBORw0KGgoAAAANSUhEUgAAAKAAAACgCAYAAACLz2ctAAA5R0lEQVR4nO29eZgcV3n2/XvOqeptumfftO+SNSPJsiUZgQGJYIzZHEiY4QPyBRIgBt6QYMgC' .
+            'BjKagBdwCGSPExK+NxsfmgRCMIQEXmQRLxJY3rDGsi1blhcto32WXqrqnPP+Ud09I0uyZbClntHcvuay3d11qurUXc959gPTmMY0pjGNaUxjGtOYxjSmMY1p' .
+            'TGMa05jGNKYxjWlMYxrTmMY0pjGNaUxjGtOYxjSmMY1pTGMa05jGNKYxjWlMYxrTmMYURF8fyvWhzvWx05jGNKZx/uD6+hTAts+uWrDj8yvWbu5BVz47m2Nd' .
+            'H+ru61dctOP6FasmjjeNcUxPyHOhe1AAxI/eFll3W+8ABvqRszq4H+nHhtjvhMp+aOJ405jGWcGBbOmbl9p2Y9czD//pxe6Ozy3/dYAtfRu85zqu8v0dn+t+' .
+            '/eCXVxa23dAVDd6wrgUQx1ny9wLBtAQ8A+6+ZY2Pg0w69+HGjNdeCk2UTuqPPHDjyqaN3e3OuTMSSXIzR2XPVzekfC3XGkMql9acIN8PuB23rHlO8l5omCbg' .
+            'aeAcsmbfDnPHF5ZlFXw0H1hvrORsNqVX5525SnoHDAM9p527zT2otdfsCPc+eXhlNq1eP1I0phhYcinV++Mblyx8vGmhdW5aF6xgeiJOg4GBHiX9WBV678um' .
+            '1ZxSaK0WvHzJWOu4AYDeAffs41xfn9rZhbv98yuXtWT1N4qBCZWICo3D86TNWO8jvb0Dhk3n+o5qF9MEfBYqS+s9169uSyXUR8LIGgEcqFJoTUvOm7X9xu73' .
+            'C9i7b1njn3Rw96D092N1ZN6fTsjsUuREBBFEjRWNTfj6ff9zU9dc6e+3z7GEX1CYnoRnwfVt8GCr3Z7q+lBL1v/zw8NhqJT4AA5sylcqNG4wpd1VK+Z27aNn' .
+            'wIrgHMimPuQtuTXNJiwcEESVRaQAOOfC5pzvHRuLvpwvtP5ebuaorL1mR3j+7rQ2MC0BJ8CBsGmrobtHnGXTibxxoqRqNAiofMmYpjrdNVJyX5HeAfM318RG' .
+            'xY5b1nj9/dgwKG6qz3hicYYJL7iI+EdHI7TIhzJ1h1rX7Nth+qYjJNMTcBK2bNAiuO27H7y2PqNbI2utPGuV0ErUsdEoaKrz1v/4pu5X7JuxwzzY15X49r4d' .
+            '5sc3Lr+iLim9+aJxONGnjO+cTSclZUI+I/3YjWy44Of/gp+AClxfnxo41O7uuHlhe9rXH4iss5xeRRFjnQbqjXG/09+P7e7uNv39WOPkq1pJW2gQkdMcK0gp' .
+            'sCaX0m/f/kerlt7GRnuhR0cu6Js/Cd2D0ts7YFSYeHsmpZcWStYKctr5ERE9XDQ2lVBv+/EN3eukd8Bsu7HrN5qzfvto0QYip59XQVQpci6VUO22FH2gv7/f' .
+            'XujRkQv65ifCgfznnyxOtOQTe31P2qIotnzP/HsXNWc8OV4037zs93f23PtHK3aKSFcxsFae+8V2sVXtbM7Zjq7rdh1xIAKnuHUuBExLQOKoh4BrLiR/uynr' .
+            'tQShMyeRTyT+mwBBvGN5oxS8efsNy//aGLqKJcsp5Dv1WLE4U5/xZNipz0FswLxkN1fjmCYgsGZp1t19yxpfHHOsE4+JK4MIzkTYKDyFhIBYR6ou7V1jrLOn' .
+            'fP0cxzqHUlpm3PnF2ek1S7MXpPSD6SWYiivkramL5+KZPaXIuYmWr7WGTH0ryvMZPbIP7fk4dzJfnHNG5FSr11lDesKxSvuMr7Quash43vHR8NUvCx66g+4e' .
+            'kd4B8xLeak3igpeAG9mg+vuxBRvd4HsCztnKdyKCjUIWrnk9S1/+NsBh7anC6nTkE1GYsFQ+9q2nkZ6iSpHFwk3Sj2XnqaG9CwEXNAFdT4++ja12+xe6Vjek' .
+            '9VWlwBrKlq8oRRQUaZ61hExDO34yTeeStTgXIacuxSdBRBEWR2lbsIp0fRt+qo72+SuJggIyblhLGLmoIeOv2X5T9+ulH/t8aV5TERc0AQH6+7E24jc9T5pC' .
+            '41zFf+ecQ2mfjsWXIp6PCUvMv/T11DV2EAaFM5KwIvna5l/MkpddDc6Bc7QvWo2fTJ8kYI11iJBUItc+8ieLk5XPX/q7rh1csATsAyUDA2bbZ1ct8LW870Q+' .
+            'siJx2E2UIioVyDbPoGnGYkxQREThwhJzVryKRCp3ih5YgbMW5xyzlq/HOYfDYcIS2ZbZNM5YRFjKIyqedkG84/nIZhLq9ccLyTWv6d8a9fVNE/CCwFtuWaP7' .
+            '+lBORf25lDa2LJpEBBMGZBraWLz+akwUxNJOBBOFNM7ponPxJQT54SqRqhCFc5Yl668mXd9aPVaUxpTyLLj0Sho7FhAFRUQEByhwDmed5SYHcqGF5y6om63A' .
+            'be7RjzcttFenu5flMvqtw4XIQcWQEJw1tC9YRTLbhLPjhqkohckP07HoElrmdGHCUtW4UEoTFoaZ3X05rYtWY6LiScu0sxYvVUfn4ksQpGoLi4jOF41prNNr' .
+            '775pxRUb2WrdBaQLXpAEZOeA6+0dMCXjPqlEctbG7mKI3S7JukY6Fq3GlPITjQYg1g39VI45K14FSPyPCGEpT7Z5Jq3zujHFsVOOE6UwxTzNc5ZT1zwDG0VV' .
+            '8lpEhYZ0aOx10o+FrZYLBBccAV0fSvqx229a3p1Jql8ulIypsKVivc5Ytg7tpyYaDFWICFGQp655Js0zlxAUR3HOUdfYwfIN/w+JVA7sSZlY4+cufzr7opdj' .
+            'ggKVfAUBPVYyNpvSG+/6bPdG6cdu7uHUbJopiAuOgDtmrtFxwZG+Np3QmdDEWS8igjEhzbOX0Tqna1z3Ow1EBGcjZi1/OZnGdkr5YTqXXEoi20gUFDlDDkOs' .
+            'X0YhuY55dCy6BBMFVIjqcNbXWO1x3Z1fnJ1eeMWaC+LZXBA3WUFfX1wwJMN2pqd537GxyIpUs50RYMGlV+Kn6s4oxWII1gTUtc9nxpK1zFi6jvaFq4kKYyj9' .
+            '/IJLK82CNVfi+SlcWRsUxDuRNzab1ldIWL9m7TU7Qre5Z8pLwQuKgBULMwiDP0rEUQ8HZbdLMU/b/JWkcs1EpcIZpVgFIhpTGKF55hIWXHolJgqf10FdgTEh' .
+            'yk/SuXTtSXqmiKgwsoLlZgB6B6a8LnhBERDgwb6uhBKZW+WKxDFbP5mhY9ElYO1ZEwkcXiJddTafLaScpNA2fwWpXDPWjEdXLKCEOVv65qVe0I1NUlwwBHR9' .
+            'G7yNbLXFjHpjU526dLRgQhHRceQioHnWUuqaZ2BOn/Vy5nFPY6g8P+IYczLbROu8FRhT1QVVKbBhU9bvzKRzH8aVC+SnMC4YAsJWK/3YILKbCoHzKJMvKhWp' .
+            'b5vLwsveFFumL4B8Pw9EaaLCGHMvfg1t81ZMiJCIN1I0WsFH7/jCsuyafTvMVC7hvCAI6Db3aOnHbv/cirfVp/XFhTDOWnYu7tTSufjS+HcvYBl9UVBeijsW' .
+            'XYL2kjhrEIUEobXZtJqjQu990o8dOEMXhqmAKXtjFTiH3NY2JLd/fllO+/yOCHGwFsHaiFzLLJpnL8VGpVOcxy81KmG/+va5NM1YGDunUQgQRtakEuoj91y/' .
+            'uq1yH+f04s4RpjwBGehRGzduNdqoV+XS+hXDBWNj3U+ISnlmLF0Hyjv30m8CnLHMXPYyrAkR5xARNVa0NpdWCwMV9PbsHHBs2jAlXTJT8q2aCAdKwN51Q9dP' .
+            '0wnVXQqdExEVhSVmLruMOSs2nGSFnq+rFOVzcPcOnrj/h2gvgcM5TwlhZI+sX9LdSc+AJY4XTqnE1SktAbds2eAJ2DuvX9HbWOctDSJrAGWtJZHKMmPZZWco' .
+            '4D3XEHARHYsvJVPfGuuCIJG1tj6jW7fvfvBaERxbpp4UnMoElEOH2t2Wvnkpz3PXRpaEtYgohQlKdCxaTSJTjwmDF+R2ealgrUVpjxnL1mHG9VGJrLNpX3/g' .
+            'jpsXtg8candTrZB9St3MRGzuQfX2Dpi0n3ttLqXXjxQiK0ppEwYkM/W0L1yNCUqn5vSdJ4goorBIy5zl1DV1EoVFlChVKFmbSemlKky8vbd3wEy1QvbamP2X' .
+            'AG1dG+TBvq6EaPeHxjijyrqTiDBj2WUkUlmcrbFIl3Noz2fmRevROhGXBYiokWJktejPbOmbl5pq4bkpSUDXt8F7Tf/WaDSj3tiU0StHi8YqpbUJijTNXMLM' .
+            'Fa8iCovn2fA4FRXHeNviS+lYvDqOSSulgtCZxqxuzSRzHxZwUyk6MuUIWGmxducX16cxtj8fOl8E7ZxDlMfMpeuwpXzNka8CEcEURulYdAmJdA5rIhDxRgrW' .
+            '05qP7vj8JTPX/MaOaKq0dpsSN3E6zMuGAnSHkUNEi4lKNM9eSl3LLJyNqFkPlAjOWlLZFtrmrcBGIUopCSLnEr7MMTZKbdpUqxf/wjHlCLjjljWeCO7JQ4VP' .
+            'NWQ0Fhc55wTKITc5+5Cbcw7nbPUv7rf7fH/xlMbVcbacrPDCXXfORLQvuiT2CRqLEqyAi6z9XP8U6i04Zd4kKPf46x6UJU/d16lI3WWsnRUaISoV1JL1b6Ft' .
+            '/iqiUuEMlq+r8sQBOIeXSIHS1e/C4micdvUcs+acQ3sJdLKcpoVgw1JlKZ3YMvW578U5tJ9geGgvg1u/jvISztPOpj09PBpFv/DdscEHNg32iAxM7nYeU6v6' .
+            'anBQevsHzF3XL/+1lno159iojawJvWzzDJpmLcWEwWmLjHAW5fnjiaFKgfI49swjBPlhlNZYE/H04F3PuXzHKfcBudbZtM1fhTUBzkQ0dC4k1dAGUVhN37Im' .
+            'KicfnN63LCLYcpy4sXMBxw/skQjfeSlpskV+s7+f92+aAnUjU0YCVuTSXX1dTX6a3UpLgzFKoqAoi9ZdRfviNUSFsar0qyzD2k8gXpLiiSGctRRHjvLMrrvw' .
+            'EmmGD+0lLI4Xkms/yXNPmUMQrDXYKABRWBuRbZ5JIp3FS6SZ0/1KrIlIZZvQqSy2lMfGkY/TdNCy6ESa4/t38/Dt/4b2EoC1SkRFgVq4/jMP7OkD1R/nsU5K' .
+            'TBkC3n3LGn/Nvh3mx6nuP2jKep85OmqMDYt+OtfCqte/D1deAivE8/wEiObIk4Pkhw9z5KlBCiPHUEphjQEc2k/GEqp8zFknn5b1wbjQRLBRUF6CFUp72Cig' .
+            'Zc5yMg1ttMy5iHR9G85GmLB0ikR0zuAlMuy87Z85fmAPfqouakyJHB2N/uV7weB73zJzjZ7M3fanBAGdQ9iE/DS1siFQbreDJmMs2vNl8cuupqFtTrVmQ/tJ' .
+            'HI7hob0889A2Rg4/RRgU8ZOZWNK5cUHk4syUCedxZ2HACEpNnFZXlovlvqjlMU0YYExIMl1P2/xu2hZdQqahHRsUsGUHeUxih2iP/PAhHr3z3wkKo057yqQT' .
+            'qlAq2Zc9trDrkR5gsrZ2mxKW1G2bNmjpx44a87FMUjVbh7VRIK1zumictZQoLOEl0ygvwfGDj7Pr9gEGb/saw4f2IkqTzNRXH3YstsZJFoZR+S/EWYfnabR+' .
+            'rj9FVD0mIorseOFlVZLGBkYincOYgGd2bWfnD/+RPXd/j7A0hpdIxn0IrS1L0JBs21w6l1yKjQKxTokSyZWM+2Rv74CZzK3dJr0EjHcj7+MnuX+dlXBylwid' .
+            'hdAJDrX6ql8nmWkAFMf2P8aBR+/m+NAesBYvkY5LIsukkPLybK0t1xjFZGtuaQTAGEuuPkNrWzPG2DMYsYJzln1PD2GtQSlFKQg5fuQEolT5GEFrKf+2cm6F' .
+            'swYTBXiJFB0LV8et3Ro7sEERa6O4gwyOn37/fxMUx1zC01ZrSqXIXPayTzy0s1Jw/9LP+IuLKUDADd4mtto3pLo/0ZL1rj8yZsKoMOrPW/1aZq98NcefeZR9' .
+            'u7YzPLQXV9HrykSpVqJZSxRGJFNJtFa0tjeTy9UBUN+YK7teYgdxTL4zTVvsdtG6WmZJGEaMDI+iPY8DzwxRKJQolUpYY/F8rzyWwzkpvwSWqJQnUVdPy5zl' .
+            'zFiyjlS2KS4TTSQ5tOvHPHLXN/HTubAxo/zjY+bvdHPyQwCTURec1AR0xF1+nvrj9alnSsOHPa1SURRJqq5BZiy9jOMH93D0yYdA6djaZVyvs9Zibbws5nJ1' .
+            'NDTmyNZnaGioL5NT4ZzDmJNVq7MJ4U3UE0UErWNfoi1/fujgUYJSwNDBI9XxPU+Xj43dQDaKsCZC+0k6l1yKUh7OWvxUhsNPDjJ6dD/i+dZXKGX0gn8v3v8k' .
+            'xP0OX4y5PVeY1AS8+5Y1/tprdoR3fa7r+pZ677oTBYuJDH6qDhMFhMVR/GQd48o/gBAEIelMimTSp7mliZbWBnzfxxhbXV5d2Yn8YoSM3YRlHmKyOaBUCNi/' .
+            '7yCFQonRkXx12Z94buccUVAA4sZJiVQWP1VHKT8ciWiTTYseHrNfe8WnB391SzkJ4+e/4nOHSUvAODGzn211S1dkVOI/rSVVCG3e02q2Nabal6/iOol7vxic' .
+            'c8yY1UFrWxOZTLqs88W637lKUKgQUmmFklgfPH58hIP7hjh69ASJhF/VSeNrL9uKEreOwxmackmMdWgBY+HoWHjFfwcPbZls0ZFJbQVLP5aSV2+sfPjoCXdZ' .
+            'U9r/e8FZUcpR1qcqCMOQTCbNgoWzmTt/JslkgjAMqwQ8l9kxlbixs44oMkRRRFNTPYuWzmXmrI6q7li5pmo82hqUCA4VHhuJbhnOR/94dCT8qqfkX2DyLb8w' .
+            'iSUglOt9ewfMn3xkcfLyOal7GzN6+eGRqLpTUUXXU0oxb8EsGhpz+L5PGJ59H5dzhcpL4PkehbEiBw8e5sC+IXz/5G0hHNhMQmwQuevW/v7Om8/jJb8omLQS' .
+            'sEK+H1y3ZNaG+en70r4sPzQcBRN3KjJRvBQvXjqPtvaWsmSpPfLBuH4YBiGJlM/8BbOYMauDMIxOktACqhA41ZLzv7D9xu4/A9jz1Q0pN0nzA2vvSZwFKuTb' .
+            '0re0tSmX2Opr6RopmEiJeHH0KzY0Zs5uZ8bMDjxPPY/7pLZQIZyIUCyWePzRp8jn83jeeP1yeQNs/9hY9KWXfWLnx8oGWcQkK9ucdG9NXx9KegfMrX1dnfV1' .
+            'iTt8rbpGCiaSCeQLg5CZszqYN38WWiuMObc63s+Lif7JTCbF0uULSKdTRFHs3C7/xj86EkbNdd61Oz6/4ua11+wIN2+efC08Js9TIY567Ji5RtuRYmcS+a6n' .
+            'ZcWJvDFaxQ3GnYuV+lmz2pm7YBZRON6HebLCOVcO7xl2PfQY+dECnl/NonNA2Jz1EoeGwz99+XWDH71t0wY9mVwxk+yN2aDWXrMjjIruV+oz3orhvC15E8iX' .
+            'qUvTtWIxs+bOIIrMpCcfVNxHFu1pLupaxPxFc8oSMnZqOvCPjUUmk1C/ddumro7X9G+NJpM+OGmekNvcozftHHBvSHT9UjqpvlaKHM7FCbWxzhfQtXIpTU31' .
+            'lEpn7u88WVHRCxPJJI/ueoyhg0dJJhOxGwln074ywMNE8oawKXFwzb43G+nvr3m3zKR4UyrkuzKxdGku4w2Exom1cTZwxeCYNbuDbDYzJckH43phUCoxa04n' .
+            'ddlM1aIXRBUCp1IJtSJvom+svWZHeBu3TYpnOxmeVDVR6u6buv8l4at35kumvD2qEIUhM2Z1MG/BzHjZneKIdUJNGEY8PPgYhUKpEr5zIi5KJ7QZLdr3vvy6' .
+            'nV+fDKG5WiegbN7co7L77/Xaisl/aMx4vUdHwwjEq4TWOjtbmbtg1kmRg6mOiYbJw7sep1gooZRgLU4pJJ1QDBfNuy6/bvBrm3vQvQPU7JtZ02K6rw/p7R0w' .
+            'rYXkmlxK9x4pkw+oRjg6Z7VjyrHfCwVx8ZMlmUrQ3tlKGMaFUiKIMc44cEklf3D755fl2ro2yHPX8Z1f1DQBN7JBORBnuSmyzjChS6hSiiXL5uN53mk3kZ7q' .
+            'EBXrvm1tzcya00lUfgmVEp0v2rA+4y1N4L310OBWR1/ttnWrWQJWutrffdOKKxrr9Np80VgqnU2jiLkLZtHYVH/BSb+JiGPdhvkLZtPYmCWKKllAeKNFq4xx' .
+            '/b0DmE1stbU6QzVLwEpX+9DY60JD2iJKlfW+bK6Oxsb6C0rvOxOci+eko7NtPI/RoUJjTX1aL7jz+uXv6+/H/rBGd+CsSQJu7kFLP/auz3ZvzKb0xrGSsULs' .
+            'drHW0dbejO+f377OtQKRWB9uaMyRq89WVwTnHNZhUwn9mw/cuLJpY3e7q8VG5zVJwIVXrFF3fnF2Wntc52usw9mKs3nmrA46Z7TVbFbL+YIxliXLFpBKJTHG' .
+            'opTSo0Vjsym9Ou/MVdI7YKjB7R5q7oLc5h69Zt8Oo4q5tdm0vuJE3lglyrPWkU6naG1vuiD8fS8UFddMR2dr9f+ViMqXjLWOGwA29dZe+WbNEZDeASv9WAs3' .
+            'hcaKlPPRrbUkkwkydelJlVp1rlCpqGtoyk3ct06VQmtact6s7Td2v78fbK01t6wpAm4ub096143dv5xLe2uC0FX3THXO0dLaiDX2WZ0HplGBtQ7f92loyo3r' .
+            'goguBM5XSq7d/oWuzlrb+qumCNi1c6cWcAIX1yV10lgMINZacvV1NLc0/YybA14YqITp2jtb0TqurhNQ+cC6dEK6PJdU0o+tpQaXNUPAvj5U96bBcNtNK2d7' .
+            'il85Oho5wK/4/Roac/gJ/4J0Op8tKuHJhsYcnj8+V0qcM9ZZY4NNziHd3T3TBDwdRHA2Ui7pqwWhcYgg1jqSySTZXN0F7XR+IXDW0dRcz4SOm87ToiLLShFc' .
+            '286hmpnEmiIggFZuZWicndihSmlNQ0Ou2jVqGmdGvAxLNUpU1pcljJxL+ZK86/oVHYcG25+nz+u5Q80QcCMblHMIYj6X8EThYt8fONram8q1sdPL7/MhVlks' .
+            '6VSShsb6Sh2JKpRs1FjnXSLK/mLvwICplfhwzRAQqv1/jk1cZSsGyPTSe/ZwzpFMJUmnExhT6a4AkXHOIUfO8+WdhJqID7rNPZreAbP9pu7X55J6Xb5kIkR0' .
+            'pVcKTHRtTeNsEO89p8ddViJ6rGRF4NN7vrrhO/za1lK5F+d5ndnakIA7h+KJcMxJ+aohjJxTIhJFhuaWRurrc1PGAIm7rL6056h0hJg5qwPf9+K+NyCRcYBb' .
+            'NTZ2yDvfxKugJiRgFc4VQuvc+eJZtXG5VuWdGVy1priqfwpoJWdFopPGo+Io1uDAlJshGWOrY8XF6C/y/UwYTwSwMjZcytVMLLOmCGgVGZ5lnZ0ry9daRyIR' .
+            'L1kjo3Fhk1ZCus4nCgxesjxVxpEvhHj6uRePZ4+Hg1Sdz67dx8hlE7S1pAnDiFydD148VlQyRJGlvDE11amQn91ktebk+RNxCobTQOFnHPJFxXknoAOR/q3R' .
+            'fTevqiuF5qbRggERzzmHUopsru4ltX6tjfsGpnI+hw7k+cl9Q2y/fwilhLq0xxWXz2burCy7HzxBOumz72CeVFKz4VWzKYwE6GeHBR2gIJX1OHRwfDyAtuYU' .
+            'uWyiSsJiyfDKdZ20t6bJFyIuWtRIc2sm7rdmx6/NWEcYjhPzbEKRE+dv+MQIIiKRtVFD2qsbyZubgN/Yccsaj/PcVfW8E/BkuLSr9JN38XLV2t78ovTuc85V' .
+            'lR6pNH+0jlQqziv8xq2PsXPXUY6dCKjLeBhjOVoy/NO/P0JnW4ZnDo4R2ICxfMQbNs7FSAkveWrxe7xsC9/8zl4e3HWkOp5z8MzBMTgwhucpxvJxOtkPbn8a' .
+            'ayGMLHNm1tHSlGJsLOLi5S10LW+mlI/IZX1yTanYEjOOUtFUSwUrdyWc3L3VOUci4dHa3szxYyfGQ3Oxsp3+uSbzRURNEdA9a8MV58BEtmoJv1BUQlEOSCc1' .
+            'qFj1tsZhrMVPeTy0+xjb7jnIT3cdJZ3W1Gd9jI2lh1JxcP/IsSJNuRTrOtcgAsXDEYfvaaCuzi/riPH5jLXk0nXcs3sP/+fOJ2nKZiaMJ9W+Ls7FUkwEPK2w' .
+            '4shlkxw/EXD4SBHrHE8fGOW/fvQUQWCYPSPLqq4WCoWQ1uY06y5uJwotoim3/41RLEblLtXjtazm9KlrNePRrykCng4vVPDFDRzj4xJprzrI3idOUCxFJJOa' .
+            '27bt4+ChAqmk5tCRAsWSoT7nY43DiQYijInirRKAhK8phgGjQYEr561HKUV+X8SIHSefA5QoduWPseXxx2iqTyE4nHgnjRf/OG4DbIyjsz1DXcbjkcdPEIYW' .
+            'pSBZ1h3jHEiPoSN5bv3BCNY6kgnNHXcfIAwNuWyC171yNtbFBF+0oLH8kjmCQlS+9dr2HNQ8AV8IHFAK4uUpjBz/5/tPEBmLEuG+wSMUSxFKxcaFKOHEMGgt' .
+            '1GUqkkwxevwQmVwTqUyO0WOHEKVIpOvwtcftz9zLksa5zK3vxHlBub1u+dzOkktm+f6+nzIUHKIhkcPCGccTHKXA0PumRXTOq+f+HQcolgzJpOb2n+xn6HCB' .
+            'TNpjdCwkjOJ7SKU9fE8YOlwAgaPHS9zyL4NViXpJdyueFqyD171yFo2NtV+2MCUI6Bz4vuLQkQJ//g8Pkig3+h4uW7MikEl7pMWLIwNl6SOA58WSBok3Glzx' .
+            'yjfx6rd/kNlLL+bOb/099/3wGww9uZtkKkPaS7F/7DBz6jvjpLEJtqnG41hhlBPFMVI6iRMw4XOMl86gFQw+eoy2lhQXd7XG0kvgooWNBKElkdTc88Ah9jw1' .
+            'TKbOZ+9TIzzx9AhJX0HZSvd0vDOT7yvuefAQAPlixOVrOmhqqW3pB1OEgBCTUGvB9xTFUlwtl63zKRQNxliODwe0NqXIZn3yYyFrL26nqSHJ5lsfI5OOjY5k' .
+            'Jsu7P/M3JJJprDW85p2/RX1LJ1+78cNlqSXcO7SLtZ1dpyj8SS/BkyMHeOz409Qn6whN9LzjKSVsv+8gr75sBsUwKm8TG0uzVDL2F75iTQeveNkM0Irjh/Ls' .
+            'H8qTznjs2TvMtnsPkk55FIoRQ4cL+L6iWDS89uWzaWvPEAW1nzk+JQgoAmFoaO2oY/3qDm794V4a65PkCxGXXdxOa3OasULI6q4WZs3IUipFJDMJnnziRKy7' .
+            'aY/ho/t4w/u+iO8nCYMSfiKJjULWXNnLHd/4W/Y9PohKJkl6idNeg8PhKY2vPUR55I8e5I3vu+7M4+0ZROkU6ZSH58UbXTsoGysTyG0dhZEA52IpftHiRgRh' .
+            '3swsr1zXie9pjhwr8uP7h8ikPfYdzFOf80mkPMJCzfibz4iaIqCI/MwzJgI2cjTUJ/jgr3TT2ZamVLJ0tKZRiTiyEZUMhXwYP2BjCUJbyffH85Mc3PsI1lmU' .
+            '0pgoRHs+Jw7tJz9yHF1uj1ttkcuznMMSW93WurMaT2mN1sKxEyX++CsPIBLrrwvnNrDuknbCUqzLnmRclK16ExqMcSgRwsjQ2JDgDa+dF19DYDg+HFAaC/C9' .
+            'Mzzen2OeX2zUDAG90UhKKal/ts58tkq0iBAVI9auakOIn5VkY/9aUsdU8RIKL6XJjwaUKlEH4g1g0rlGtn37H1h/9XuZubA7/txE3Pmtv+Pg3odpaJtFEBRA' .
+            'HJ5WiIHIlQks4IygdaxTGhOexXgzMVGIc3D4WLEamb3nwUP8pOy4jqWqYnXZuECgWDKsu7idebNzlEoRAmhPkfYUWFCeork9QzAWR1+e1WEfFTtZ63+GR/SS' .
+            '4LwrCJXtth7908WJY2PJ76YS6hcKYbwpcxhGdHS2sGDR3LOqA67ogZ6vqrMdFCPuf+hI2fEMfkJx+0/2c+hIEa2EMBp3iWntEYUBl73pV5h70aXc/s2/5eCe' .
+            'XeU9fC0gjOSLXNS8gKuXvgpd2UrYCmRKtK0/wNdvfYh7HjxCJu0hop9zPOegVDJxfFlXtnSFhK9QKnYnWesYy4dViWsd1KU9EgmNOAgiS3trileum0EYxO4d' .
+            '66B7SRO+L/z0vkeIoqjcRxCTSogrltxvX3bdzr+shfZt552AEPeBkf6t0fYbV7ytOau/cWQkDJVSfhhGtLU3sWjJ/OcloLWOVNbn/vsPsXX7fuoysXAvBYbd' .
+            'T5wAqURYIJlU1VhuxZVS2cfNOUdQGCUKQ5KZLJ7vx5sbEkvTX7pqIQ3NiuzebnQ+C4kIm/fJdO2jsXuEW7/1ND+48yka65MY4553vLddtYD21gzf2/Iko2MB' .
+            'vq85eChPsbwEJ5MeyYSq7JdYTmBw1X3uRARjLaWSreZWGeO47n9dQktTknt27MLFmUTOUyKBcaMvv25nDqhsjXxe/TQ1swQDILbeWH3ShCilzsqS01oYGwvZ' .
+            'du8Qjz85TDKpcdYhSqjPJeLZVpVtoyEITDW+6hykkhXnL6SzjdXGP3FJgFAsGd7x5sVcsroDjCHqGCL/QIroWIZM1yES80coHYGrXjuXE6Ml7t91hEzKw5gz' .
+            'jFc0vOMti7nkknYILb/xruU4C56v+Mn9Qxw+WiCd9nlg8AhP7R8lmdBExmLLCaaep6rE9LQm6ZfzJoklvSr7Oiv3W/lOCXZb3+L69f27h1+05/ZzoKYI6BzJ' .
+            'lC8yMT0pCMLnbUIU+wE1QwdGGXzsGC1NyXIgP053CsPYHREUI4xxRMbS2ZahvS0Th/q08PiTw4wVIjJJj8ryWFnyjp4osWhOPSsuaqYwXARRhJR4ovgE0fEm' .
+            '0vmnaTsu1NelUUq4fF0n9zx4mHwhIpUYX24px2KPDwcsnlfPJStaKQ4HWMa3kYiMZd3qdtACIqxZ0crIaEgy4zH40FHuf+gIdXUeR44VeWrfKJ6Ol+tkQpcT' .
+            'EOKXxVooFUonZROVpWh9XVuiZkJxtbEEO2Sgt0fNXDU4vy6lbkXc0lJoUaJUGIYs61pEY2Ou2n7sTLAC3/jO42y79yDJhMZaR7bOj/1jJcO6VW3Mm1NPfixk' .
+            'wZwcM2bnIDDgKR7dc5ztOw7y4K5jhJHBOodWQrYuweVrO3jFmk7qGpIQGkj77H3kODd/5R4aGjyOHo74xdct4Kor55I/EZBMap7YP8q2nxzkwYePEkbmJCl7' .
+            '+dpOLl3ZRibtU5fSSEVnFXCRpVAOoznA9xSep6rkEhHwFEcP59n12HEyaY+hwwVu/8kBUknNyGjIkgX1vPsdXTyxaw+Hh46RSPhYa0025emxwPxFvtD60Y2D' .
+            '7a4WNjWsCQkogtvSNySv/MzOx+68oftQQ0ZdVAowlHWeiQH3M8EYR7oxSXtLmuWLm5jRkSGfj3jVuhm0taYJAkM248cuGesIA8PY8VKsVylhyaImlixsYt/T' .
+            'I9y54wC+r8hmfDaun4luTPLUw8d44KEj+H6sPw4dLlCfSZJUHnUZwfel6kSOIsui2fUsml3P3qdHuOPuA6RSmkceP87wSMiDDx/l3p2xhHz1ZTNoa0kTGUsU' .
+            'OTrb0sxf2Ahl9SBOnqhY6w5whMWIbNrnFWs7488jx8sv7cD349j28EiJZNJDKV19YZ3DphNKjwX2R/FWDrXRrq0mLqKCvj6UQg5VVo1YyVbs3zdE3ZJ5zyn9' .
+            'tBbCsZAVy5rYsH4GftoDC1EQ612ZlEcYWWxgSKc0fsrDTwFKCPMhzzw1gqeFdEpzxatm899bn2JkNOSr//owAM/sH+PYiSJaq2ojoHRKY8obX9ty/p6NmwJR' .
+            'LMZqw5yZWd71S0sg7fH3X/0pR4+XOH4iwBFLtO/f/nRVXYgiS1NDklkzs9jIViXgla+eg+8pKGdotzan8DM+RBZEUDqWrgAz2zPMmZHlxMETDB8fru4/rDUS' .
+            'RLZY9lQK3e01ESSuGQLexlbb3499y0322lKk3kp1k1wo5ktnNYY1ls72uvi/g9hH52mhkpGklZBMan5y/xBHjhXxlEL7iqf3j/LAQ0eqy7a1DlPOdFFKsMaR' .
+            'SCgaG5JUUm3iPYZj6QkxUVTaIx05RAtByWDLiaRR0ZI2jiC0GOuqki2KYt3U88p+Ss8jMpZHHzteVY6cg0efOFHN9ysFhlXLW5g9I0sUWoy1tDSl4hStyMYv' .
+            'AGCcpVQK8P14+a1Lae/4mPnRyz81+K9b+jZ4r+kdqInu+TVDwAqUJJKphFXH88ZpiespSqUSh4aO0Dmj/YzuGOdih+zQ4QJHj8eSSus4Hf77tz8dp2k5UAqG' .
+            'jhQIgrjJkXMO36tIM4dS8TmVibNVYj0yBSJYE6dVnXxiQbAcOV7kqT2jBIWIKIpYOLeeVFpTLET4nsJElp43Lootb8BPaJ548gTb7h0ildRx7p517H7iBHZC' .
+            '96CEr8s1KA6HI53SDD5ylPsHjyAqfmF8bfjR9mdwE/IfL1+RIOEJVhRS9iSI2OaX8NH9TKgZAvb34zZv7tH5PQ8cMCX/G7mUelu+aAwi2lpLEITPGRVxzuGl' .
+            'PO756SH+4wd74/y+8gPxtDrJ3PI9NaFeNnZGJxKaVFIjxL7DRfMaWHtJB87Av337fkaG82SyOdK5Jhyu6jR2ztGUEX58335+sGUnnu+TrGtkyfwGLl/byYru' .
+            'ZoqjcfivsT5RzVcEaFnZxpqL2ylfCM5Y7tt5mMg4cOAnNffcP8Sep0dIJT0cEEWO0ICSABeOoIFMfQcn8uNVJMZB6BKkk0lKJw6CtVIii5dq+LJzTt122ybo' .
+            '3/qiPbufBzVhBVfwYF9XYkX/YLDthhV9rfW67/BwFIoQR/8FVqxaWrboTiVixRH9w61P8+0fPEFdxq9KkorjthKvTac8Ll7eErslFASBrRorYWTAKZJeRKJO' .
+            '8y9ffxDTvpGEr5m/cj2XvPaXq1tExOeN//vRu7fw4O3fwU+muft7X2OsEKG05r3vWMXFK1spjAQofarbd+JLJQLJ9IT2fQJBISrnOCo87Th0aJT/2fYYyaaF' .
+            '0LwKa0Je96u/S11DM86NZ7/E8e6AJ3/4RawJXDC0U37v/bfW3Qr58nlFRM67HlhTBHRlwbL95lXzfWfvB1cXRYiouEa4vaOZ+Qtnn9YdY60jlUvw3f/aw7Z7' .
+            'h6q+wGLJsOqiFrouaiYqGRxxxvG8+Q3j1e4i2FKEseVGj1ERnZvBHQ+ENF76a6y87PIXdB9PPrSD/xn4C5557CEOPrWXX+1dwcWr2ikOl2Ln8HPM+rNfLqUE' .
+            'pTXOlEBn0Ik61OKroHMj0HS2l2RN4ZiykftnP9fcd+LEiaONjY3HnHP650kAeTFQUwQEcH19Svr77V3Xd32pKed99PhoZJRSOooM9fV1XNS9uBrbPOk4B15C' .
+            's/vxY7S1pGluTFWTDbQSpCJ9yt7lQslUbz5Og9KIi3DhGHrO6/BWXourhO+sxVqDKBVLvompMBX/nXXxb0RQelyz+c+vXM93/v5mfv1dl3DppbMJ86XYeDnr' .
+            'mVe4aAzx0njr+pHG5eORjbI+GrtbzjCfNuaXqJO0rQeBq0TkmfNNwtojoOtTAwODMv+x++ZlkqltpdA2hxalRMQYw5KLFtLUlDttdMQ5SCYUkXEnFQtNrB6D' .
+            'UyvIEA1RHlIteKt/D9W4jIqpGi+xL6woqkLEePci4cATD/O1G/4Xbng3H3zvejIZypVtzzP94kHpCHrJu9HzroZkI+WK+fL3L+DxxWGQSgREAYeAfxSRjzvn' .
+            'fCA6H0tybbTmmACRfrvw2OPqsk8++vhI0W7OpLSAM5VcvAP7hs4Ymqvk1E0kX+XzMh1QIqcnX7IJ/7LPoRovmjjiCyYfVCSSqsZ/O+cv4wNf+BoFfw5f+PMf' .
+            'cfBIWPYnPtdEaFzpCHrxO9FLfzUmn4szcspZCS/souLfq/KfBdqAjznnbhaREPCcc2ca9CUTVDVHQIA11+yIAPETqU3D+cgpRDtwnudx7OgJnnnqAJ53+oKb' .
+            'Z7e3qGSRJBNxVsnJP66QrxH/suuRzEwYb0v9okApjbWGbGMbH//Lb7Fg+UoeenAvyvM4YyKKaCgeQS95F3rZe+NrqlhML9JlEZMwAH7HOfflMglPdwIBXN+G' .
+            'l8ZjUpMEFHBuc49a+zs7DlvLl5qynjjnDM6RSPgcPXKcQmE8KnEmWOtQXiwtdvx0iO33DaF8FfvLRI2T72U3IXWzYgkjL37bPKU0zllSuWbec/O32HjVKwnz' .
+            'x8t5gc++eYUrHUUvfTfe0vfE5BP9wiXeWVwWkAAi4Ledc18QEeOcq0rCisv8qsWLk/1biTb39Oi+F3k39pokIAA7u1xfX59SSe9vi4EdSnoitrphTcTBA4fP' .
+            'mKrlXNkqTsWRha9u3sU///tuvrvlSUxg0Z7G2QhSzWXJN6P8oF+66ZC45ybWprArN6HqF4INTj5nWSJ7i9+FXvqel+yFeBY8Ykn4u865PxaRCFB9GzZ4Au66' .
+            'Ny345KtXyQ8//ab5v9o7MGD6+7EvJglrzgiZiErG7p3Xd/1FLq0/PFo0RpU3LAzLG1XPntM53rrDVTJIBJXx+dGPnuK2bfsoFOKC9CAwrLyold6rFxOOHiHx' .
+            '6r+OiVCRMucCzpadjycItrw3NjRE4vMHx5D2V+Cv/QOwESjNOXxEJSAJfEBEvuK2OG/TF2cmRKXvT3hqsXNgHZ8cLYT//+f/a+8TfX2owUFk4Ofci7imCdjX' .
+            'h9oE/LRpRZsJ5UBkHcY4F9sRQhhGrLx4KZm6NGFoECUkfc2T+0b50fZ9DD56DIfD98Zz5YZHQy6/tJW3f+ga3Lz3xsvguSJfBWVpax7+30R7vol46XIWqY9/' .
+            '6aeRpoohdE4fjyV+fx8Grnzvxo1H5uSe/kHCk8tLoQkBlUl6Oozsfk/UGz/9rUfvg3hfv96B6rEvGDVNQIg3r2nbOSR1ycO/nE6pfyoExjknnohIvMwmWLp8' .
+            'Iely5OPr39rN/Q8dIYocmXSs6FfURK0UxhqCwPKRP/s2s5euxFmLqPOgiZQlYbj9E7hjD4Mp4K3+HdSsK86tRD4ZhnhTyH/80Bq1f8nS5b93dCQfiig/vmRn' .
+            'tBbtaQmtdd8Mjfvb67+z5wcAfRs2eP1bX3h9Se3qgGX09g6YjWy0l1238+sjBfObzVnft46w0nyxUCiw+5EnuPv+Q/zJVx7gvsEj+J4qd6RyVStYKWGsGBEG' .
+            'Ib/4S5eTSKfLDRzP5zvokHQHYMHLQKK+7Go5P7DWKMAc2ffEG1s65715rFgCURoXL7OiRBuLK0XO10r1Jn39/U2/uOj//f0rFjb0b936MxkpNS8BIY6O7Jh5' .
+            'q/aGwyYR+0NfS/fxvLGphFL5kuNH9xY4OmLi/ikJXS0wgjgKEhlHMTB0L23lZSuSdL3vn8GfP66PnZ+7AgRXOkL4g3chHevx1/af52sCIAR84J0fWlv3qoWL' .
+            '5n24GASUoqqTMLaQnTOISMbXqhRFDzonf/vZWx//U4hVp/7+s+vANSkICOM3taVvaWtTLvH9hCcXb9tZcnsORMqYOO8vLruIyafK3ufhkYDWljTvfOsy5rU5' .
+            '9LzXYhd+ECl3MDivcLH+bh7+KtJ6Kar1Uk5T8n6uUfZ2sxu46A9/ac4aEyVuFpENDrDGGYSqfmCds75WKpPQ5EvRl4Iw+sqN33ty0IFs2oDu38pzLsuThoCA' .
+            'uJ4eJQMD5q/es+zdmaT8084ni6Gvla8UJ0UV4sKcCGPgtZfPYu2qNto6chSPHUTNfgOJ1deeTz1rHOVrMI/+E6r9MqRhKTVAQAeItSZSSjeJyCjAp9+y4ONJ' .
+            'rf4wsmQiYw0i5VZKcbq/A5tJKM9aN+Zwv9j3rce3AHZzD7pnAHum8s9JQcBK/eqHN7Rl2xtz/+GcvKJQsn4yIeok4klcxVYoWRbMybFmZRvr13ZgAkMYOhQh' .
+            'uuuD6Dmvr4WlrnoN9uBdSG5+7I+sEQICo0Dnpk1SmLl/jb7mb3aEX7yyq/mYX/xWLq1fmQ8sUbyjVXUSnXNGKdGeUs5Y88PQ2T+/8da9//5cJ6t5Avb09OjN' .
+            'AwP2U29ZdHWdxyZjWR2UY70V8jmHVQpVChzJhGL1Yo+l83N0r1qItYowjFDiwM+SeM3/d17vZxKgQsAxoENExpxzMtDbq3oHBkzfm9dkUokTbyhE9iYlsjgy' .
+            'zjlHhYhSzvuQhCckPEUxMNcGznxvd/qyRwcGBk5x19Q8AcuQvg0bdJR78qCvVXMYOiMq1kOsc1FCK68QWDenw2PJLF86WzSjYyHpuhSdM9poa2/Gmgin0yRf' .
+            '/VfgZ8/3/ZwMV8nPqonHcVoCljNlJta586m3LPzjjK+ujQyExuLATVyWwZn6tO+P5qNPfva7j99U9hme5LiueTcMQF8f0r91a4RIj0Bee+Ksc5Fz2FzS8xD7' .
+            '9BvXp+XyFUlpaRSbL1m8hEdQCnjs0b089eR+PF+jPS8mX63tOSyKGiFfBWdyKjsHsrkHDajrv/34x4joDiPz3wLOVyLOjRMs6Wt/tGSG6sPsn/X1oXo2n2oZ' .
+            'TwoC9vdje0Bf/+3HfxhF9ioleOmE9rQS5cT+biohlzfXy+d9JSWcKHCWcuQjmUxwcP8hdj20l+FD+3BPfy9+4O6812TXKp6dbnsSBFxZillAPvUfuwc/9509' .
+            'r7dG3okw5mvROBd6CmOtfcoF5tW/+/0HChCXvZxmvMmDirf9ujcuuDOT0hRD9+XPffuxzZXvd/75JfMKo8F/ZdN62fG8sbiyN0aknMYPuZRj2S/fjDfvzeUa' .
+            'iknxDp4rOGI/4CjQA9wGIOOJrKegrw/Fbaj+rUQff11HXTqR+btsyn+HCBwrBq+/6dYn/rtvA96Z3DGTioAOZFMfwn3z6gcfrcsPDA4GfRvwNm3FDGzuUb29' .
+            'A+aOvlXtmZz9D2PcZSDOWGtBvEqGchgUaGjpoOuDt8V+wFqwhmsHFSf0ZhF5h3POK2fHPC8q+p1zyKarF77NwRskVB/ff6ihcMuOHdGkdsOcCT096InZGOVu' .
+            'ZQ7gJzd1vT2V0AMAYyUb4PBFEFGasDhK44L1XPTOv0d5yfGs1QsbFfL9D/AW4uq5F5qmf5KRcjaYlK++i839U1KByg0LxPVt8NZ9YvBfRwrm3Z7IjsaMTvie' .
+            'iANrTWQS6RzHd29l19fej42KnOTTuTBhicm3FbhCRE7ws9WIOMpGSjkm/Lxv9ZR97TdvRvf2xgS9+6au90SWTXUpPR8Ho6UoUjqpw9EhaVr6Cyzr+SuUny5n' .
+            'xUzZKTkTKgbF/wBXE0s+eS6978XElJ5t14eiHyfgnvzi+vSBaOTXMr56b8JX60YLhgjfFI/ulbmv+Ziad+WnsCZA6dN3wZ+iqNbXAdmyz++clmlOyiX4bCH9' .
+            'WCHOrJ778W2Fy35/518OPnVsA1Z6jHO7M77RDa2z1MH7/s0NP3m3VTphrDE15iR8yeCI60EE+H2gWDY6zql/akpLwGfDbe7R0jvelPGuG5b/VsL3fiMhQbdx' .
+            'Hqve809I2+q4zZZ6ng2BJz8qyacfE5Evna8C9QuKgBBbygMDPapn54CTfuyWvnmNy5cubn58z95P5Orqli77wA9a/LrWFcR60VQlYcXi/biI/LFzzi+XZU7j' .
+            'XGLLabqEOufqnHP3OudC51zkph6C8r8/Vb5f/9SZmcY5Q+y2QW3uQe/Z8tVU/Jl7X/khheeHIy8ZKi/UfufcLOec75w7r1L+gluCnw+u7P13zv0u8AXimlmf' .
+            'yT9XFZ3vMHC5iDzinFPnyt1yJkxVHednRpl8vojcDHyMuHvAZCefJSbffmBjmXz6fJMPpgl4WohIWCbhl4BrgQKxBJmM4ZJKdssTwGtFZKc7D+6WM2GagGdA' .
+            'mYRaRL4MPEMsQSYjASu+vr8WkYecc8mzTTA4F/i/jxiks0uO8gcAAAAASUVORK5CYII=',
+        'image_width' => 160,
+        'image_height' => 160,
+    ],
+    'katumia-wow' => [
+        'emoji' => '🙀',
+        'label' => 'Katumia Wow',
+        'image' => 'data:image/png;base64,' .
+            'iVBORw0KGgoAAAANSUhEUgAAAKAAAACgCAYAAACLz2ctAAA5C0lEQVR4nO29eZhdV3nm+1tr7eGMNQ+SSvNkq0qSZZfkgRgkAjGQBAI3qJJO59IQkrjJJR2c' .
+            '0A2YkFI1eABCyNT3Xmeik/SFjooGbgYy4CAreJCM5VnlUZJHDVUqqVTDOWcPa63+Y+9zqmRLtoxl61SpXj/1PFad2vvsvfa7v/n7FsxjHvOYxzzmMY95zGMe' .
+            '85jHPOYxj3nMYx7zmMc85jGPecxjHvOYxzzmMY95zGMe85jHPOYxj3nMYx7zmMc85jGPecxjHnMQ/f1I2498s4+dxzzmMY8LB9vfLwH2fH7jin1fXL9553ZU' .
+            '9XfncqztR9530/pL9920fuPM881jGvML8kroGRIAwo0/EBt7R98gGgYQ53TwAGIAE2H+IZLmYzPPN495nBMsiF39yzJ7bul+8Yk/vMze9YV1vwSwq3+r80rH' .
+            'VT+/6ws97xr6/Q3lPTd3x0M3b2kFhOUc+XuRYF4CngX33dbrYiGXLf5aU87pCCIdZ3316w/fsqF5W0+HtfasRBLFRZPi0Ne2ZlwlbtCaTDGrOEVpALD7but9' .
+            'RfJebJgn4BlgLaL38D5915cuKUj4RCk0zlRgTSGjNpWsfrfoG9QMbj/j2u3cjtx8/b7o2eeObyhk5bsmKlpXQkMxI/vuvWXNyoPNK42187ZgFfMLcQYMDm6X' .
+            'YgAjI+ejhaxcEkTGKIFTCrQxlpsB6Bu0Lz3O9vfL/d3YO7+44ZLWgvpWJdSRFEJG2uI4ol0b59f7+gY1O97sO6pfzBPwJaiq1vtv2tSe8eSvR7HRArAgg8jo' .
+            '1qLTtfeWnl8WYO67rdc97eCeITEwgFGx/uWsJxYHsRVCIARCTlW08Vz10R/c2r1UDAyYV1DhFxXmF+ElsP1bHdht9ma6P9ZacP/4+HgUSSlcAAsm40oZaTuU' .
+            'Ufbd65d2H2b7oBECa0Hs6Ee8t9jboqPyUYGQqYgUANbaqKXoOien4t8vldv+S3HRpNh8/b7owt1pfWBeAs6ABcGO3Zqe7cIadpwqaSukqDkNAmQp0Lo5r7on' .
+            'Avtnom9Q/8n1iVOx77ZeZ2AAE4WVHQ05RxisZsYLLoRwT0zGKCE+lsuPtPUe3qf75zMk8wtwGnZtVUJg9z796A0NOdUWG2PES7SEkkKenIzD5rxz9b239rzl' .
+            '8MJ9+tH+bu/vDu/T996y7p15X/SVKtpihXrZ+a01WV9kdMTnxABmG1sv+vW/6BegCtvfLwdHOuxdX17ZkXXVr8TGGs5soghtrAIatLafHBjA9PT06IEBjLbi' .
+            'a0qK9kgjhDjDsQIRhEYXM+qDe39349o72GYu9uzIRX3zp6FnSPT1DWoZeR/MZdTacmCMQJxxfYQQaryiTcaTH7j35p4tom9Q77ml+1dbCm7HZMWEQpx5XQVC' .
+            'BrG1GU92mCD+lYGBAXOxZ0cu6pufCQviH/9gtdda8p51HdEex4nne/a/t3FLzhFjFf3tKz+1f/sDv7t+vxCiuxIaI175xbaJV21N0ZrO7hsfH7UgBLwsrHMx' .
+            'YF4CkmQ9BNiWsv8bzQWnNYysPo18QiQ/MyAQzsmSlhJ+eu/N6/5fremuBIaXke/lxwqD1Q05R4xb+QVIHJg37ObqHPMEBHrXFux9t/W6wrLEWOEwUzMIgdUx' .
+            'Jo5eRkJAGEsmn3Wu18aal338Csdai5RKLLz7K4uzvWsLF6X0g3kVTDUU8v7MZUtx9KEgtnam52uMJtfQhnRcJkcPoxwXa0/ni7VWC/Fyr9caTXbGsVK5TGta' .
+            'GzfmHGdsMnrbVeFjd9GzXYi+Qf0G3mpd4qKXgNvYKgcGMGUT3+w6Aqw11c+EEJg4YmXvu1h7zQcAizEvF1ZnIp8QEh0F6bHvP4P0FDKIDQZuFQMY9r88tXcx' .
+            '4KImoN2+Xd3BbrP3S92bGrPq3UFoNKnnK6QkDiu0dK0h19iB62dZsGYz1saIl6vi0yCEJKpM0r5iI9mGdtxMno7lG4jDMmLasRZRbOPGnNu799aed4kBzKuV' .
+            'ec1FXNQEBBgYwJiYjzuOaI60tdX4nbUWqVw6V1+BcFx0FLD8ineRb+okCstnJWFV8rUvv4w1V70PrAVr6Vi1CdfPniZgtbEIgS+FuOHJP1jtV3//xt91/eCi' .
+            'JWA/SDE4qPd8fuMKV4mPnirFRogk7SakJA7KFFoW0rxwNTqsIITERgFL1r8VL1N8mR1YhTUGay1d667GWovFoqOAQutimhauIgpKCJksu0A4Y6XY5Dz5rrGy' .
+            '3/v2gd1xf/88AS8KvPe2XtXfj7QyHihmlDapaBJCoKOQXGM7q69+HzoOE2knBDqOaFrSzYLVlxOWxmtEqkFIrDWsufp9ZBvaascKqdBBiRVXXEdT5wrisIIQ' .
+            'AgtIsBZrrOFWC+JiS89dVDdbhd25XR1sXmnel+25pJhT7x8vxxaqjoTAGk3Hio34hWasmXZMhZTo0jidqy6ndUk3OgpqzoWUiqg8zuKeH6Nt1SZ0XDlNTVtj' .
+            'cDJ5Fqy+HIGo+cJCCFWqaN2UV5vvu3X9O7ex29iLyBa8KAnI/kHb1zeoA20/I4UoGpOEiyEJu/j5JjpXbUIHpZlOA5DYhm6myJL1bwVE8p8QREGJQssi2pb1' .
+            'oCtTLztOSImulGhZso58y0JMHNfIaxAy0mQjbW4UAxjYbbhIcNER0PYjxQBm763renK+/NlyoHWVLVXvdeElW1BuZqbDUIMQgjgskW9ZRMuiNYSVSay15Js6' .
+            'Wbf15/EyRTCnVWJNf3f628WXXoMOy1TrFQSoqUCbQkZtu+fzPdvEAGbndl5eTTMHcdERcN+iXpU0HKkbsp7KRTqpehFCoHVEy+JLaFvSPW37nQFCCKyJ6Vp3' .
+            'DbmmDoLSOAvWXIFXaCIOK5ylhiGxL+OIYucyOlddjo5DqkS1WOMqjHK48e6vLM6ufGfvRfFsLoqbrKK/P2kYEuNmkaP46Mmp2AhRq3ZGACuuuA43kz+rFEsg' .
+            'MDok37GchWs2s3DtFjpWbiIuTyHVqwsuJRUreq/DcTPY1BoUCOdUSZtCVr1TRA29m6/fF9md2+e8FLyoCFj1MMMo/F0vyXpYSMMulRLtyzeQKbYQB+WzSrEq' .
+            'hFDo8gQti9aw4orr0HH0qgHqKrSOkK7PgrWbT7MzhRAyio3A8GUA+gbnvC14UREQ4NH+bk8KsbTGFZHkbF0/R+eqy8GYcyYSWBwvWws2nytEWqTQvnw9mWIL' .
+            'Rk9nVwwgBUt29S/LvKYbm6W4aAho+7c629htKjn5k815ecVkWUdCCJVkLkJautaSb1mIPnPVy9nPewZH5dWR5Jj9QjNty9ajdc0WlEFoouaCuyCXLf4aNm2Q' .
+            'n8O4aAgIu40YwISx2VEOrUNKvjio0NC+lJVX/lTimb4G8r0eCKmIy1MsvezttC9bPyNDIpyJilYSPnHXly4p9B7ep+dyC+dFQUC7c7sSA5i9X1j/gYasuqwc' .
+            'JVXL1iaTWhasviL5u9egRs8LUlXcuepylONjjUZIRBgZU8jKJTJyPioGMINnmcIwFzBnb6wKaxF3tA+LO794SVG5fFIIkmQtAmNiiq1dtCxei4mDlwWP32hU' .
+            '034NHUtpXrgyCU4jEUAUG53x5K/ff9Om9up9vKkX9yZhzhOQwe1y27bdWmn51mJWvWW8rE1i+wnioMTCtVtAOm++9JsBqw2LLrkKoyOEtQgh5FTFmGJWrgxl' .
+            '2Ld9/6Blx9Y5GZKZk2/VTFiQAsw9N3c/kvVkTxBZK4SQcRSw6JIrWbJ+62le6IW6SiFdjj29j2ce+j7K8bBY60hBFJvRq9f0LGD7oCHJF86pwtU5LQF37drq' .
+            'CDB337S+rynvrA1jowFpjMHLFFh4yZVnaeB9syHAxnSuvoJcQ1tiC4KIjTENOdW29+lHbxACy665JwXnMgHFyEiH3dW/LOM49obY4BmDEFKiw4DOVZvwcg3o' .
+            'KHxNYZc3CsYYpHJYeMkW9LQ9KmJjTdZVv3LXl1d2DI502LnWyD6nbmYmdm5H9vUN6qxbfEcxo66eKMdGSKl0FOLnGuhYuQkdBi+v6btAEEISRxVal6wj37yA' .
+            'OKoghZTlwJhcRq2VkffBvr5BPdca2etj9d8AtHdvFY/2d3tC2f+qtdUytZ2EECy85Eq8TAFr6izTZS3KcVl06dUo5SVtAULIiUpslFCf29W/LDPX0nNzkoC2' .
+            'f6vz9oHd8WRO/mRzTm2YrGgjpVI6rNC8aA2L1r+VOKpcYMfj5agGxttXX0Hn6k1JTlpKGUZWNxVUW84v/poAO5eyI3OOgNURa3d/5eos2gyUIusKgbLWIqTD' .
+            'orVbMEGp7shXhRACXZ6kc9XleNkiRscghDNRNo5SfGLfFy9f1Pur++K5MtptTtzEmbCsEAmgJ4otQiih44CWxWvJt3ZhTUzdRqCEwBpDptBK+7L1mDhCSinC' .
+            '2FrPFUu0iTM7dtTrxb92zDkC7rut1xEC+9xI+bONOYXBxtZaAWnKTZx7ys1ai7Wm9pPM2321n2RJk+44kxYrvPbQndUxHasuT2KC2iAFRoCNjfnCwByaLThn' .
+            '3iRIZ/z1DIk1zz+4QJK5RxvTFWlBHJTlmqvfS/vyjcRB+Syer63xxAJYi+NlQKraZ1FlMim7eoVVs9aiHA/lp2VaCEwUVFXpzJGpr3wv1qJcj/HhZxna/TdI' .
+            'x7OOsibrqPHJOP7x704NPbxjaLsQg7N7nMfc6r4aGhJ9A4P6npvWfaS1QS45OWlioyOn0LKQ5q616Cg8Y5MR1iAdd7owVEqQDidffJKwNI5UCqNjXhi65xXV' .
+            'd1JyH1JsW0z78o0YHWJ1TOOClWQa2yGOauVbRsdp8cGZY8tCCEyaJ25asIKxo4dEjGudjGg2FT4+MMAv75gDfSNzRgJW5dI9/d3NbpanpRKNWksRhxWxasu7' .
+            '6VjdS1yeqkm/qhpWrodwfCqnhrHGUJk4wYuP34PjZRkfeZaoMt1IrlyfV14yi0BgjMbEIQiJMTGFlkV42QKOl2VJz7UYHZMpNKMyBUxQwiSZjzNM0DIoL8vY' .
+            'kad54s7/hXI8wBgphIxDufLqzz18qB/kQFLHOisxZwh43229bu/hffreTM/vNBecz52Y1NpEFTdbbGXjuz6KTVVglXiO64FQjD43RGn8OKPPD1GeOImUEqM1' .
+            'YFGun0io9JhzLj5N7cGk0URg4jBVwRKpHEwc0rpkHbnGdlqXXEq2oR1rYnQUvEwiWqtxvBz77/j/GDt6CDeTj5syQpyYjL/+T+HQh9+7qFfN5mn7c4KA1iLY' .
+            'gXgks6ExlPZpC81aG5TjitVXvY/G9iW1ng3l+lgs48PP8uJje5g4/jxRWMH1c4mks9OCyCaVKTO+x56DAyOQcuay2lQupnNR03PqKETrCD/bQPvyHtpXXU6u' .
+            'sQMTljFpgDwhsUUoh9L4CE/d/R3C8qRVjtRZT5aDwFx1YGX3k9uB2TrabU54Unfs2KrEAGZS69/M+bLFWIyJQ9G2pJumrrXEUYDjZ5GOx9ixgzx+5yBDd3yD' .
+            '8ZFnEVLh5xpqDzsRW9Mki6I4/YmwxuI4CqVe6UcS146JiWMz3XhZk6SJg+Fli2gd8uLje9n//b/m0H3/RBRM4Xh+MofQmFSCRhTal7JgzRWYOBTGSiGFKAba' .
+            'fqavb1DP5tFus14CJruR9/PD4je7PCvuEYIF5cgKLHLTu38JP9cISE4eOcDRp+5jbPgQGIPjZZOWyJQUIlXPxpi0xyghW0trEwBaG4oNOdraW9DanMWJFVhr' .
+            'OPzCMMZopJQEYcTY6CmElOkxAqVE+rfV75ZYo9FxiONl6Fy5KRnt1tSJCSsYEycTZLA88r2/JKxMWc9RRimCINZXXvXpx/ZXG+7f+BU/v5gDBNzq7GC3eU+m' .
+            '59OtBeem0SkdxeVJd9mmd7B4w9sYe/EpDj++l/HhZ7FVuy4lSq0TzRjiKMbP+CglaetooVjMA9DQVExDL0mAOCHf2ZYtCbsoVWuzJIpiJsYnUY7D0ReHKZcD' .
+            'giDAaIPjOum5LNaK9CUwxEEJL99A65J1LFyzhUyhOWkT9XxGHr+XJ+/5Nm62GDXlpDs2pf9ctfgfA5iNtuCsJqAlmfLz/O9dnXkxGD/uKJmJ41hk8o1i4dor' .
+            'GTt2iBPPPQZSJd4u03adMQZjErVYLOZpbCpSaMjR2NiQklNirUXr002rc0nhzbQThRAolcQSTfr7kWMnCIOQ4WOjtfM7jkqPTcJAJo4xOka5PgvWXIGUDtYY' .
+            '3EyO488NMXniCMJxjSuRUqsV36k89Bwk8w7Px9q+WZjVBLzvtl538/X7onu+0H1Ta4Nz46myQccaN5NHxyFRZRLXzzNt/AMIwjAim8vg+y4trc20tjXiui5a' .
+            'm5p6tWkQ+XykjO0MNQ8J2SwQlEOOHD5GuRwwOVGqqf2Z322tJQ7LQDI4ycsUcDN5gtJ4LITShaxQ41PmG2/57aEP7UqLMF7/Fb95mLUETAozB9iTX7s+J71/' .
+            'NIZMOTIlR8nFRuvaXL5q6CSZ/aKx1rKwq5O29mZyuWxq8yW235tVoFAlpFQSKRJ7cGxsgmOHhzlx4hSe59Zs0uTaU19RJKPjsJrmoo82FiVAGzgxFb3zX8LH' .
+            'ds227Mis9oLFAIbAadBG/NqJU/bK5qz7FwJrhJSW1J6qIooicrksK1YuZunyRfi+RxRFNQK+mdUx1byxNZY41sRxTHNzA6vWLmVRV2fNdqxeUy0fbTRSCCwy' .
+            'OjkR3zZeiv/6xET0NUeKr8PsU78wiyUgpP2+fYP6D359tf9jSzIPNOXUuuMTcW2noqqtJ6Vk2YouGpuKuK5LFJ37HJc3C9WXwHEdylMVjh07ztHDw7ju6dtC' .
+            'WDA5T5gwtjdu/tT+L1/ASz4vmLUSsEq+229c07V1efbBrCvWjYzH4cydinScqOLVa5fR3tGaSpb6Ix9M24dRGOFlXJav6GJhVydRFJ8moQXIcmhla9H90t5b' .
+            'ev4I4NDXtmbsLK0PrL8ncQ6okm9X/9q25qK321Wie6KsYymEk2S/Ekdj0eIOFi7qxHHkq4RP6gtVwgkhqFQCDj71PKVSCceZ7l9ON8B2T07FX73q0/t/M3XI' .
+            'YmZZ2+ase2v6+5Gib1D/fX/3goa8d5erZPdEWcdiBvmiMGJRVyfLlnehlETrN9fGe72YGZ/M5TKsXbeCbDZDHCfB7fRv3BMTUdySd27Y98X1X958/b5o587Z' .
+            'N8Jj9jwVkqzHvkW9ykxUFviI7zpKrD9V0lrJZMC4tYlR39XVwdIVXcTR9Bzm2QprbZre0zz+2AFKk2Uct1ZFZ4GopeB4I+PRH15z49An7tixVc2mUMwse2O2' .
+            'ys3X74viiv3FhpyzfrxkAmcG+XL5LN3rV9O1dCFxrGc9+aAaPjIoR3Fp9yqWr1qSSsgkqGnBPTkV65wn/9MdO7o73z6wO55N9uCseUJ253a1Y/+gfY/X/X9k' .
+            'ffmNILZYmxTUJjZfSPeGtTQ3NxAEZ5/vPFtRtQs93+epxw8wfOwEvu8lYSSsybpSA08Qi/dEzd6x3sM/rcXAQN2HZWbFm1Il33Xe2rXFnDMYaSuMSaqBqw5H' .
+            '1+JOCoXcnCQfTNuFYRDQtWQB+UKu5tELhCyHVmY8ub6k429tvn5fdAd3zIpnOxueVK1Q6r5be77uufLflQKdbo8qiKOIhV2dLFuxKFG7cxyJTaiIopgnhg5Q' .
+            'LgfV9J0VwsZZT+nJivnwNTfu/5vZkJqrdwKKnTu3y8KRB5z2iv9XTTmn78RkFINwqqm1BQvaWLqi67TMwVzHTMfkiccPUikHSCkwBislIutJxiv6F37sxqFv' .
+            '7NyO6hukbt/MuhbT/f2Ivr5B3Vb2e4sZ1Teakg+oZTgWdHWg09zvxYKk+cngZzw6FrQRRUmjlBAIra22YH0pfufOL15SbO/eKl65j+/Coq4JuI2t0oKwhltj' .
+            'YzUzpoRKKVlzyXIcxznjJtJzHUImtm97ewtdSxYQpy+hlEKVKiZqyDlrPZz3jwzttvTX71i3uiVgdar9fbeuf2dTXm0uVbShOtk0jlm6ooum5oaLTvrNRJLr' .
+            '1ixfsZimpgJxXK0CwpmsGKm1HegbRO9gt6nXFapbAlan2kfa3BhpsgYhZWr3FYp5mpoaLiq772ywNlmTzgXt03WMFhlpoxuyasXdN6376MAA5vt1ugNnXRJw' .
+            '53aUGMDc8/mebYWM2jYVaCNIwi7GWNo7WnDdCzvXuV4gRGIPNzYVKTYUahrBWouxmIynPv7wLRuat/V02HocdF6XBFz5zl5591cWZ5XDja7CWKypBpsXdXWy' .
+            'YGF73Va1XChobVhzyQoyGR+tDVJKNVnRppBRm0pWv1v0DWrqcLuHursgu3O76j28T8tKcXMhq955qqSNFNIxxpLNZmjraL4o4n2vFdXQTOeCttq/pRCyFGhj' .
+            'LDcD7Oirv/bNuiMgfYNGDGAM3BppI0Raj26Mwfc9cvnsrCqterNQ7ahrbC7O3LdOBpHRrUWna+8tPb88AKbehlvWFQF3ptuT3nNLz88Ws05vGNnanqnWWlrb' .
+            'mjDavGTywDyqMMbiui6NzcVpWxChyqF1pRQ37P1S94J62/qrrgjYvX+/EmAFXJb3la8NGhDGGIoNeVpam3/EzQEvDlTTdB0L2lAq6a4TIEuhsVlPdDvWl2IA' .
+            'U08DLuuGgP39yJ4dQ9GeWzcsdiS/eGIytoBbjfs1NhVxPfeiDDqfK6rpycamIo47vVZSWKuNNdqEO6xF9PRsnyfgmSAE1sTS+q5cEWmLEAhjLL7vUyjmL+qg' .
+            '82uBNZbmlgZmTNy0jhIyNmwQAtu+f7huFrGuCAigpN0QaWtmTqiSStHYWKxNjZrH2ZGoYVHLEqX2sohiazOu8O+5aX3nyFDHq8x5ffNQNwTcxlZpLQKhv+A5' .
+            'QmKT2B9Y2jua097YefX7akhMFkM249PY1FDtI5HlwMRNeedyIc3P9A0O6nrJD9cNAaE2/+fkTC1bdUDmVe+5w1qLn/HJZj20rk5XgFhbaxGjF/jyTkNd5Aft' .
+            'zu2KvkG999aedxV9taUU6BghVHVWCswMbc3jXJDsPaemQ1ZCqKnACAG/fehrW/+Bj+wO0lmcF3Rl60MC7h9OFsKyJOPKxii2Vgoh4ljT0tpEQ0NxzjggyZTV' .
+            'N/Y7qhMhFnV14rpOMvcGRKwtYDdOTY04F5p4VdSFBKzB2nJkrK03nlkSzxIAAUqKH4lE1oLnKayxaGNrHW/VcyXN6Oftsqsbw9cgBGDE1HhQrJtcZl0R0Ehy' .
+            'vMQ7e7M935nEqk3SVwI3n2awtKVUjnDUa1Me1loc3+Gh/cdpa8nQ1pIlimKKeRec5FxxoIljQ7oxNbWlED+6y2r06esnhJUwngXKP+IpzysuOAEtCDGwO37w' .
+            'yxvzQaRvnSxrEMKx1iKlpFDMv6Her6mqRAuOI3AdibUgJcle60pSHo944NFhslmHw0enyPqKt711MeWJEPVqaUGRXLsxoDzJyGiF//Htp2ht9ilXNNduWUBH' .
+            'W5ZSOebSVU20tOWSeWsmSa0JAdpYomiamOeSipy5fuOnJhBCiNiYuDHr5CdK+lbgV/fd1utwgaeqXnACng6btdV58tbiuoq2jpbzMrvPWlszesSM4Y8Z30kk' .
+            'kITyqZCR0RJ+1uHQs6fY+8Awrg+jp0o88/wEjisplWLevXUpWgQ4/is3vwvAxAprwPMkJ0fKPPTYcTxXMlWKEQJuv/MFjLFEsWXJojytzRmmpmIuW9dK97oW' .
+            'glJMseBSbM4k4llbgoqutQpW70pw+vRWay2e59DW0cLYyVPTqbnE2M6+rsU8j6grAtqXbLhiLejY1Dzh14pqKsoCWV8lEs2C0RZtDJ7v8Ohjozx3eJJc3uWp' .
+            'A2M8efAUvq8wxlKOQlY1LWZ942o29pjqCGii44aR+xsp5N107sxL7qPqXlpBpmsMnBghJJVKzJGREhlPYawljgxSCKQjKBYcxk6FHB+tYKzlhaOT/PO/PU8Y' .
+            'ahYvLLCxu5VyOaKtJcuWyzqII4NQpON/E1QqcfUSawTVZy5dq5uIfl0R8Ex4rYIvGeCYHOdlndpJnn3mFJUgxvcVd+w5zLGRMr6nOH6iwlQ5QkmB5ymyGYW2' .
+            'FteVCOlyvDTGz655B4VMBoOpSc/S4ZgJ83LyJd9nMYFLdukJrBsibdI41dqc4dMfuxwsVELN7Xe+QBQnJHz62VOEoUFK8D2VtllaslmH4dESf3/7BMZYfE9x' .
+            '131HiSJNseDxE9cuxliLlIJVK5rSl8wSluP01uvMo3sJ6p6ArwUWCMJEPUWx5V+/9wyxTh7wg0OjVIIYKQVKCkQqDT1XUsy7VCqaSqBpKLj4jmJyKqKx6HPt' .
+            'Ne2QeRFzfDmTQTkdqQvSFa8Yw3JzIf7yETJZl7BkKVeS7y7mXVxHovIuH1lUqImrR4aOUyonL8idPzzC8PEyuazD5FRUI2km6+A6guHjZRBwYizgtq8PpTar' .
+            '4PKeNhwlMBZ+4toumprqv21hThDQWnBdychomT/+q0fx0kHf45NhLbSRyzpkhZNkBkSihq21nApiFrTl2NTTjtaG8YkQYy3jEyFBqLlrzwiPNB9nc0eJ5VyK' .
+            'kVFSMHa25yospuKS7z5Crj3iscemuOuHL/Lc4Ul8TxGEmrbWLFuvWkTP6mbi1EvdsK41EdsCLl3ZRBgZPF9x/8MjHHp+nFze5dnnJ3jmhQl8V4JIXiRHJTsz' .
+            'ua7k/kdHAChVYn6st5Pm1vqWfjBHCAgJCZVKvNhKkHTLFfIu5YpGa8PYeEhbc4ZCwaVcitm4rpWedS2Up2Jam3w61jRz/w9eYPAfDiCkJJNxiLXh1KRmfELx' .
+            'xIEf8Lalk7xj2VVU4uDMFyEsaIm/6CSFxSE/uGuEb333IJmsi6ME5YoGAcdGKvzF/3yM6962hJ/6ieUElZhyqjJJpVnGV2DhLb2dvOWqhaAkYyMljgyXyOYc' .
+            'Dj07zp4HjpHNOJQrMcPHy7iupFLRvOOaxbR35IjD+q8cnxMEFAKiSNPWmefqTZ38/fefpanBp1SOufKyDtpaskyVIzZ1t9K1sEAUahwlUzVswZHc8Y8H+c6/' .
+            'HKKxmCUOy0SBqH1ubUhLoZE7X3wQgK1LNhPpMzRFaYkVhubLRrhzzxG+/U+HaGzKElXKJHslitr2sK0teW6/8wUAfuqdy4ijRBJKefpec9ZYyhMh1iZS/NLV' .
+            'TQgEyxYVuHbLAlxHMXqywr0PDZPLOhw+VqKh6OJlHKJy3cSbz4q6IqAQ4kdeMSHAxJbGBo//+Is9LGjPEgSGzrYs0ks2IYwDTbmUBJFjbdChJZNzefzJE3zn' .
+            'X56huTHH5KkTLF67iV/47P+DVA5SKr79B5/i0bv+kcbWTn7wwv00ZxrZ3NnNZDSFrG2hAAZD++WjPPXMGN/8+0M0N2eZHDvL+e7+RxqbO7jzh0d44uAYQgiC' .
+            'MGbl0ka2XN5BFCS27GnORerV60ijtUUKQRRrmho93vOOZck1hJqx8ZBgKsR1zvJ4X8c6n2/UDQGdyVgEGdHwUpv5XI1oIQRxJWbzxvYk/mZBFCCKDb5KJIrj' .
+            'SZyMojIVJZsICsHERMid9x4hm3EJgxJdazby0Vu+TqG5vXbuX+z/M/7ydz7MwYfuJu/leWD4MVY3LSbjeOh0yy8TKPzOCWzbcXb/81GyWZew8srnO/DgXfi5' .
+            'PCOj5TTILLj/0RF++NBwcu9YHCnZlDoXCKgEmi2XdbBscZEgiBGAciRZR4IB6UhaOnKEUyHY09fPkvAYaxt+lGf0RqAuCGgt4qk/DKOpKf/7nit+vBxZK6UU' .
+            'YRhx+IVjrFi19Jz6gC2pLehKZLrauhLzw4eGk7iYAdeTqZdZwXMl2iQequc5RBXLhwa+RqG5HaPjdK9gg5fJ8eHP/xU3/8IVxEGZY1MnmQor5L0MWhswAqex' .
+            'QmHdMMEEPHd4AkcJ4vDVzxcGZVxXEccmJYggk03CMJYklnnfw8O1+J6x8MSBMTxPISyEsaGjLcO1WxYShckuT8ZCz5pmIObwC8dqQWiFEJXIxALxfYCJw4UL' .
+            '7iJfcAIKsHbHVmftwO5g7y3r/zjnyx8vh1ozox3zXGCMJVNweeihEXbvPUI+l9xaEGqefuYUiGqGBXxf4ihJECaayE8DwyJ9UNaYdHdLAUltLMbEKOUQGYvn' .
+            'OCjXEkeAsuiKJLvmJCofwLgk4yvKFX1O50vTGbQ0+UiZTMYfPl6ikqpg33co5N1acDspYLAEga5NTX3x6BR/9c0na7VVWltu/L8up7XZR09LQKukUFOBnbzm' .
+            'xv3/N8C2gd0XXBVfcAKeBmEatFGnvZWy+uBeBUoJpqYi9jwwzMHnxvH9pOpESEFD0UuSzrK6bTSEoa7lV5UUuJ5KNgP0M8lmgSYhANYihMTL5GopwTDSFDe+' .
+            'SPFoI6XhHPnuEbyl4+iKg0UTprHIczmfFBBEMR/62R462nJYC/c9PMzxE2WyWZeHh0Z5/kgSwom1waQFpo4j8b0kb+0ohe+mdZMkkl6msc7q/VY/kwKzp391' .
+            'w9UDT4+fp6f2ulBXBLQWP+MKMbM8KQyjVx1ClMQBFcNHJxk6cJLWZj9N5CflTlGUEqcSo7Ul1oYF7Tk623NYY5mYDDk+FiKwDH7pN/jQwNdw/TRdmu6aufNL' .
+            'n6A8cRLpZmkpuohMyMHyQSrjTeRKL9A+JmhqyOE4gvbWLEdGKud8vqYGhVSSMEyciy2bOkAJEILe9W1MTEb4OYehx07w0GOj5PMOoycrPH94EkdJpBT4nkoL' .
+            'EASVQGMMBOXgNA2SStGGfLtXN6m4uggSWYsY7NsuF20cWp7PyL9H2LVBZJBCyiiKuKR7FU1Nxdr4sbPBCPjWPxxkzwPHErVqLIW8m8THAs2Wje0sW9JAaSpi' .
+            'xZIiCxcVwFU88uAxbvv6Y7S35jg1Okz31dfx73/7NoRSSKn4zh9+hnv+7r/T2NbJxHjAR37uEha05/ncV/fS0uxy4njMz/zECt79zqWgLY88PsqffuMx2lpy' .
+            'jL3K+SYnQ/7d+1bT+2OLYDICYymlMUELuI7EcWSNXEIIcCQnjpd4/MAYuazD8PEyd/7wKBlfMTEZsWZFA//+57p55vFDHB8+iee5GGN0IeOoqVD/t1K57RPb' .
+            'hjpsPWxqWBcSUAjsrv5hce3n9h+4++aekcacvDQI0aQ2z8yE+9mgtSXb5NPRmmXd6mYWduYolWLeumUh7W1ZwlBTyLlJSMZYolAzNR5igXVrmnnfO5fxvTtf' .
+            'oKG5g6cfuJMvf+TaGtmnTp2gobWDKIxpafapRIZ9jwzTXMjgS4d8TuC6iZdaLsesW9PMu962hNvveoHm1k4OPJieT0qw9rTztTYnw4T23X2YKDIsaM+yfGUT' .
+            'pOZBUjyRCKykuMISVWIKWZe3bF6Q/D62XHNFJ66rGBktMz4R4PtJyGd6w0NM1pNqKjT/lmzlUB/j2uriIqro70dKxEhVa9jUXjpyeJj8mmWvKP2UEkRTEesv' .
+            'aWbr1Qtxsw4YiMPEWM9lHKLYYEJNNqNwMw5uBpCCqBTRu6mD4eNlHn58lFwuT1CerJ3by+ZqI0HKFc03vv0UUoqkcCHd+NqYam2hRceGn/qJ5QD88+7nKRaz' .
+            'RJWpWkjET8+nlKBciRn87kEA4tjQ3OjTtaiASb1i15Fc97YluI4ELFpb2loyuDkXYgNCIBVJ5gRY1JFjycICp46dYnxsvLb/sFKIMDYVm9BY0NNxwT1gqCMC' .
+            '3sFuMzCAee+t5oYglu+ntkkuVEpnSX29BEYbFnTkk/8PDQKScEiqaJQU+L7ihw8NM3qykuRSXcULRyZ46LETFHMuvqfQWqOUk2QkbFK6VYUQUEiro6sFo9aC' .
+            '6whkxiEbJY5PUIl5z7YltLRk2LvvGIeHp/DchAxRekHV0nxVjVM6SfrvqQNjNePIWnjqmVO1er8g1Gxc18rihQXiSKPTKpstl3UQRSapjAG00QRBiOsm6jef' .
+            'Uc7YlP63az479M1d/Vudt/cN1sX0/LohYBVSeH7GM3KspK0SoJQkCAJGhkdZsLDjrPFAa5OA7PDxMifGKiglUUowMRnyvTtfSMq00krn4dFyWvqUpMZcR5L1' .
+            'FUGk03qAJMMQhslspFzWOa3s6qXjQRwlGB0LeObpMaJyjLGwcmkDUkmu6V3AhrUtTEyGKJVcg7XgeopnnjvFngeGyfgqqd0zlqefOZWEhNJze65Ke1AsFks2' .
+            'oxh68gQPDR1Pm48sXhrbNIZaHPAt6z08z0GbmQWrtLwxT+1HR90QcGAAu3PndlU69PBRHbjfKmbkB0oVrRFCGWMIw+gVsyLWWpyMw/2PjPC3tz9LQ3F6Noqj' .
+            '5GnuluvIGf2ygig2eJ7C8xI1FoaaNcsb6d3UgYkM/7T7eaZKUY1AM5HU7Cnue3iYPfcfRcgkTrd6eSPXblnI+nUtuI5kQXvuZQU0rRva6b2sg/RCsNrw4P7j' .
+            'xDqJDbq+4v6Hhjn0wgQZ38GSqOkonp4QVi3AGDlRqZ1XG0ulDH6htrGhCLU1UoivAIwM7a4L9Qt1REDAdu/fr9YPPDGx5+b1D2fz8gNTFaOxVjmOw/CxUTo6' .
+            'W1OP7izrl3ad+V4SaDYykSRa1ywfjLGojMOVl3UkYQkJYWhSZyWTZCQMZLMOTtHjO995ivHJEM+VCAT2ZTSaLgerElhKwaHnxjn0/Di/8P41bNrQTmXqbJJ7' .
+            '+nxCwOUbO6Y/FNC9qikJmIvkxRk5XuEHPzyC50lsKvEeemyUMKyN4Ti9H5ik/FkKIa3StwPs766PlkyokzBMFTZtCNn75Y3LXWseApuPY4SQSY9wR2cLy1cu' .
+            'PmM4xhhLpujx3X8+xJ4HhmuxwEqg2XhpK92XthAHGkuS+Vi2vHG6BU6ACUxq6yXnNVj+1z8c4N6HRmgsemhtCCNTU5evcA+EkSafdYl1Iq1+/n2rWX9pKzoy' .
+            'r1rh/dKXq1Ydk/Z/KCmRvpyOLqfV3kFKQKtj/u2eZ1i+0KWpIIm0iZsLrjNeigc9pT5ycnNz8Pa379bM9wW/HEJgbX+/vPo/Dxy656buP28uOp8Ym4y1INkR' .
+            's1IOONs7I4RAh4ZVyxq4+opOWpoSaQaJ8yGUqPV0YCzlybB2pmoOtjrwO5Nzuff+o9yx5wgLO3JEsSHrK9atbuaRJ07guTIl4cwzJF5w1ndYt6aJB/cfx/cc' .
+            'wkiz8++eZvWyxlovyCvhTB1vM0kZxQYT6dO+eVlXIakyEIKoHHBqtYuxAm2sdaUQYWQq1oivbvr0w1PpENC6IB/Uy2SEmdiRTEpVMvqjOLYjrhIYa63jKCYm' .
+            'phgbmzjjhHwhkpDLJSubaCh4BIFOwyOWMDJUKjGVIKZSiQlCjUolS61EP32iUiYZkw2XtvKT71iGTA39t121iBNjQZqPVWl6LcaYGGsMUjkoKSmVI3IZl80b' .
+            'OvB9ydqVTXzwJ1eRzU47BK8HIk0dzrz2IDSUSxE6hkMHjxBGtQ26TcaTarKi//WqGx+9x/Yj+/oufPB5JupKBVeRbj8f3XNzzx835dXHTpViIxCO1pqGxiKr' .
+            '1549JpgQ8/VPGBCAm3c58uIkLx6ZZPfeIxwdmSKf86mUprDWUGhKBoIbHTM+eoxcQ3PSsFSOuWJ9O+/ZtoTmthw21ETxG5f9qvYAT0yUOPDkoZo3DDYuZhxT' .
+            'CsNrDt73+EPbt29HzBPw1ZEWfnDf7/a26qh8VCBkakiLIAhZ1NXB8pVL3vCtGmJtyDX43HX3i3zzuwdpbspSKZVo7VpO73U/xzXv/TBCSkrjJ/jeX32FR+/8' .
+            'LkZHWCtQSvDxD62nqclHx2/OXOuHH3icOI6RUmKxcWPOkeOl+G9VS7YPYPMFbkI/E+pPBZOWaO3cLjd/ct9xY/hqc8ER1lqNtXiey4nRMcrlJNb3RnZ9ua5i' .
+            '4kSF79/9IvmcSxAEeNkcH/v9v2Xbz30cP1fAy+Ro6ljM9k9+lZ++vp+JE8fxfI+JyYh/u/cIypPndd7LS5FMEHMYOTZKFMW1tKUQQlZCIy1ix+br90W9h/fV' .
+            'leSroi4JCMD+btvf3y+l7/xpJTTDviOEqW1YE3Ps6PFzLtX6UWCMxc0o9jxwjLHxENd1iCplrnnfL5ErNqPjqjCxGKOJo5B111zHig1XUp6coFj02PfoCMNH' .
+            'S7juK3vOPyqqQ8mDMGRkeHRG3tfqhoySldB8++rP7H/I9vdLMVA/zegzUbcEFAMDZht3yKs++fCTExX9TdeRKkm1WlzX4ejhYZ595vB0o88bdR1pBoW0vm/9' .
+            'tT+Z5KhldelEkvSXkkJTG8vXX0VQnqplEt9I6VfdPeqJoYOUyyFKSYy1VkmhgXGlxO/29yPpGapLUwvqmICQ5IdtP7KQl/811uComSR0OfLiMJVypZZwfyPw' .
+            '8rEb5hUN55nbSLyR5DPG4Hkex46OMjU5VYsMWGt1U8HxTk7Fe6789P67Fx3pVfXmeMxEXRNwYAAz2LNdjJ5sHY0i8/MZV8RS2pg0jqWU4uDTzxOG8RtjDwqS' .
+            'qunqP6Xk0CN7k4ClmX6m1hqM1pQnxjh66HFcPwNY4ti+IdtKWGvxfI/hY8cZOTaK53kYY5KSK1/JU6X4iaIvfnlX/1bnV2/bVxdFB2dDXRMQoK9vUG9jm7ny' .
+            'xv1/M1HWH28puK6xREnoAUqlMk8MHSSOddp8c36+V0pBXNFsuaydxqKX9BL7Pnf8zz/C6BjleFhjqOpn1/M58ODdPL73dvINTUxMBFy2rpW2jlxakX1+rqtq' .
+            'ghwfPsmBp55Nixss1mI9B2O0LSGjazd8cv/zd7DbpKNy6hZ1T8Aq7rut1815zrenKnp/Y056xlpjbVLCVC5XeHzoQJqiO/dWzleDjg2tbTl6N7QThDG+n6U0' .
+            'Mcaf/pftPPCv30rsQCGIKiX+9X98lf//v32WQnMbcRiRzTi85YrOdH7g+bmeqsc7OjrGgaeeRSk1HUAXmIac41Qi/SebP/nkcbtzuxqoU8djJurWOH0pbD9S' .
+            'DGB29a9tK+bcXUqKdUFsk95tKQiCiBWrlrBocSdhENa6yF4PTDqj8ORYwFf/7GHA4vsuk6fGUI5Lx9I1AMRRwOED+8k3tuC5DmPjifT7Dz+3jqAUJRMWXu/9' .
+            'W4tyFFJIhh59konx0gzb18ZZT4ow5iubP/Xop+67rdftvX5fLOoo5XY2zBoCAtjbel1x/b7orpvWvX9xS+bbx8bCigWf9D6ESDZo6VrSied76FfpITmn77Q2' .
+            'rd2b4C92PkY50DQUMhhjCCtpQ7kQZLJ5ojhmfCKgZ00L/+cHL2Fm+vl1X4ObSL5jR0aYmiwnweZE9eqMJ1Ul1FNX3zhUqBZ0zAbywSwjIMCu/q1OOyNyKiNv' .
+            'aimqT46OR7EQwoHpLrpCIcvadatqDd+vNwthTDLC48ChMe645zCPHxhDKZGSIKkDCMJkkull69q47m1LkjbK+PXbftZYXN9ldPgETz/1HEBN8hlrjedI4SlR' .
+            'mgr1+5yW7A96b19p6qHZ6Fwx6wgI0+p47609v9ecd244MRFFQggX0hEdcUw2m+XSnpX4vkcYvv6UnTHpOF8sTz87zu13vsDEZITrCioVQ8/aZq7s7aSzI09Y' .
+            'il63CVA93vNcho+NzrD5RI18riOlkoQTU1z3tv5Hd/f3I2eD3TcTs5KAAHbndiX6BvW9t/b8XkvBuWF0Ig4tuIlGTEiYy2XpWNBGezpn+vWTIm0qyjjoeHpk' .
+            'b9IcnriblYqu9Xj8qDAm2aAnDCOOHR1h5NiJ2hSE5DowriOkqyiNV/S7r/3sYz+oFnC8ri++AJi9BLSIwR3dbt/AULjv1vVfasjL/zw6qSFpD5bVzVqiKKZr' .
+            'yQKWr+hCa31e4nImNbRmkjnhpj0vqUHHdQiDkMeHDjI5UcLzpss2rbXad6VyJKVTleinr/3sE7ts/1ZHDOyu63jf2TBrCVhFVRLuubn79wsZ5z8GsfHD2Bgp' .
+            'RDpNN91Dt7FI58I2GpuK6eYw54cs5wvVkiprLcNHRxkZOUFQCXAcVX1pDGB9Vypr7YlKxfzMNZ8bunO2Sr4q6ucJ/IiwIAZ3Ivv60Af/+PJlo5PhPxez6pKx' .
+            'kjYkI/RqdqEQkobGPKvXrkCppNA0TV9dEDJWSQdJPHPs5CkOPPVcrcysOtXKglEC2VRwODkef+WBZ078zvV/cqRUtYXf9As/j5j1BKxi587tqq9vUN/Vv7Ej' .
+            'VzR/q7W9EoTVxhgQTnXrV60Nfsajc0EbjY0NuJ6DchRxOn/mjSbjzPO7rkO5HKC15ujhEcZOjqc9yUnVfJrliH1XOq4jRkoV89dXfmb/bwHs3I7qG2TWeLtn' .
+            'w5whIKSDp9LU0w9v7f5gxlODAFOBCbG4QiQOitZJvy9YGhobWLCwhYamBqxJJJLWuuZwnA8yTm/5Ne3Faq05PnyS4WPHqVTCtNR/unbQWqsRiNaCI8uheVQT' .
+            'vPvy33rqxXRnUTNb4nyvhjlFQEg763ZsVWJgd3z3Td2/0JxzflNIeqcCQ6STXa+llKoqieIoRjkK13VoammkqbmBbMbHz/oYbTCmSlZq6vrVkMQdU2kqBSqt' .
+            'W5yYmCKONEcODxMGUa2otjrJPxkVaGOscBpyiqmKQUr7veNT6hffNfDw8K7+rc7bZ6mzcTbMOQJWsXMnqq8vUVH33dr9H2LDjnxGLcfCZKBjgVBViWitrY0x' .
+            '01rT2NRAJuOjlGJhVwdVdaiUxHGSWODZYIEobaJXUlKuBBw9MoLrOJwYPUUYhIltB7UKHpuO9RPW2oaco2JtIm3Ft0sRf/qWzzxyO5wu3ecS5iwBIQlYM5Ds' .
+            '6vHcV67OHo0nPpJz5Yc9V26ZLGui2GgrhBAzijKqKjoZRilx3WQsh9aGYjFPW0fLDBV+OqptnYdfGMZYU+uoi6JEaDnOtAquXaO1sZTCyXrJuGBXya9b4i+v' .
+            'v2HoQUgyP9sGduu5onJfijlNwBRiV/9WVVVdO29YnN20vO2nTpWjW7K+XB1rSzmwVkhq7rCcMRipKhmrcUWjqy1nZ+ODQClJ1cZM1OtpKjx1HIS0WNucd2Q5' .
+            'MmEY2X81wt58zaeH7oSqd7+97toozzcuBgLWUI0ZVv99z83r/pPnyF/NuKon0hZXCWJtKYU6SocUKU5fI3EuTomtRqWn/20AgxCqkJFSIAhigyMFriP+cqpi' .
+            '/3zzpx75ASQSrzop7Hzddz3joiIgpBmUwe1y+/5Bm5R3Xda0stO0HDtlPp3xxCWl0LR0NHjrI20oBYZYV40vizE2rla3nEn+Cao5XCFVuoGIsZacJ8l4kqmK' .
+            'oRLqXQ05R42VzZ+25vx71v7GvgOQmAuDQ4i5EFp5LbjoCDgTZ/Iq77utN5cP4r6JqTA2yN/yXdYEoTUIVGPOySVjIs8OKQRTgSaIzJQQQuc8oUqR/e++y71x' .
+            'KCY2f+bRb8/8+4uVeFVc1ASEatgGMTiEaO/eKmYSclf/Vqe7fSRzpOzYkox9GfBFR0lP6zNrR4swjTkpJ0pmr+eqv6xMltRVq3JafOjhqZnnBNjGbgMw2zMZ' .
+            '8zjPsBZh+7c6u87jDOX+fuT5PudcwUUvAV8FYqa63Xdb7zkRqLd5paFvsCbZ5moIZR7zmMc85vF68L8Bahatj5OaeM8AAAAASUVORK5CYII=',
+        'image_width' => 160,
+        'image_height' => 160,
+    ],
+    '+1' => ['emoji' => '👍', 'label' => 'Thumbs Up Sign'],
+    '-1' => ['emoji' => '👎', 'label' => 'Thumbs Down Sign'],
+    '100' => ['emoji' => '💯', 'label' => 'Hundred Points Symbol'],
+    '1234' => ['emoji' => '🔢', 'label' => 'Input Symbol For Numbers'],
+    '8ball' => ['emoji' => '🎱', 'label' => 'Billiards'],
+    'a' => ['emoji' => '🅰️', 'label' => 'Negative Squared Latin Capital Letter A'],
+    'ab' => ['emoji' => '🆎', 'label' => 'Negative Squared Ab'],
+    'abacus' => ['emoji' => '🧮', 'label' => 'Abacus'],
+    'abc' => ['emoji' => '🔤', 'label' => 'Input Symbol For Latin Letters'],
+    'abcd' => ['emoji' => '🔡', 'label' => 'Input Symbol For Latin Small Letters'],
+    'accept' => ['emoji' => '🉑', 'label' => 'Circled Ideograph Accept'],
+    'accordion' => ['emoji' => '🪗', 'label' => 'Accordion'],
+    'adhesive_bandage' => ['emoji' => '🩹', 'label' => 'Adhesive Bandage'],
+    'admission_tickets' => ['emoji' => '🎟️', 'label' => 'Admission Tickets'],
+    'adult' => ['emoji' => '🧑', 'label' => 'Adult'],
+    'aerial_tramway' => ['emoji' => '🚡', 'label' => 'Aerial Tramway'],
+    'airplane' => ['emoji' => '✈️', 'label' => 'Airplane'],
+    'airplane_arriving' => ['emoji' => '🛬', 'label' => 'Airplane Arriving'],
+    'airplane_departure' => ['emoji' => '🛫', 'label' => 'Airplane Departure'],
+    'alarm_clock' => ['emoji' => '⏰', 'label' => 'Alarm Clock'],
+    'alembic' => ['emoji' => '⚗️', 'label' => 'Alembic'],
+    'alien' => ['emoji' => '👽', 'label' => 'Extraterrestrial Alien'],
+    'ambulance' => ['emoji' => '🚑', 'label' => 'Ambulance'],
+    'amphora' => ['emoji' => '🏺', 'label' => 'Amphora'],
+    'anatomical_heart' => ['emoji' => '🫀', 'label' => 'Anatomical Heart'],
+    'anchor' => ['emoji' => '⚓', 'label' => 'Anchor'],
+    'angel' => ['emoji' => '👼', 'label' => 'Baby Angel'],
+    'anger' => ['emoji' => '💢', 'label' => 'Anger Symbol'],
+    'angry' => ['emoji' => '😠', 'label' => 'Angry Face'],
+    'anguished' => ['emoji' => '😧', 'label' => 'Anguished Face'],
+    'ant' => ['emoji' => '🐜', 'label' => 'Ant'],
+    'apple' => ['emoji' => '🍎', 'label' => 'Red Apple'],
+    'aquarius' => ['emoji' => '♒', 'label' => 'Aquarius'],
+    'aries' => ['emoji' => '♈', 'label' => 'Aries'],
+    'arrow_backward' => ['emoji' => '◀️', 'label' => 'Black Left-Pointing Triangle'],
+    'arrow_double_down' => ['emoji' => '⏬', 'label' => 'Black Down-Pointing Double Triangle'],
+    'arrow_double_up' => ['emoji' => '⏫', 'label' => 'Black Up-Pointing Double Triangle'],
+    'arrow_down' => ['emoji' => '⬇️', 'label' => 'Downwards Black Arrow'],
+    'arrow_down_small' => ['emoji' => '🔽', 'label' => 'Down-Pointing Small Red Triangle'],
+    'arrow_forward' => ['emoji' => '▶️', 'label' => 'Black Right-Pointing Triangle'],
+    'arrow_heading_down' => ['emoji' => '⤵️', 'label' => 'Arrow Pointing Rightwards Then Curving Downwards'],
+    'arrow_heading_up' => ['emoji' => '⤴️', 'label' => 'Arrow Pointing Rightwards Then Curving Upwards'],
+    'arrow_left' => ['emoji' => '⬅️', 'label' => 'Leftwards Black Arrow'],
+    'arrow_lower_left' => ['emoji' => '↙️', 'label' => 'South West Arrow'],
+    'arrow_lower_right' => ['emoji' => '↘️', 'label' => 'South East Arrow'],
+    'arrow_right' => ['emoji' => '➡️', 'label' => 'Black Rightwards Arrow'],
+    'arrow_right_hook' => ['emoji' => '↪️', 'label' => 'Rightwards Arrow With Hook'],
+    'arrow_up' => ['emoji' => '⬆️', 'label' => 'Upwards Black Arrow'],
+    'arrow_up_down' => ['emoji' => '↕️', 'label' => 'Up Down Arrow'],
+    'arrow_up_small' => ['emoji' => '🔼', 'label' => 'Up-Pointing Small Red Triangle'],
+    'arrow_upper_left' => ['emoji' => '↖️', 'label' => 'North West Arrow'],
+    'arrow_upper_right' => ['emoji' => '↗️', 'label' => 'North East Arrow'],
+    'arrows_clockwise' => ['emoji' => '🔃', 'label' => 'Clockwise Downwards And Upwards Open Circle Arrows'],
+    'arrows_counterclockwise' => ['emoji' => '🔄', 'label' => 'Anticlockwise Downwards And Upwards Open Circle Arrows'],
+    'art' => ['emoji' => '🎨', 'label' => 'Artist Palette'],
+    'articulated_lorry' => ['emoji' => '🚛', 'label' => 'Articulated Lorry'],
+    'artist' => ['emoji' => '🧑‍🎨', 'label' => 'Artist'],
+    'astonished' => ['emoji' => '😲', 'label' => 'Astonished Face'],
+    'astronaut' => ['emoji' => '🧑‍🚀', 'label' => 'Astronaut'],
+    'athletic_shoe' => ['emoji' => '👟', 'label' => 'Athletic Shoe'],
+    'atm' => ['emoji' => '🏧', 'label' => 'Automated Teller Machine'],
+    'atom_symbol' => ['emoji' => '⚛️', 'label' => 'Atom Symbol'],
+    'auto_rickshaw' => ['emoji' => '🛺', 'label' => 'Auto Rickshaw'],
+    'avocado' => ['emoji' => '🥑', 'label' => 'Avocado'],
+    'axe' => ['emoji' => '🪓', 'label' => 'Axe'],
+    'b' => ['emoji' => '🅱️', 'label' => 'Negative Squared Latin Capital Letter B'],
+    'baby' => ['emoji' => '👶', 'label' => 'Baby'],
+    'baby_bottle' => ['emoji' => '🍼', 'label' => 'Baby Bottle'],
+    'baby_chick' => ['emoji' => '🐤', 'label' => 'Baby Chick'],
+    'baby_symbol' => ['emoji' => '🚼', 'label' => 'Baby Symbol'],
+    'back' => ['emoji' => '🔙', 'label' => 'Back With Leftwards Arrow Above'],
+    'bacon' => ['emoji' => '🥓', 'label' => 'Bacon'],
+    'badger' => ['emoji' => '🦡', 'label' => 'Badger'],
+    'badminton_racquet_and_shuttlecock' => ['emoji' => '🏸', 'label' => 'Badminton Racquet And Shuttlecock'],
+    'bagel' => ['emoji' => '🥯', 'label' => 'Bagel'],
+    'baggage_claim' => ['emoji' => '🛄', 'label' => 'Baggage Claim'],
+    'baguette_bread' => ['emoji' => '🥖', 'label' => 'Baguette Bread'],
+    'bald_man' => ['emoji' => '👨‍🦲', 'label' => 'Man: Bald'],
+    'bald_person' => ['emoji' => '🧑‍🦲', 'label' => 'Person: Bald'],
+    'bald_woman' => ['emoji' => '👩‍🦲', 'label' => 'Woman: Bald'],
+    'ballet_shoes' => ['emoji' => '🩰', 'label' => 'Ballet Shoes'],
+    'balloon' => ['emoji' => '🎈', 'label' => 'Balloon'],
+    'ballot_box_with_ballot' => ['emoji' => '🗳️', 'label' => 'Ballot Box With Ballot'],
+    'ballot_box_with_check' => ['emoji' => '☑️', 'label' => 'Ballot Box With Check'],
+    'bamboo' => ['emoji' => '🎍', 'label' => 'Pine Decoration'],
+    'banana' => ['emoji' => '🍌', 'label' => 'Banana'],
+    'bangbang' => ['emoji' => '‼️', 'label' => 'Double Exclamation Mark'],
+    'banjo' => ['emoji' => '🪕', 'label' => 'Banjo'],
+    'bank' => ['emoji' => '🏦', 'label' => 'Bank'],
+    'bar_chart' => ['emoji' => '📊', 'label' => 'Bar Chart'],
+    'barber' => ['emoji' => '💈', 'label' => 'Barber Pole'],
+    'barely_sunny' => ['emoji' => '🌥️', 'label' => 'Sun Behind Large Cloud'],
+    'baseball' => ['emoji' => '⚾', 'label' => 'Baseball'],
+    'basket' => ['emoji' => '🧺', 'label' => 'Basket'],
+    'basketball' => ['emoji' => '🏀', 'label' => 'Basketball And Hoop'],
+    'bat' => ['emoji' => '🦇', 'label' => 'Bat'],
+    'bath' => ['emoji' => '🛀', 'label' => 'Bath'],
+    'bathtub' => ['emoji' => '🛁', 'label' => 'Bathtub'],
+    'battery' => ['emoji' => '🔋', 'label' => 'Battery'],
+    'beach_with_umbrella' => ['emoji' => '🏖️', 'label' => 'Beach With Umbrella'],
+    'beans' => ['emoji' => '🫘', 'label' => 'Beans'],
+    'bear' => ['emoji' => '🐻', 'label' => 'Bear Face'],
+    'bearded_person' => ['emoji' => '🧔', 'label' => 'Bearded Person'],
+    'beaver' => ['emoji' => '🦫', 'label' => 'Beaver'],
+    'bed' => ['emoji' => '🛏️', 'label' => 'Bed'],
+    'bee' => ['emoji' => '🐝', 'label' => 'Honeybee'],
+    'beer' => ['emoji' => '🍺', 'label' => 'Beer Mug'],
+    'beers' => ['emoji' => '🍻', 'label' => 'Clinking Beer Mugs'],
+    'beetle' => ['emoji' => '🪲', 'label' => 'Beetle'],
+    'beginner' => ['emoji' => '🔰', 'label' => 'Japanese Symbol For Beginner'],
+    'bell' => ['emoji' => '🔔', 'label' => 'Bell'],
+    'bell_pepper' => ['emoji' => '🫑', 'label' => 'Bell Pepper'],
+    'bellhop_bell' => ['emoji' => '🛎️', 'label' => 'Bellhop Bell'],
+    'bento' => ['emoji' => '🍱', 'label' => 'Bento Box'],
+    'beverage_box' => ['emoji' => '🧃', 'label' => 'Beverage Box'],
+    'bicyclist' => ['emoji' => '🚴', 'label' => 'Bicyclist'],
+    'bike' => ['emoji' => '🚲', 'label' => 'Bicycle'],
+    'bikini' => ['emoji' => '👙', 'label' => 'Bikini'],
+    'billed_cap' => ['emoji' => '🧢', 'label' => 'Billed Cap'],
+    'biohazard_sign' => ['emoji' => '☣️', 'label' => 'Biohazard'],
+    'bird' => ['emoji' => '🐦', 'label' => 'Bird'],
+    'birthday' => ['emoji' => '🎂', 'label' => 'Birthday Cake'],
+    'bison' => ['emoji' => '🦬', 'label' => 'Bison'],
+    'biting_lip' => ['emoji' => '🫦', 'label' => 'Biting Lip'],
+    'black_bird' => ['emoji' => '🐦‍⬛', 'label' => 'Black Bird'],
+    'black_cat' => ['emoji' => '🐈‍⬛', 'label' => 'Black Cat'],
+    'black_circle' => ['emoji' => '⚫', 'label' => 'Medium Black Circle'],
+    'black_circle_for_record' => ['emoji' => '⏺️', 'label' => 'Record Button'],
+    'black_heart' => ['emoji' => '🖤', 'label' => 'Black Heart'],
+    'black_joker' => ['emoji' => '🃏', 'label' => 'Playing Card Black Joker'],
+    'black_large_square' => ['emoji' => '⬛', 'label' => 'Black Large Square'],
+    'black_left_pointing_double_triangle_with_vertical_bar' => ['emoji' => '⏮️', 'label' => 'Last Track Button'],
+    'black_medium_small_square' => ['emoji' => '◾', 'label' => 'Black Medium Small Square'],
+    'black_medium_square' => ['emoji' => '◼️', 'label' => 'Black Medium Square'],
+    'black_nib' => ['emoji' => '✒️', 'label' => 'Black Nib'],
+    'black_right_pointing_double_triangle_with_vertical_bar' => ['emoji' => '⏭️', 'label' => 'Next Track Button'],
+    'black_right_pointing_triangle_with_double_vertical_bar' => ['emoji' => '⏯️', 'label' => 'Play Or Pause Button'],
+    'black_small_square' => ['emoji' => '▪️', 'label' => 'Black Small Square'],
+    'black_square_button' => ['emoji' => '🔲', 'label' => 'Black Square Button'],
+    'black_square_for_stop' => ['emoji' => '⏹️', 'label' => 'Stop Button'],
+    'blond-haired-man' => ['emoji' => '👱‍♂️', 'label' => 'Man: Blond Hair'],
+    'blond-haired-woman' => ['emoji' => '👱‍♀️', 'label' => 'Woman: Blond Hair'],
+    'blossom' => ['emoji' => '🌼', 'label' => 'Blossom'],
+    'blowfish' => ['emoji' => '🐡', 'label' => 'Blowfish'],
+    'blue_book' => ['emoji' => '📘', 'label' => 'Blue Book'],
+    'blue_car' => ['emoji' => '🚙', 'label' => 'Recreational Vehicle'],
+    'blue_heart' => ['emoji' => '💙', 'label' => 'Blue Heart'],
+    'blueberries' => ['emoji' => '🫐', 'label' => 'Blueberries'],
+    'blush' => ['emoji' => '😊', 'label' => 'Smiling Face With Smiling Eyes'],
+    'boar' => ['emoji' => '🐗', 'label' => 'Boar'],
+    'boat' => ['emoji' => '⛵', 'label' => 'Sailboat'],
+    'bomb' => ['emoji' => '💣', 'label' => 'Bomb'],
+    'bone' => ['emoji' => '🦴', 'label' => 'Bone'],
+    'book' => ['emoji' => '📖', 'label' => 'Open Book'],
+    'bookmark' => ['emoji' => '🔖', 'label' => 'Bookmark'],
+    'bookmark_tabs' => ['emoji' => '📑', 'label' => 'Bookmark Tabs'],
+    'books' => ['emoji' => '📚', 'label' => 'Books'],
+    'boom' => ['emoji' => '💥', 'label' => 'Collision Symbol'],
+    'boomerang' => ['emoji' => '🪃', 'label' => 'Boomerang'],
+    'boot' => ['emoji' => '👢', 'label' => 'Womans Boots'],
+    'bouquet' => ['emoji' => '💐', 'label' => 'Bouquet'],
+    'bow' => ['emoji' => '🙇', 'label' => 'Person Bowing Deeply'],
+    'bow_and_arrow' => ['emoji' => '🏹', 'label' => 'Bow And Arrow'],
+    'bowl_with_spoon' => ['emoji' => '🥣', 'label' => 'Bowl With Spoon'],
+    'bowling' => ['emoji' => '🎳', 'label' => 'Bowling'],
+    'boxing_glove' => ['emoji' => '🥊', 'label' => 'Boxing Glove'],
+    'boy' => ['emoji' => '👦', 'label' => 'Boy'],
+    'brain' => ['emoji' => '🧠', 'label' => 'Brain'],
+    'bread' => ['emoji' => '🍞', 'label' => 'Bread'],
+    'breast-feeding' => ['emoji' => '🤱', 'label' => 'Breast-Feeding'],
+    'bricks' => ['emoji' => '🧱', 'label' => 'Brick'],
+    'bride_with_veil' => ['emoji' => '👰', 'label' => 'Bride With Veil'],
+    'bridge_at_night' => ['emoji' => '🌉', 'label' => 'Bridge At Night'],
+    'briefcase' => ['emoji' => '💼', 'label' => 'Briefcase'],
+    'briefs' => ['emoji' => '🩲', 'label' => 'Briefs'],
+    'broccoli' => ['emoji' => '🥦', 'label' => 'Broccoli'],
+    'broken_chain' => ['emoji' => '⛓️‍💥', 'label' => 'Broken Chain'],
+    'broken_heart' => ['emoji' => '💔', 'label' => 'Broken Heart'],
+    'broom' => ['emoji' => '🧹', 'label' => 'Broom'],
+    'brown_heart' => ['emoji' => '🤎', 'label' => 'Brown Heart'],
+    'brown_mushroom' => ['emoji' => '🍄‍🟫', 'label' => 'Brown Mushroom'],
+    'bubble_tea' => ['emoji' => '🧋', 'label' => 'Bubble Tea'],
+    'bubbles' => ['emoji' => '🫧', 'label' => 'Bubbles'],
+    'bucket' => ['emoji' => '🪣', 'label' => 'Bucket'],
+    'bug' => ['emoji' => '🐛', 'label' => 'Bug'],
+    'building_construction' => ['emoji' => '🏗️', 'label' => 'Building Construction'],
+    'bulb' => ['emoji' => '💡', 'label' => 'Electric Light Bulb'],
+    'bullettrain_front' => ['emoji' => '🚅', 'label' => 'High-Speed Train With Bullet Nose'],
+    'bullettrain_side' => ['emoji' => '🚄', 'label' => 'High-Speed Train'],
+    'burrito' => ['emoji' => '🌯', 'label' => 'Burrito'],
+    'bus' => ['emoji' => '🚌', 'label' => 'Bus'],
+    'busstop' => ['emoji' => '🚏', 'label' => 'Bus Stop'],
+    'bust_in_silhouette' => ['emoji' => '👤', 'label' => 'Bust In Silhouette'],
+    'busts_in_silhouette' => ['emoji' => '👥', 'label' => 'Busts In Silhouette'],
+    'butter' => ['emoji' => '🧈', 'label' => 'Butter'],
+    'butterfly' => ['emoji' => '🦋', 'label' => 'Butterfly'],
+    'cactus' => ['emoji' => '🌵', 'label' => 'Cactus'],
+    'cake' => ['emoji' => '🍰', 'label' => 'Shortcake'],
+    'calendar' => ['emoji' => '📆', 'label' => 'Tear-Off Calendar'],
+    'call_me_hand' => ['emoji' => '🤙', 'label' => 'Call Me Hand'],
+    'calling' => ['emoji' => '📲', 'label' => 'Mobile Phone With Rightwards Arrow At Left'],
+    'camel' => ['emoji' => '🐫', 'label' => 'Bactrian Camel'],
+    'camera' => ['emoji' => '📷', 'label' => 'Camera'],
+    'camera_with_flash' => ['emoji' => '📸', 'label' => 'Camera With Flash'],
+    'camping' => ['emoji' => '🏕️', 'label' => 'Camping'],
+    'cancer' => ['emoji' => '♋', 'label' => 'Cancer'],
+    'candle' => ['emoji' => '🕯️', 'label' => 'Candle'],
+    'candy' => ['emoji' => '🍬', 'label' => 'Candy'],
+    'canned_food' => ['emoji' => '🥫', 'label' => 'Canned Food'],
+    'canoe' => ['emoji' => '🛶', 'label' => 'Canoe'],
+    'capital_abcd' => ['emoji' => '🔠', 'label' => 'Input Symbol For Latin Capital Letters'],
+    'capricorn' => ['emoji' => '♑', 'label' => 'Capricorn'],
+    'car' => ['emoji' => '🚗', 'label' => 'Automobile'],
+    'card_file_box' => ['emoji' => '🗃️', 'label' => 'Card File Box'],
+    'card_index' => ['emoji' => '📇', 'label' => 'Card Index'],
+    'card_index_dividers' => ['emoji' => '🗂️', 'label' => 'Card Index Dividers'],
+    'carousel_horse' => ['emoji' => '🎠', 'label' => 'Carousel Horse'],
+    'carpentry_saw' => ['emoji' => '🪚', 'label' => 'Carpentry Saw'],
+    'carrot' => ['emoji' => '🥕', 'label' => 'Carrot'],
+    'cat' => ['emoji' => '🐱', 'label' => 'Cat Face'],
+    'cat2' => ['emoji' => '🐈', 'label' => 'Cat'],
+    'cd' => ['emoji' => '💿', 'label' => 'Optical Disc'],
+    'celebrate' => ['emoji' => '🎉', 'label' => 'Celebrate'],
+    'chains' => ['emoji' => '⛓️', 'label' => 'Chains'],
+    'chair' => ['emoji' => '🪑', 'label' => 'Chair'],
+    'champagne' => ['emoji' => '🍾', 'label' => 'Bottle With Popping Cork'],
+    'chart' => ['emoji' => '💹', 'label' => 'Chart With Upwards Trend And Yen Sign'],
+    'chart_with_downwards_trend' => ['emoji' => '📉', 'label' => 'Chart With Downwards Trend'],
+    'chart_with_upwards_trend' => ['emoji' => '📈', 'label' => 'Chart With Upwards Trend'],
+    'checkered_flag' => ['emoji' => '🏁', 'label' => 'Chequered Flag'],
+    'cheese_wedge' => ['emoji' => '🧀', 'label' => 'Cheese Wedge'],
+    'cherries' => ['emoji' => '🍒', 'label' => 'Cherries'],
+    'cherry_blossom' => ['emoji' => '🌸', 'label' => 'Cherry Blossom'],
+    'chess_pawn' => ['emoji' => '♟️', 'label' => 'Chess Pawn'],
+    'chestnut' => ['emoji' => '🌰', 'label' => 'Chestnut'],
+    'chicken' => ['emoji' => '🐔', 'label' => 'Chicken'],
+    'child' => ['emoji' => '🧒', 'label' => 'Child'],
+    'children_crossing' => ['emoji' => '🚸', 'label' => 'Children Crossing'],
+    'chipmunk' => ['emoji' => '🐿️', 'label' => 'Chipmunk'],
+    'chocolate_bar' => ['emoji' => '🍫', 'label' => 'Chocolate Bar'],
+    'chopsticks' => ['emoji' => '🥢', 'label' => 'Chopsticks'],
+    'christmas_tree' => ['emoji' => '🎄', 'label' => 'Christmas Tree'],
+    'church' => ['emoji' => '⛪', 'label' => 'Church'],
+    'cinema' => ['emoji' => '🎦', 'label' => 'Cinema'],
+    'circus_tent' => ['emoji' => '🎪', 'label' => 'Circus Tent'],
+    'city_sunrise' => ['emoji' => '🌇', 'label' => 'Sunset Over Buildings'],
+    'city_sunset' => ['emoji' => '🌆', 'label' => 'Cityscape At Dusk'],
+    'cityscape' => ['emoji' => '🏙️', 'label' => 'Cityscape'],
+    'cl' => ['emoji' => '🆑', 'label' => 'Squared Cl'],
+    'clap' => ['emoji' => '👏', 'label' => 'Clapping Hands Sign'],
+    'clapper' => ['emoji' => '🎬', 'label' => 'Clapper Board'],
+    'classical_building' => ['emoji' => '🏛️', 'label' => 'Classical Building'],
+    'clinking_glasses' => ['emoji' => '🥂', 'label' => 'Clinking Glasses'],
+    'clipboard' => ['emoji' => '📋', 'label' => 'Clipboard'],
+    'clock1' => ['emoji' => '🕐', 'label' => 'Clock Face One Oclock'],
+    'clock10' => ['emoji' => '🕙', 'label' => 'Clock Face Ten Oclock'],
+    'clock1030' => ['emoji' => '🕥', 'label' => 'Clock Face Ten-Thirty'],
+    'clock11' => ['emoji' => '🕚', 'label' => 'Clock Face Eleven Oclock'],
+    'clock1130' => ['emoji' => '🕦', 'label' => 'Clock Face Eleven-Thirty'],
+    'clock12' => ['emoji' => '🕛', 'label' => 'Clock Face Twelve Oclock'],
+    'clock1230' => ['emoji' => '🕧', 'label' => 'Clock Face Twelve-Thirty'],
+    'clock130' => ['emoji' => '🕜', 'label' => 'Clock Face One-Thirty'],
+    'clock2' => ['emoji' => '🕑', 'label' => 'Clock Face Two Oclock'],
+    'clock230' => ['emoji' => '🕝', 'label' => 'Clock Face Two-Thirty'],
+    'clock3' => ['emoji' => '🕒', 'label' => 'Clock Face Three Oclock'],
+    'clock330' => ['emoji' => '🕞', 'label' => 'Clock Face Three-Thirty'],
+    'clock4' => ['emoji' => '🕓', 'label' => 'Clock Face Four Oclock'],
+    'clock430' => ['emoji' => '🕟', 'label' => 'Clock Face Four-Thirty'],
+    'clock5' => ['emoji' => '🕔', 'label' => 'Clock Face Five Oclock'],
+    'clock530' => ['emoji' => '🕠', 'label' => 'Clock Face Five-Thirty'],
+    'clock6' => ['emoji' => '🕕', 'label' => 'Clock Face Six Oclock'],
+    'clock630' => ['emoji' => '🕡', 'label' => 'Clock Face Six-Thirty'],
+    'clock7' => ['emoji' => '🕖', 'label' => 'Clock Face Seven Oclock'],
+    'clock730' => ['emoji' => '🕢', 'label' => 'Clock Face Seven-Thirty'],
+    'clock8' => ['emoji' => '🕗', 'label' => 'Clock Face Eight Oclock'],
+    'clock830' => ['emoji' => '🕣', 'label' => 'Clock Face Eight-Thirty'],
+    'clock9' => ['emoji' => '🕘', 'label' => 'Clock Face Nine Oclock'],
+    'clock930' => ['emoji' => '🕤', 'label' => 'Clock Face Nine-Thirty'],
+    'closed_book' => ['emoji' => '📕', 'label' => 'Closed Book'],
+    'closed_lock_with_key' => ['emoji' => '🔐', 'label' => 'Closed Lock With Key'],
+    'closed_umbrella' => ['emoji' => '🌂', 'label' => 'Closed Umbrella'],
+    'cloud' => ['emoji' => '☁️', 'label' => 'Cloud'],
+    'clown_face' => ['emoji' => '🤡', 'label' => 'Clown Face'],
+    'clubs' => ['emoji' => '♣️', 'label' => 'Black Club Suit'],
+    'cn' => ['emoji' => '🇨🇳', 'label' => 'China Flag'],
+    'coat' => ['emoji' => '🧥', 'label' => 'Coat'],
+    'cockroach' => ['emoji' => '🪳', 'label' => 'Cockroach'],
+    'cocktail' => ['emoji' => '🍸', 'label' => 'Cocktail Glass'],
+    'coconut' => ['emoji' => '🥥', 'label' => 'Coconut'],
+    'coffee' => ['emoji' => '☕', 'label' => 'Hot Beverage'],
+    'coffin' => ['emoji' => '⚰️', 'label' => 'Coffin'],
+    'coin' => ['emoji' => '🪙', 'label' => 'Coin'],
+    'cold_face' => ['emoji' => '🥶', 'label' => 'Freezing Face'],
+    'cold_sweat' => ['emoji' => '😰', 'label' => 'Face With Open Mouth And Cold Sweat'],
+    'comet' => ['emoji' => '☄️', 'label' => 'Comet'],
+    'compass' => ['emoji' => '🧭', 'label' => 'Compass'],
+    'compression' => ['emoji' => '🗜️', 'label' => 'Clamp'],
+    'computer' => ['emoji' => '💻', 'label' => 'Personal Computer'],
+    'confetti_ball' => ['emoji' => '🎊', 'label' => 'Confetti Ball'],
+    'confounded' => ['emoji' => '😖', 'label' => 'Confounded Face'],
+    'confused' => ['emoji' => '😕', 'label' => 'Confused Face'],
+    'congratulations' => ['emoji' => '㊗️', 'label' => 'Circled Ideograph Congratulation'],
+    'construction' => ['emoji' => '🚧', 'label' => 'Construction Sign'],
+    'construction_worker' => ['emoji' => '👷', 'label' => 'Construction Worker'],
+    'control_knobs' => ['emoji' => '🎛️', 'label' => 'Control Knobs'],
+    'convenience_store' => ['emoji' => '🏪', 'label' => 'Convenience Store'],
+    'cook' => ['emoji' => '🧑‍🍳', 'label' => 'Cook'],
+    'cookie' => ['emoji' => '🍪', 'label' => 'Cookie'],
+    'cool' => ['emoji' => '🆒', 'label' => 'Squared Cool'],
+    'cop' => ['emoji' => '👮', 'label' => 'Police Officer'],
+    'copyright' => ['emoji' => '©️', 'label' => 'Copyright Sign'],
+    'coral' => ['emoji' => '🪸', 'label' => 'Coral'],
+    'corn' => ['emoji' => '🌽', 'label' => 'Ear Of Maize'],
+    'couch_and_lamp' => ['emoji' => '🛋️', 'label' => 'Couch And Lamp'],
+    'couple_with_heart' => ['emoji' => '💑', 'label' => 'Couple With Heart'],
+    'couplekiss' => ['emoji' => '💏', 'label' => 'Kiss'],
+    'cow' => ['emoji' => '🐮', 'label' => 'Cow Face'],
+    'cow2' => ['emoji' => '🐄', 'label' => 'Cow'],
+    'crab' => ['emoji' => '🦀', 'label' => 'Crab'],
+    'credit_card' => ['emoji' => '💳', 'label' => 'Credit Card'],
+    'crescent_moon' => ['emoji' => '🌙', 'label' => 'Crescent Moon'],
+    'cricket' => ['emoji' => '🦗', 'label' => 'Cricket'],
+    'cricket_bat_and_ball' => ['emoji' => '🏏', 'label' => 'Cricket Bat And Ball'],
+    'crocodile' => ['emoji' => '🐊', 'label' => 'Crocodile'],
+    'croissant' => ['emoji' => '🥐', 'label' => 'Croissant'],
+    'crossed_fingers' => ['emoji' => '🤞', 'label' => 'Hand With Index And Middle Fingers Crossed'],
+    'crossed_flags' => ['emoji' => '🎌', 'label' => 'Crossed Flags'],
+    'crossed_swords' => ['emoji' => '⚔️', 'label' => 'Crossed Swords'],
+    'crown' => ['emoji' => '👑', 'label' => 'Crown'],
+    'crutch' => ['emoji' => '🩼', 'label' => 'Crutch'],
+    'cry' => ['emoji' => '😢', 'label' => 'Crying Face'],
+    'crying_cat_face' => ['emoji' => '😿', 'label' => 'Crying Cat Face'],
+    'crystal_ball' => ['emoji' => '🔮', 'label' => 'Crystal Ball'],
+    'cucumber' => ['emoji' => '🥒', 'label' => 'Cucumber'],
+    'cup_with_straw' => ['emoji' => '🥤', 'label' => 'Cup With Straw'],
+    'cupcake' => ['emoji' => '🧁', 'label' => 'Cupcake'],
+    'cupid' => ['emoji' => '💘', 'label' => 'Heart With Arrow'],
+    'curling_stone' => ['emoji' => '🥌', 'label' => 'Curling Stone'],
+    'curly_haired_man' => ['emoji' => '👨‍🦱', 'label' => 'Man: Curly Hair'],
+    'curly_haired_person' => ['emoji' => '🧑‍🦱', 'label' => 'Person: Curly Hair'],
+    'curly_haired_woman' => ['emoji' => '👩‍🦱', 'label' => 'Woman: Curly Hair'],
+    'curly_loop' => ['emoji' => '➰', 'label' => 'Curly Loop'],
+    'currency_exchange' => ['emoji' => '💱', 'label' => 'Currency Exchange'],
+    'curry' => ['emoji' => '🍛', 'label' => 'Curry And Rice'],
+    'custard' => ['emoji' => '🍮', 'label' => 'Custard'],
+    'customs' => ['emoji' => '🛃', 'label' => 'Customs'],
+    'cut_of_meat' => ['emoji' => '🥩', 'label' => 'Cut Of Meat'],
+    'cyclone' => ['emoji' => '🌀', 'label' => 'Cyclone'],
+    'dagger_knife' => ['emoji' => '🗡️', 'label' => 'Dagger'],
+    'dancer' => ['emoji' => '💃', 'label' => 'Dancer'],
+    'dancers' => ['emoji' => '👯', 'label' => 'Woman With Bunny Ears'],
+    'dango' => ['emoji' => '🍡', 'label' => 'Dango'],
+    'dark_sunglasses' => ['emoji' => '🕶️', 'label' => 'Sunglasses'],
+    'dart' => ['emoji' => '🎯', 'label' => 'Direct Hit'],
+    'dash' => ['emoji' => '💨', 'label' => 'Dash Symbol'],
+    'date' => ['emoji' => '📅', 'label' => 'Calendar'],
+    'de' => ['emoji' => '🇩🇪', 'label' => 'Germany Flag'],
+    'deaf_man' => ['emoji' => '🧏‍♂️', 'label' => 'Deaf Man'],
+    'deaf_person' => ['emoji' => '🧏', 'label' => 'Deaf Person'],
+    'deaf_woman' => ['emoji' => '🧏‍♀️', 'label' => 'Deaf Woman'],
+    'deciduous_tree' => ['emoji' => '🌳', 'label' => 'Deciduous Tree'],
+    'deer' => ['emoji' => '🦌', 'label' => 'Deer'],
+    'department_store' => ['emoji' => '🏬', 'label' => 'Department Store'],
+    'derelict_house_building' => ['emoji' => '🏚️', 'label' => 'Derelict House'],
+    'desert' => ['emoji' => '🏜️', 'label' => 'Desert'],
+    'desert_island' => ['emoji' => '🏝️', 'label' => 'Desert Island'],
+    'desktop_computer' => ['emoji' => '🖥️', 'label' => 'Desktop Computer'],
+    'diamond_shape_with_a_dot_inside' => ['emoji' => '💠', 'label' => 'Diamond Shape With A Dot Inside'],
+    'diamonds' => ['emoji' => '♦️', 'label' => 'Black Diamond Suit'],
+    'disappointed' => ['emoji' => '😞', 'label' => 'Disappointed Face'],
+    'disappointed_relieved' => ['emoji' => '😥', 'label' => 'Disappointed But Relieved Face'],
+    'disguised_face' => ['emoji' => '🥸', 'label' => 'Disguised Face'],
+    'diving_mask' => ['emoji' => '🤿', 'label' => 'Diving Mask'],
+    'diya_lamp' => ['emoji' => '🪔', 'label' => 'Diya Lamp'],
+    'dizzy' => ['emoji' => '💫', 'label' => 'Dizzy Symbol'],
+    'dizzy_face' => ['emoji' => '😵', 'label' => 'Dizzy Face'],
+    'dna' => ['emoji' => '🧬', 'label' => 'Dna Double Helix'],
+    'do_not_litter' => ['emoji' => '🚯', 'label' => 'Do Not Litter Symbol'],
+    'dodo' => ['emoji' => '🦤', 'label' => 'Dodo'],
+    'dog' => ['emoji' => '🐶', 'label' => 'Dog Face'],
+    'dog2' => ['emoji' => '🐕', 'label' => 'Dog'],
+    'dollar' => ['emoji' => '💵', 'label' => 'Banknote With Dollar Sign'],
+    'dolls' => ['emoji' => '🎎', 'label' => 'Japanese Dolls'],
+    'dolphin' => ['emoji' => '🐬', 'label' => 'Dolphin'],
+    'donkey' => ['emoji' => '🫏', 'label' => 'Donkey'],
+    'door' => ['emoji' => '🚪', 'label' => 'Door'],
+    'dotted_line_face' => ['emoji' => '🫥', 'label' => 'Dotted Line Face'],
+    'double_vertical_bar' => ['emoji' => '⏸️', 'label' => 'Pause Button'],
+    'doughnut' => ['emoji' => '🍩', 'label' => 'Doughnut'],
+    'dove_of_peace' => ['emoji' => '🕊️', 'label' => 'Dove'],
+    'dragon' => ['emoji' => '🐉', 'label' => 'Dragon'],
+    'dragon_face' => ['emoji' => '🐲', 'label' => 'Dragon Face'],
+    'dress' => ['emoji' => '👗', 'label' => 'Dress'],
+    'dromedary_camel' => ['emoji' => '🐪', 'label' => 'Dromedary Camel'],
+    'drooling_face' => ['emoji' => '🤤', 'label' => 'Drooling Face'],
+    'drop_of_blood' => ['emoji' => '🩸', 'label' => 'Drop Of Blood'],
+    'droplet' => ['emoji' => '💧', 'label' => 'Droplet'],
+    'drum_with_drumsticks' => ['emoji' => '🥁', 'label' => 'Drum With Drumsticks'],
+    'duck' => ['emoji' => '🦆', 'label' => 'Duck'],
+    'dumpling' => ['emoji' => '🥟', 'label' => 'Dumpling'],
+    'dvd' => ['emoji' => '📀', 'label' => 'Dvd'],
+    'e-mail' => ['emoji' => '📧', 'label' => 'E-Mail Symbol'],
+    'eagle' => ['emoji' => '🦅', 'label' => 'Eagle'],
+    'ear' => ['emoji' => '👂', 'label' => 'Ear'],
+    'ear_of_rice' => ['emoji' => '🌾', 'label' => 'Ear Of Rice'],
+    'ear_with_hearing_aid' => ['emoji' => '🦻', 'label' => 'Ear With Hearing Aid'],
+    'earth_africa' => ['emoji' => '🌍', 'label' => 'Earth Globe Europe-Africa'],
+    'earth_americas' => ['emoji' => '🌎', 'label' => 'Earth Globe Americas'],
+    'earth_asia' => ['emoji' => '🌏', 'label' => 'Earth Globe Asia-Australia'],
+    'egg' => ['emoji' => '🥚', 'label' => 'Egg'],
+    'eggplant' => ['emoji' => '🍆', 'label' => 'Aubergine'],
+    'eight' => ['emoji' => '8️⃣', 'label' => 'Keycap 8'],
+    'eight_pointed_black_star' => ['emoji' => '✴️', 'label' => 'Eight Pointed Black Star'],
+    'eight_spoked_asterisk' => ['emoji' => '✳️', 'label' => 'Eight Spoked Asterisk'],
+    'eject' => ['emoji' => '⏏️', 'label' => 'Eject Button'],
+    'electric_plug' => ['emoji' => '🔌', 'label' => 'Electric Plug'],
+    'elephant' => ['emoji' => '🐘', 'label' => 'Elephant'],
+    'elevator' => ['emoji' => '🛗', 'label' => 'Elevator'],
+    'elf' => ['emoji' => '🧝', 'label' => 'Elf'],
+    'email' => ['emoji' => '✉️', 'label' => 'Envelope'],
+    'empty_nest' => ['emoji' => '🪹', 'label' => 'Empty Nest'],
+    'end' => ['emoji' => '🔚', 'label' => 'End With Leftwards Arrow Above'],
+    'envelope_with_arrow' => ['emoji' => '📩', 'label' => 'Envelope With Downwards Arrow Above'],
+    'es' => ['emoji' => '🇪🇸', 'label' => 'Spain Flag'],
+    'euro' => ['emoji' => '💶', 'label' => 'Banknote With Euro Sign'],
+    'european_castle' => ['emoji' => '🏰', 'label' => 'European Castle'],
+    'european_post_office' => ['emoji' => '🏤', 'label' => 'European Post Office'],
+    'evergreen_tree' => ['emoji' => '🌲', 'label' => 'Evergreen Tree'],
+    'exclamation' => ['emoji' => '❗', 'label' => 'Heavy Exclamation Mark Symbol'],
+    'exploding_head' => ['emoji' => '🤯', 'label' => 'Shocked Face With Exploding Head'],
+    'expressionless' => ['emoji' => '😑', 'label' => 'Expressionless Face'],
+    'eye' => ['emoji' => '👁️', 'label' => 'Eye'],
+    'eye-in-speech-bubble' => ['emoji' => '👁️‍🗨️', 'label' => 'Eye In Speech Bubble'],
+    'eyeglasses' => ['emoji' => '👓', 'label' => 'Eyeglasses'],
+    'eyes' => ['emoji' => '👀', 'label' => 'Eyes'],
+    'face_exhaling' => ['emoji' => '😮‍💨', 'label' => 'Face Exhaling'],
+    'face_holding_back_tears' => ['emoji' => '🥹', 'label' => 'Face Holding Back Tears'],
+    'face_in_clouds' => ['emoji' => '😶‍🌫️', 'label' => 'Face In Clouds'],
+    'face_palm' => ['emoji' => '🤦', 'label' => 'Face Palm'],
+    'face_vomiting' => ['emoji' => '🤮', 'label' => 'Face With Open Mouth Vomiting'],
+    'face_with_cowboy_hat' => ['emoji' => '🤠', 'label' => 'Face With Cowboy Hat'],
+    'face_with_diagonal_mouth' => ['emoji' => '🫤', 'label' => 'Face With Diagonal Mouth'],
+    'face_with_hand_over_mouth' => ['emoji' => '🤭', 'label' => 'Smiling Face With Smiling Eyes And Hand Covering Mouth'],
+    'face_with_head_bandage' => ['emoji' => '🤕', 'label' => 'Face With Head-Bandage'],
+    'face_with_monocle' => ['emoji' => '🧐', 'label' => 'Face With Monocle'],
+    'face_with_open_eyes_and_hand_over_mouth' => ['emoji' => '🫢', 'label' => 'Face With Open Eyes And Hand Over Mouth'],
+    'face_with_peeking_eye' => ['emoji' => '🫣', 'label' => 'Face With Peeking Eye'],
+    'face_with_raised_eyebrow' => ['emoji' => '🤨', 'label' => 'Face With One Eyebrow Raised'],
+    'face_with_rolling_eyes' => ['emoji' => '🙄', 'label' => 'Face With Rolling Eyes'],
+    'face_with_spiral_eyes' => ['emoji' => '😵‍💫', 'label' => 'Face With Spiral Eyes'],
+    'face_with_symbols_on_mouth' => ['emoji' => '🤬', 'label' => 'Serious Face With Symbols Covering Mouth'],
+    'face_with_thermometer' => ['emoji' => '🤒', 'label' => 'Face With Thermometer'],
+    'facepunch' => ['emoji' => '👊', 'label' => 'Fisted Hand Sign'],
+    'factory' => ['emoji' => '🏭', 'label' => 'Factory'],
+    'factory_worker' => ['emoji' => '🧑‍🏭', 'label' => 'Factory Worker'],
+    'fairy' => ['emoji' => '🧚', 'label' => 'Fairy'],
+    'falafel' => ['emoji' => '🧆', 'label' => 'Falafel'],
+    'fallen_leaf' => ['emoji' => '🍂', 'label' => 'Fallen Leaf'],
+    'family' => ['emoji' => '👪', 'label' => 'Family'],
+    'family_adult_adult_child' => ['emoji' => '🧑‍🧑‍🧒', 'label' => 'Family: Adult, Adult, Child'],
+    'family_adult_adult_child_child' => ['emoji' => '🧑‍🧑‍🧒‍🧒', 'label' => 'Family: Adult, Adult, Child, Child'],
+    'family_adult_child' => ['emoji' => '🧑‍🧒', 'label' => 'Family: Adult, Child'],
+    'family_adult_child_child' => ['emoji' => '🧑‍🧒‍🧒', 'label' => 'Family: Adult, Child, Child'],
+    'farmer' => ['emoji' => '🧑‍🌾', 'label' => 'Farmer'],
+    'fast_forward' => ['emoji' => '⏩', 'label' => 'Black Right-Pointing Double Triangle'],
+    'fax' => ['emoji' => '📠', 'label' => 'Fax Machine'],
+    'fearful' => ['emoji' => '😨', 'label' => 'Fearful Face'],
+    'feather' => ['emoji' => '🪶', 'label' => 'Feather'],
+    'feet' => ['emoji' => '🐾', 'label' => 'Paw Prints'],
+    'female-artist' => ['emoji' => '👩‍🎨', 'label' => 'Woman Artist'],
+    'female-astronaut' => ['emoji' => '👩‍🚀', 'label' => 'Woman Astronaut'],
+    'female-construction-worker' => ['emoji' => '👷‍♀️', 'label' => 'Woman Construction Worker'],
+    'female-cook' => ['emoji' => '👩‍🍳', 'label' => 'Woman Cook'],
+    'female-detective' => ['emoji' => '🕵️‍♀️', 'label' => 'Woman Detective'],
+    'female-doctor' => ['emoji' => '👩‍⚕️', 'label' => 'Woman Health Worker'],
+    'female-factory-worker' => ['emoji' => '👩‍🏭', 'label' => 'Woman Factory Worker'],
+    'female-farmer' => ['emoji' => '👩‍🌾', 'label' => 'Woman Farmer'],
+    'female-firefighter' => ['emoji' => '👩‍🚒', 'label' => 'Woman Firefighter'],
+    'female-guard' => ['emoji' => '💂‍♀️', 'label' => 'Woman Guard'],
+    'female-judge' => ['emoji' => '👩‍⚖️', 'label' => 'Woman Judge'],
+    'female-mechanic' => ['emoji' => '👩‍🔧', 'label' => 'Woman Mechanic'],
+    'female-office-worker' => ['emoji' => '👩‍💼', 'label' => 'Woman Office Worker'],
+    'female-pilot' => ['emoji' => '👩‍✈️', 'label' => 'Woman Pilot'],
+    'female-police-officer' => ['emoji' => '👮‍♀️', 'label' => 'Woman Police Officer'],
+    'female-scientist' => ['emoji' => '👩‍🔬', 'label' => 'Woman Scientist'],
+    'female-singer' => ['emoji' => '👩‍🎤', 'label' => 'Woman Singer'],
+    'female-student' => ['emoji' => '👩‍🎓', 'label' => 'Woman Student'],
+    'female-teacher' => ['emoji' => '👩‍🏫', 'label' => 'Woman Teacher'],
+    'female-technologist' => ['emoji' => '👩‍💻', 'label' => 'Woman Technologist'],
+    'female_elf' => ['emoji' => '🧝‍♀️', 'label' => 'Woman Elf'],
+    'female_fairy' => ['emoji' => '🧚‍♀️', 'label' => 'Woman Fairy'],
+    'female_genie' => ['emoji' => '🧞‍♀️', 'label' => 'Woman Genie'],
+    'female_mage' => ['emoji' => '🧙‍♀️', 'label' => 'Woman Mage'],
+    'female_sign' => ['emoji' => '♀️', 'label' => 'Female Sign'],
+    'female_superhero' => ['emoji' => '🦸‍♀️', 'label' => 'Woman Superhero'],
+    'female_supervillain' => ['emoji' => '🦹‍♀️', 'label' => 'Woman Supervillain'],
+    'female_vampire' => ['emoji' => '🧛‍♀️', 'label' => 'Woman Vampire'],
+    'female_zombie' => ['emoji' => '🧟‍♀️', 'label' => 'Woman Zombie'],
+    'fencer' => ['emoji' => '🤺', 'label' => 'Fencer'],
+    'ferris_wheel' => ['emoji' => '🎡', 'label' => 'Ferris Wheel'],
+    'ferry' => ['emoji' => '⛴️', 'label' => 'Ferry'],
+    'field_hockey_stick_and_ball' => ['emoji' => '🏑', 'label' => 'Field Hockey Stick And Ball'],
+    'file_cabinet' => ['emoji' => '🗄️', 'label' => 'File Cabinet'],
+    'file_folder' => ['emoji' => '📁', 'label' => 'File Folder'],
+    'film_frames' => ['emoji' => '🎞️', 'label' => 'Film Frames'],
+    'film_projector' => ['emoji' => '📽️', 'label' => 'Film Projector'],
+    'fire' => ['emoji' => '🔥', 'label' => 'Fire'],
+    'fire_engine' => ['emoji' => '🚒', 'label' => 'Fire Engine'],
+    'fire_extinguisher' => ['emoji' => '🧯', 'label' => 'Fire Extinguisher'],
+    'firecracker' => ['emoji' => '🧨', 'label' => 'Firecracker'],
+    'firefighter' => ['emoji' => '🧑‍🚒', 'label' => 'Firefighter'],
+    'fireworks' => ['emoji' => '🎆', 'label' => 'Fireworks'],
+    'first_place_medal' => ['emoji' => '🥇', 'label' => 'First Place Medal'],
+    'first_quarter_moon' => ['emoji' => '🌓', 'label' => 'First Quarter Moon Symbol'],
+    'first_quarter_moon_with_face' => ['emoji' => '🌛', 'label' => 'First Quarter Moon With Face'],
+    'fish' => ['emoji' => '🐟', 'label' => 'Fish'],
+    'fish_cake' => ['emoji' => '🍥', 'label' => 'Fish Cake With Swirl Design'],
+    'fishing_pole_and_fish' => ['emoji' => '🎣', 'label' => 'Fishing Pole And Fish'],
+    'fist' => ['emoji' => '✊', 'label' => 'Raised Fist'],
+    'five' => ['emoji' => '5️⃣', 'label' => 'Keycap 5'],
+    'flag-ac' => ['emoji' => '🇦🇨', 'label' => 'Ascension Island Flag'],
+    'flag-ad' => ['emoji' => '🇦🇩', 'label' => 'Andorra Flag'],
+    'flag-ae' => ['emoji' => '🇦🇪', 'label' => 'United Arab Emirates Flag'],
+    'flag-af' => ['emoji' => '🇦🇫', 'label' => 'Afghanistan Flag'],
+    'flag-ag' => ['emoji' => '🇦🇬', 'label' => 'Antigua & Barbuda Flag'],
+    'flag-ai' => ['emoji' => '🇦🇮', 'label' => 'Anguilla Flag'],
+    'flag-al' => ['emoji' => '🇦🇱', 'label' => 'Albania Flag'],
+    'flag-am' => ['emoji' => '🇦🇲', 'label' => 'Armenia Flag'],
+    'flag-ao' => ['emoji' => '🇦🇴', 'label' => 'Angola Flag'],
+    'flag-aq' => ['emoji' => '🇦🇶', 'label' => 'Antarctica Flag'],
+    'flag-ar' => ['emoji' => '🇦🇷', 'label' => 'Argentina Flag'],
+    'flag-as' => ['emoji' => '🇦🇸', 'label' => 'American Samoa Flag'],
+    'flag-at' => ['emoji' => '🇦🇹', 'label' => 'Austria Flag'],
+    'flag-au' => ['emoji' => '🇦🇺', 'label' => 'Australia Flag'],
+    'flag-aw' => ['emoji' => '🇦🇼', 'label' => 'Aruba Flag'],
+    'flag-ax' => ['emoji' => '🇦🇽', 'label' => 'Åland Islands Flag'],
+    'flag-az' => ['emoji' => '🇦🇿', 'label' => 'Azerbaijan Flag'],
+    'flag-ba' => ['emoji' => '🇧🇦', 'label' => 'Bosnia & Herzegovina Flag'],
+    'flag-bb' => ['emoji' => '🇧🇧', 'label' => 'Barbados Flag'],
+    'flag-bd' => ['emoji' => '🇧🇩', 'label' => 'Bangladesh Flag'],
+    'flag-be' => ['emoji' => '🇧🇪', 'label' => 'Belgium Flag'],
+    'flag-bf' => ['emoji' => '🇧🇫', 'label' => 'Burkina Faso Flag'],
+    'flag-bg' => ['emoji' => '🇧🇬', 'label' => 'Bulgaria Flag'],
+    'flag-bh' => ['emoji' => '🇧🇭', 'label' => 'Bahrain Flag'],
+    'flag-bi' => ['emoji' => '🇧🇮', 'label' => 'Burundi Flag'],
+    'flag-bj' => ['emoji' => '🇧🇯', 'label' => 'Benin Flag'],
+    'flag-bl' => ['emoji' => '🇧🇱', 'label' => 'St. Barthélemy Flag'],
+    'flag-bm' => ['emoji' => '🇧🇲', 'label' => 'Bermuda Flag'],
+    'flag-bn' => ['emoji' => '🇧🇳', 'label' => 'Brunei Flag'],
+    'flag-bo' => ['emoji' => '🇧🇴', 'label' => 'Bolivia Flag'],
+    'flag-bq' => ['emoji' => '🇧🇶', 'label' => 'Caribbean Netherlands Flag'],
+    'flag-br' => ['emoji' => '🇧🇷', 'label' => 'Brazil Flag'],
+    'flag-bs' => ['emoji' => '🇧🇸', 'label' => 'Bahamas Flag'],
+    'flag-bt' => ['emoji' => '🇧🇹', 'label' => 'Bhutan Flag'],
+    'flag-bv' => ['emoji' => '🇧🇻', 'label' => 'Bouvet Island Flag'],
+    'flag-bw' => ['emoji' => '🇧🇼', 'label' => 'Botswana Flag'],
+    'flag-by' => ['emoji' => '🇧🇾', 'label' => 'Belarus Flag'],
+    'flag-bz' => ['emoji' => '🇧🇿', 'label' => 'Belize Flag'],
+    'flag-ca' => ['emoji' => '🇨🇦', 'label' => 'Canada Flag'],
+    'flag-cc' => ['emoji' => '🇨🇨', 'label' => 'Cocos (Keeling) Islands Flag'],
+    'flag-cd' => ['emoji' => '🇨🇩', 'label' => 'Congo - Kinshasa Flag'],
+    'flag-cf' => ['emoji' => '🇨🇫', 'label' => 'Central African Republic Flag'],
+    'flag-cg' => ['emoji' => '🇨🇬', 'label' => 'Congo - Brazzaville Flag'],
+    'flag-ch' => ['emoji' => '🇨🇭', 'label' => 'Switzerland Flag'],
+    'flag-ci' => ['emoji' => '🇨🇮', 'label' => 'Côte D’Ivoire Flag'],
+    'flag-ck' => ['emoji' => '🇨🇰', 'label' => 'Cook Islands Flag'],
+    'flag-cl' => ['emoji' => '🇨🇱', 'label' => 'Chile Flag'],
+    'flag-cm' => ['emoji' => '🇨🇲', 'label' => 'Cameroon Flag'],
+    'flag-co' => ['emoji' => '🇨🇴', 'label' => 'Colombia Flag'],
+    'flag-cp' => ['emoji' => '🇨🇵', 'label' => 'Clipperton Island Flag'],
+    'flag-cr' => ['emoji' => '🇨🇷', 'label' => 'Costa Rica Flag'],
+    'flag-cu' => ['emoji' => '🇨🇺', 'label' => 'Cuba Flag'],
+    'flag-cv' => ['emoji' => '🇨🇻', 'label' => 'Cape Verde Flag'],
+    'flag-cw' => ['emoji' => '🇨🇼', 'label' => 'Curaçao Flag'],
+    'flag-cx' => ['emoji' => '🇨🇽', 'label' => 'Christmas Island Flag'],
+    'flag-cy' => ['emoji' => '🇨🇾', 'label' => 'Cyprus Flag'],
+    'flag-cz' => ['emoji' => '🇨🇿', 'label' => 'Czechia Flag'],
+    'flag-dg' => ['emoji' => '🇩🇬', 'label' => 'Diego Garcia Flag'],
+    'flag-dj' => ['emoji' => '🇩🇯', 'label' => 'Djibouti Flag'],
+    'flag-dk' => ['emoji' => '🇩🇰', 'label' => 'Denmark Flag'],
+    'flag-dm' => ['emoji' => '🇩🇲', 'label' => 'Dominica Flag'],
+    'flag-do' => ['emoji' => '🇩🇴', 'label' => 'Dominican Republic Flag'],
+    'flag-dz' => ['emoji' => '🇩🇿', 'label' => 'Algeria Flag'],
+    'flag-ea' => ['emoji' => '🇪🇦', 'label' => 'Ceuta & Melilla Flag'],
+    'flag-ec' => ['emoji' => '🇪🇨', 'label' => 'Ecuador Flag'],
+    'flag-ee' => ['emoji' => '🇪🇪', 'label' => 'Estonia Flag'],
+    'flag-eg' => ['emoji' => '🇪🇬', 'label' => 'Egypt Flag'],
+    'flag-eh' => ['emoji' => '🇪🇭', 'label' => 'Western Sahara Flag'],
+    'flag-england' => ['emoji' => '🏴󠁧󠁢󠁥󠁮󠁧󠁿', 'label' => 'England Flag'],
+    'flag-er' => ['emoji' => '🇪🇷', 'label' => 'Eritrea Flag'],
+    'flag-et' => ['emoji' => '🇪🇹', 'label' => 'Ethiopia Flag'],
+    'flag-eu' => ['emoji' => '🇪🇺', 'label' => 'European Union Flag'],
+    'flag-fi' => ['emoji' => '🇫🇮', 'label' => 'Finland Flag'],
+    'flag-fj' => ['emoji' => '🇫🇯', 'label' => 'Fiji Flag'],
+    'flag-fk' => ['emoji' => '🇫🇰', 'label' => 'Falkland Islands Flag'],
+    'flag-fm' => ['emoji' => '🇫🇲', 'label' => 'Micronesia Flag'],
+    'flag-fo' => ['emoji' => '🇫🇴', 'label' => 'Faroe Islands Flag'],
+    'flag-ga' => ['emoji' => '🇬🇦', 'label' => 'Gabon Flag'],
+    'flag-gd' => ['emoji' => '🇬🇩', 'label' => 'Grenada Flag'],
+    'flag-ge' => ['emoji' => '🇬🇪', 'label' => 'Georgia Flag'],
+    'flag-gf' => ['emoji' => '🇬🇫', 'label' => 'French Guiana Flag'],
+    'flag-gg' => ['emoji' => '🇬🇬', 'label' => 'Guernsey Flag'],
+    'flag-gh' => ['emoji' => '🇬🇭', 'label' => 'Ghana Flag'],
+    'flag-gi' => ['emoji' => '🇬🇮', 'label' => 'Gibraltar Flag'],
+    'flag-gl' => ['emoji' => '🇬🇱', 'label' => 'Greenland Flag'],
+    'flag-gm' => ['emoji' => '🇬🇲', 'label' => 'Gambia Flag'],
+    'flag-gn' => ['emoji' => '🇬🇳', 'label' => 'Guinea Flag'],
+    'flag-gp' => ['emoji' => '🇬🇵', 'label' => 'Guadeloupe Flag'],
+    'flag-gq' => ['emoji' => '🇬🇶', 'label' => 'Equatorial Guinea Flag'],
+    'flag-gr' => ['emoji' => '🇬🇷', 'label' => 'Greece Flag'],
+    'flag-gs' => ['emoji' => '🇬🇸', 'label' => 'South Georgia & South Sandwich Islands Flag'],
+    'flag-gt' => ['emoji' => '🇬🇹', 'label' => 'Guatemala Flag'],
+    'flag-gu' => ['emoji' => '🇬🇺', 'label' => 'Guam Flag'],
+    'flag-gw' => ['emoji' => '🇬🇼', 'label' => 'Guinea-Bissau Flag'],
+    'flag-gy' => ['emoji' => '🇬🇾', 'label' => 'Guyana Flag'],
+    'flag-hk' => ['emoji' => '🇭🇰', 'label' => 'Hong Kong Sar China Flag'],
+    'flag-hm' => ['emoji' => '🇭🇲', 'label' => 'Heard & Mcdonald Islands Flag'],
+    'flag-hn' => ['emoji' => '🇭🇳', 'label' => 'Honduras Flag'],
+    'flag-hr' => ['emoji' => '🇭🇷', 'label' => 'Croatia Flag'],
+    'flag-ht' => ['emoji' => '🇭🇹', 'label' => 'Haiti Flag'],
+    'flag-hu' => ['emoji' => '🇭🇺', 'label' => 'Hungary Flag'],
+    'flag-ic' => ['emoji' => '🇮🇨', 'label' => 'Canary Islands Flag'],
+    'flag-id' => ['emoji' => '🇮🇩', 'label' => 'Indonesia Flag'],
+    'flag-ie' => ['emoji' => '🇮🇪', 'label' => 'Ireland Flag'],
+    'flag-il' => ['emoji' => '🇮🇱', 'label' => 'Israel Flag'],
+    'flag-im' => ['emoji' => '🇮🇲', 'label' => 'Isle Of Man Flag'],
+    'flag-in' => ['emoji' => '🇮🇳', 'label' => 'India Flag'],
+    'flag-io' => ['emoji' => '🇮🇴', 'label' => 'British Indian Ocean Territory Flag'],
+    'flag-iq' => ['emoji' => '🇮🇶', 'label' => 'Iraq Flag'],
+    'flag-ir' => ['emoji' => '🇮🇷', 'label' => 'Iran Flag'],
+    'flag-is' => ['emoji' => '🇮🇸', 'label' => 'Iceland Flag'],
+    'flag-je' => ['emoji' => '🇯🇪', 'label' => 'Jersey Flag'],
+    'flag-jm' => ['emoji' => '🇯🇲', 'label' => 'Jamaica Flag'],
+    'flag-jo' => ['emoji' => '🇯🇴', 'label' => 'Jordan Flag'],
+    'flag-ke' => ['emoji' => '🇰🇪', 'label' => 'Kenya Flag'],
+    'flag-kg' => ['emoji' => '🇰🇬', 'label' => 'Kyrgyzstan Flag'],
+    'flag-kh' => ['emoji' => '🇰🇭', 'label' => 'Cambodia Flag'],
+    'flag-ki' => ['emoji' => '🇰🇮', 'label' => 'Kiribati Flag'],
+    'flag-km' => ['emoji' => '🇰🇲', 'label' => 'Comoros Flag'],
+    'flag-kn' => ['emoji' => '🇰🇳', 'label' => 'St. Kitts & Nevis Flag'],
+    'flag-kp' => ['emoji' => '🇰🇵', 'label' => 'North Korea Flag'],
+    'flag-kw' => ['emoji' => '🇰🇼', 'label' => 'Kuwait Flag'],
+    'flag-ky' => ['emoji' => '🇰🇾', 'label' => 'Cayman Islands Flag'],
+    'flag-kz' => ['emoji' => '🇰🇿', 'label' => 'Kazakhstan Flag'],
+    'flag-la' => ['emoji' => '🇱🇦', 'label' => 'Laos Flag'],
+    'flag-lb' => ['emoji' => '🇱🇧', 'label' => 'Lebanon Flag'],
+    'flag-lc' => ['emoji' => '🇱🇨', 'label' => 'St. Lucia Flag'],
+    'flag-li' => ['emoji' => '🇱🇮', 'label' => 'Liechtenstein Flag'],
+    'flag-lk' => ['emoji' => '🇱🇰', 'label' => 'Sri Lanka Flag'],
+    'flag-lr' => ['emoji' => '🇱🇷', 'label' => 'Liberia Flag'],
+    'flag-ls' => ['emoji' => '🇱🇸', 'label' => 'Lesotho Flag'],
+    'flag-lt' => ['emoji' => '🇱🇹', 'label' => 'Lithuania Flag'],
+    'flag-lu' => ['emoji' => '🇱🇺', 'label' => 'Luxembourg Flag'],
+    'flag-lv' => ['emoji' => '🇱🇻', 'label' => 'Latvia Flag'],
+    'flag-ly' => ['emoji' => '🇱🇾', 'label' => 'Libya Flag'],
+    'flag-ma' => ['emoji' => '🇲🇦', 'label' => 'Morocco Flag'],
+    'flag-mc' => ['emoji' => '🇲🇨', 'label' => 'Monaco Flag'],
+    'flag-md' => ['emoji' => '🇲🇩', 'label' => 'Moldova Flag'],
+    'flag-me' => ['emoji' => '🇲🇪', 'label' => 'Montenegro Flag'],
+    'flag-mf' => ['emoji' => '🇲🇫', 'label' => 'St. Martin Flag'],
+    'flag-mg' => ['emoji' => '🇲🇬', 'label' => 'Madagascar Flag'],
+    'flag-mh' => ['emoji' => '🇲🇭', 'label' => 'Marshall Islands Flag'],
+    'flag-mk' => ['emoji' => '🇲🇰', 'label' => 'North Macedonia Flag'],
+    'flag-ml' => ['emoji' => '🇲🇱', 'label' => 'Mali Flag'],
+    'flag-mm' => ['emoji' => '🇲🇲', 'label' => 'Myanmar (Burma) Flag'],
+    'flag-mn' => ['emoji' => '🇲🇳', 'label' => 'Mongolia Flag'],
+    'flag-mo' => ['emoji' => '🇲🇴', 'label' => 'Macao Sar China Flag'],
+    'flag-mp' => ['emoji' => '🇲🇵', 'label' => 'Northern Mariana Islands Flag'],
+    'flag-mq' => ['emoji' => '🇲🇶', 'label' => 'Martinique Flag'],
+    'flag-mr' => ['emoji' => '🇲🇷', 'label' => 'Mauritania Flag'],
+    'flag-ms' => ['emoji' => '🇲🇸', 'label' => 'Montserrat Flag'],
+    'flag-mt' => ['emoji' => '🇲🇹', 'label' => 'Malta Flag'],
+    'flag-mu' => ['emoji' => '🇲🇺', 'label' => 'Mauritius Flag'],
+    'flag-mv' => ['emoji' => '🇲🇻', 'label' => 'Maldives Flag'],
+    'flag-mw' => ['emoji' => '🇲🇼', 'label' => 'Malawi Flag'],
+    'flag-mx' => ['emoji' => '🇲🇽', 'label' => 'Mexico Flag'],
+    'flag-my' => ['emoji' => '🇲🇾', 'label' => 'Malaysia Flag'],
+    'flag-mz' => ['emoji' => '🇲🇿', 'label' => 'Mozambique Flag'],
+    'flag-na' => ['emoji' => '🇳🇦', 'label' => 'Namibia Flag'],
+    'flag-nc' => ['emoji' => '🇳🇨', 'label' => 'New Caledonia Flag'],
+    'flag-ne' => ['emoji' => '🇳🇪', 'label' => 'Niger Flag'],
+    'flag-nf' => ['emoji' => '🇳🇫', 'label' => 'Norfolk Island Flag'],
+    'flag-ng' => ['emoji' => '🇳🇬', 'label' => 'Nigeria Flag'],
+    'flag-ni' => ['emoji' => '🇳🇮', 'label' => 'Nicaragua Flag'],
+    'flag-nl' => ['emoji' => '🇳🇱', 'label' => 'Netherlands Flag'],
+    'flag-no' => ['emoji' => '🇳🇴', 'label' => 'Norway Flag'],
+    'flag-np' => ['emoji' => '🇳🇵', 'label' => 'Nepal Flag'],
+    'flag-nr' => ['emoji' => '🇳🇷', 'label' => 'Nauru Flag'],
+    'flag-nu' => ['emoji' => '🇳🇺', 'label' => 'Niue Flag'],
+    'flag-nz' => ['emoji' => '🇳🇿', 'label' => 'New Zealand Flag'],
+    'flag-om' => ['emoji' => '🇴🇲', 'label' => 'Oman Flag'],
+    'flag-pa' => ['emoji' => '🇵🇦', 'label' => 'Panama Flag'],
+    'flag-pe' => ['emoji' => '🇵🇪', 'label' => 'Peru Flag'],
+    'flag-pf' => ['emoji' => '🇵🇫', 'label' => 'French Polynesia Flag'],
+    'flag-pg' => ['emoji' => '🇵🇬', 'label' => 'Papua New Guinea Flag'],
+    'flag-ph' => ['emoji' => '🇵🇭', 'label' => 'Philippines Flag'],
+    'flag-pk' => ['emoji' => '🇵🇰', 'label' => 'Pakistan Flag'],
+    'flag-pl' => ['emoji' => '🇵🇱', 'label' => 'Poland Flag'],
+    'flag-pm' => ['emoji' => '🇵🇲', 'label' => 'St. Pierre & Miquelon Flag'],
+    'flag-pn' => ['emoji' => '🇵🇳', 'label' => 'Pitcairn Islands Flag'],
+    'flag-pr' => ['emoji' => '🇵🇷', 'label' => 'Puerto Rico Flag'],
+    'flag-ps' => ['emoji' => '🇵🇸', 'label' => 'Palestinian Territories Flag'],
+    'flag-pt' => ['emoji' => '🇵🇹', 'label' => 'Portugal Flag'],
+    'flag-pw' => ['emoji' => '🇵🇼', 'label' => 'Palau Flag'],
+    'flag-py' => ['emoji' => '🇵🇾', 'label' => 'Paraguay Flag'],
+    'flag-qa' => ['emoji' => '🇶🇦', 'label' => 'Qatar Flag'],
+    'flag-re' => ['emoji' => '🇷🇪', 'label' => 'Réunion Flag'],
+    'flag-ro' => ['emoji' => '🇷🇴', 'label' => 'Romania Flag'],
+    'flag-rs' => ['emoji' => '🇷🇸', 'label' => 'Serbia Flag'],
+    'flag-rw' => ['emoji' => '🇷🇼', 'label' => 'Rwanda Flag'],
+    'flag-sa' => ['emoji' => '🇸🇦', 'label' => 'Saudi Arabia Flag'],
+    'flag-sb' => ['emoji' => '🇸🇧', 'label' => 'Solomon Islands Flag'],
+    'flag-sc' => ['emoji' => '🇸🇨', 'label' => 'Seychelles Flag'],
+    'flag-scotland' => ['emoji' => '🏴󠁧󠁢󠁳󠁣󠁴󠁿', 'label' => 'Scotland Flag'],
+    'flag-sd' => ['emoji' => '🇸🇩', 'label' => 'Sudan Flag'],
+    'flag-se' => ['emoji' => '🇸🇪', 'label' => 'Sweden Flag'],
+    'flag-sg' => ['emoji' => '🇸🇬', 'label' => 'Singapore Flag'],
+    'flag-sh' => ['emoji' => '🇸🇭', 'label' => 'St. Helena Flag'],
+    'flag-si' => ['emoji' => '🇸🇮', 'label' => 'Slovenia Flag'],
+    'flag-sj' => ['emoji' => '🇸🇯', 'label' => 'Svalbard & Jan Mayen Flag'],
+    'flag-sk' => ['emoji' => '🇸🇰', 'label' => 'Slovakia Flag'],
+    'flag-sl' => ['emoji' => '🇸🇱', 'label' => 'Sierra Leone Flag'],
+    'flag-sm' => ['emoji' => '🇸🇲', 'label' => 'San Marino Flag'],
+    'flag-sn' => ['emoji' => '🇸🇳', 'label' => 'Senegal Flag'],
+    'flag-so' => ['emoji' => '🇸🇴', 'label' => 'Somalia Flag'],
+    'flag-sr' => ['emoji' => '🇸🇷', 'label' => 'Suriname Flag'],
+    'flag-ss' => ['emoji' => '🇸🇸', 'label' => 'South Sudan Flag'],
+    'flag-st' => ['emoji' => '🇸🇹', 'label' => 'São Tomé & Príncipe Flag'],
+    'flag-sv' => ['emoji' => '🇸🇻', 'label' => 'El Salvador Flag'],
+    'flag-sx' => ['emoji' => '🇸🇽', 'label' => 'Sint Maarten Flag'],
+    'flag-sy' => ['emoji' => '🇸🇾', 'label' => 'Syria Flag'],
+    'flag-sz' => ['emoji' => '🇸🇿', 'label' => 'Eswatini Flag'],
+    'flag-ta' => ['emoji' => '🇹🇦', 'label' => 'Tristan Da Cunha Flag'],
+    'flag-tc' => ['emoji' => '🇹🇨', 'label' => 'Turks & Caicos Islands Flag'],
+    'flag-td' => ['emoji' => '🇹🇩', 'label' => 'Chad Flag'],
+    'flag-tf' => ['emoji' => '🇹🇫', 'label' => 'French Southern Territories Flag'],
+    'flag-tg' => ['emoji' => '🇹🇬', 'label' => 'Togo Flag'],
+    'flag-th' => ['emoji' => '🇹🇭', 'label' => 'Thailand Flag'],
+    'flag-tj' => ['emoji' => '🇹🇯', 'label' => 'Tajikistan Flag'],
+    'flag-tk' => ['emoji' => '🇹🇰', 'label' => 'Tokelau Flag'],
+    'flag-tl' => ['emoji' => '🇹🇱', 'label' => 'Timor-Leste Flag'],
+    'flag-tm' => ['emoji' => '🇹🇲', 'label' => 'Turkmenistan Flag'],
+    'flag-tn' => ['emoji' => '🇹🇳', 'label' => 'Tunisia Flag'],
+    'flag-to' => ['emoji' => '🇹🇴', 'label' => 'Tonga Flag'],
+    'flag-tr' => ['emoji' => '🇹🇷', 'label' => 'Türkiye Flag'],
+    'flag-tt' => ['emoji' => '🇹🇹', 'label' => 'Trinidad & Tobago Flag'],
+    'flag-tv' => ['emoji' => '🇹🇻', 'label' => 'Tuvalu Flag'],
+    'flag-tw' => ['emoji' => '🇹🇼', 'label' => 'Taiwan Flag'],
+    'flag-tz' => ['emoji' => '🇹🇿', 'label' => 'Tanzania Flag'],
+    'flag-ua' => ['emoji' => '🇺🇦', 'label' => 'Ukraine Flag'],
+    'flag-ug' => ['emoji' => '🇺🇬', 'label' => 'Uganda Flag'],
+    'flag-um' => ['emoji' => '🇺🇲', 'label' => 'U.S. Outlying Islands Flag'],
+    'flag-un' => ['emoji' => '🇺🇳', 'label' => 'United Nations Flag'],
+    'flag-uy' => ['emoji' => '🇺🇾', 'label' => 'Uruguay Flag'],
+    'flag-uz' => ['emoji' => '🇺🇿', 'label' => 'Uzbekistan Flag'],
+    'flag-va' => ['emoji' => '🇻🇦', 'label' => 'Vatican City Flag'],
+    'flag-vc' => ['emoji' => '🇻🇨', 'label' => 'St. Vincent & Grenadines Flag'],
+    'flag-ve' => ['emoji' => '🇻🇪', 'label' => 'Venezuela Flag'],
+    'flag-vg' => ['emoji' => '🇻🇬', 'label' => 'British Virgin Islands Flag'],
+    'flag-vi' => ['emoji' => '🇻🇮', 'label' => 'U.S. Virgin Islands Flag'],
+    'flag-vn' => ['emoji' => '🇻🇳', 'label' => 'Vietnam Flag'],
+    'flag-vu' => ['emoji' => '🇻🇺', 'label' => 'Vanuatu Flag'],
+    'flag-wales' => ['emoji' => '🏴󠁧󠁢󠁷󠁬󠁳󠁿', 'label' => 'Wales Flag'],
+    'flag-wf' => ['emoji' => '🇼🇫', 'label' => 'Wallis & Futuna Flag'],
+    'flag-ws' => ['emoji' => '🇼🇸', 'label' => 'Samoa Flag'],
+    'flag-xk' => ['emoji' => '🇽🇰', 'label' => 'Kosovo Flag'],
+    'flag-ye' => ['emoji' => '🇾🇪', 'label' => 'Yemen Flag'],
+    'flag-yt' => ['emoji' => '🇾🇹', 'label' => 'Mayotte Flag'],
+    'flag-za' => ['emoji' => '🇿🇦', 'label' => 'South Africa Flag'],
+    'flag-zm' => ['emoji' => '🇿🇲', 'label' => 'Zambia Flag'],
+    'flag-zw' => ['emoji' => '🇿🇼', 'label' => 'Zimbabwe Flag'],
+    'flags' => ['emoji' => '🎏', 'label' => 'Carp Streamer'],
+    'flamingo' => ['emoji' => '🦩', 'label' => 'Flamingo'],
+    'flashlight' => ['emoji' => '🔦', 'label' => 'Electric Torch'],
+    'flatbread' => ['emoji' => '🫓', 'label' => 'Flatbread'],
+    'fleur_de_lis' => ['emoji' => '⚜️', 'label' => 'Fleur-De-Lis'],
+    'floppy_disk' => ['emoji' => '💾', 'label' => 'Floppy Disk'],
+    'flower_playing_cards' => ['emoji' => '🎴', 'label' => 'Flower Playing Cards'],
+    'flushed' => ['emoji' => '😳', 'label' => 'Flushed Face'],
+    'flute' => ['emoji' => '🪈', 'label' => 'Flute'],
+    'fly' => ['emoji' => '🪰', 'label' => 'Fly'],
+    'flying_disc' => ['emoji' => '🥏', 'label' => 'Flying Disc'],
+    'flying_saucer' => ['emoji' => '🛸', 'label' => 'Flying Saucer'],
+    'fog' => ['emoji' => '🌫️', 'label' => 'Fog'],
+    'foggy' => ['emoji' => '🌁', 'label' => 'Foggy'],
+    'folding_hand_fan' => ['emoji' => '🪭', 'label' => 'Folding Hand Fan'],
+    'fondue' => ['emoji' => '🫕', 'label' => 'Fondue'],
+    'foot' => ['emoji' => '🦶', 'label' => 'Foot'],
+    'football' => ['emoji' => '🏈', 'label' => 'American Football'],
+    'footprints' => ['emoji' => '👣', 'label' => 'Footprints'],
+    'fork_and_knife' => ['emoji' => '🍴', 'label' => 'Fork And Knife'],
+    'fortune_cookie' => ['emoji' => '🥠', 'label' => 'Fortune Cookie'],
+    'fountain' => ['emoji' => '⛲', 'label' => 'Fountain'],
+    'four' => ['emoji' => '4️⃣', 'label' => 'Keycap 4'],
+    'four_leaf_clover' => ['emoji' => '🍀', 'label' => 'Four Leaf Clover'],
+    'fox_face' => ['emoji' => '🦊', 'label' => 'Fox Face'],
+    'fr' => ['emoji' => '🇫🇷', 'label' => 'France Flag'],
+    'frame_with_picture' => ['emoji' => '🖼️', 'label' => 'Framed Picture'],
+    'free' => ['emoji' => '🆓', 'label' => 'Squared Free'],
+    'fried_egg' => ['emoji' => '🍳', 'label' => 'Cooking'],
+    'fried_shrimp' => ['emoji' => '🍤', 'label' => 'Fried Shrimp'],
+    'fries' => ['emoji' => '🍟', 'label' => 'French Fries'],
+    'frog' => ['emoji' => '🐸', 'label' => 'Frog Face'],
+    'frowning' => ['emoji' => '😦', 'label' => 'Frowning Face With Open Mouth'],
+    'fuelpump' => ['emoji' => '⛽', 'label' => 'Fuel Pump'],
+    'full_moon' => ['emoji' => '🌕', 'label' => 'Full Moon Symbol'],
+    'full_moon_with_face' => ['emoji' => '🌝', 'label' => 'Full Moon With Face'],
+    'funeral_urn' => ['emoji' => '⚱️', 'label' => 'Funeral Urn'],
+    'game_die' => ['emoji' => '🎲', 'label' => 'Game Die'],
+    'garlic' => ['emoji' => '🧄', 'label' => 'Garlic'],
+    'gb' => ['emoji' => '🇬🇧', 'label' => 'United Kingdom Flag'],
+    'gear' => ['emoji' => '⚙️', 'label' => 'Gear'],
+    'gem' => ['emoji' => '💎', 'label' => 'Gem Stone'],
+    'gemini' => ['emoji' => '♊', 'label' => 'Gemini'],
+    'genie' => ['emoji' => '🧞', 'label' => 'Genie'],
+    'ghost' => ['emoji' => '👻', 'label' => 'Ghost'],
+    'gift' => ['emoji' => '🎁', 'label' => 'Wrapped Present'],
+    'gift_heart' => ['emoji' => '💝', 'label' => 'Heart With Ribbon'],
+    'ginger_root' => ['emoji' => '🫚', 'label' => 'Ginger Root'],
+    'giraffe_face' => ['emoji' => '🦒', 'label' => 'Giraffe Face'],
+    'girl' => ['emoji' => '👧', 'label' => 'Girl'],
+    'glass_of_milk' => ['emoji' => '🥛', 'label' => 'Glass Of Milk'],
+    'globe_with_meridians' => ['emoji' => '🌐', 'label' => 'Globe With Meridians'],
+    'gloves' => ['emoji' => '🧤', 'label' => 'Gloves'],
+    'goal_net' => ['emoji' => '🥅', 'label' => 'Goal Net'],
+    'goat' => ['emoji' => '🐐', 'label' => 'Goat'],
+    'goggles' => ['emoji' => '🥽', 'label' => 'Goggles'],
+    'golf' => ['emoji' => '⛳', 'label' => 'Flag In Hole'],
+    'golfer' => ['emoji' => '🏌️', 'label' => 'Person Golfing'],
+    'goose' => ['emoji' => '🪿', 'label' => 'Goose'],
+    'gorilla' => ['emoji' => '🦍', 'label' => 'Gorilla'],
+    'grapes' => ['emoji' => '🍇', 'label' => 'Grapes'],
+    'green_apple' => ['emoji' => '🍏', 'label' => 'Green Apple'],
+    'green_book' => ['emoji' => '📗', 'label' => 'Green Book'],
+    'green_heart' => ['emoji' => '💚', 'label' => 'Green Heart'],
+    'green_salad' => ['emoji' => '🥗', 'label' => 'Green Salad'],
+    'grey_exclamation' => ['emoji' => '❕', 'label' => 'White Exclamation Mark Ornament'],
+    'grey_heart' => ['emoji' => '🩶', 'label' => 'Grey Heart'],
+    'grey_question' => ['emoji' => '❔', 'label' => 'White Question Mark Ornament'],
+    'grimacing' => ['emoji' => '😬', 'label' => 'Grimacing Face'],
+    'grin' => ['emoji' => '😁', 'label' => 'Grinning Face With Smiling Eyes'],
+    'grinning' => ['emoji' => '😀', 'label' => 'Grinning Face'],
+    'guardsman' => ['emoji' => '💂', 'label' => 'Guardsman'],
+    'guide_dog' => ['emoji' => '🦮', 'label' => 'Guide Dog'],
+    'guitar' => ['emoji' => '🎸', 'label' => 'Guitar'],
+    'gun' => ['emoji' => '🔫', 'label' => 'Pistol'],
+    'hair_pick' => ['emoji' => '🪮', 'label' => 'Hair Pick'],
+    'haircut' => ['emoji' => '💇', 'label' => 'Haircut'],
+    'hamburger' => ['emoji' => '🍔', 'label' => 'Hamburger'],
+    'hammer' => ['emoji' => '🔨', 'label' => 'Hammer'],
+    'hammer_and_pick' => ['emoji' => '⚒️', 'label' => 'Hammer And Pick'],
+    'hammer_and_wrench' => ['emoji' => '🛠️', 'label' => 'Hammer And Wrench'],
+    'hamsa' => ['emoji' => '🪬', 'label' => 'Hamsa'],
+    'hamster' => ['emoji' => '🐹', 'label' => 'Hamster Face'],
+    'hand' => ['emoji' => '✋', 'label' => 'Raised Hand'],
+    'hand_with_index_finger_and_thumb_crossed' => ['emoji' => '🫰', 'label' => 'Hand With Index Finger And Thumb Crossed'],
+    'handbag' => ['emoji' => '👜', 'label' => 'Handbag'],
+    'handball' => ['emoji' => '🤾', 'label' => 'Handball'],
+    'handshake' => ['emoji' => '🤝', 'label' => 'Handshake'],
+    'hankey' => ['emoji' => '💩', 'label' => 'Pile Of Poo'],
+    'hash' => ['emoji' => '#️⃣', 'label' => 'Hash Key'],
+    'hatched_chick' => ['emoji' => '🐥', 'label' => 'Front-Facing Baby Chick'],
+    'hatching_chick' => ['emoji' => '🐣', 'label' => 'Hatching Chick'],
+    'head_shaking_horizontally' => ['emoji' => '🙂‍↔️', 'label' => 'Head Shaking Horizontally'],
+    'head_shaking_vertically' => ['emoji' => '🙂‍↕️', 'label' => 'Head Shaking Vertically'],
+    'headphones' => ['emoji' => '🎧', 'label' => 'Headphone'],
+    'headstone' => ['emoji' => '🪦', 'label' => 'Headstone'],
+    'health_worker' => ['emoji' => '🧑‍⚕️', 'label' => 'Health Worker'],
+    'hear_no_evil' => ['emoji' => '🙉', 'label' => 'Hear-No-Evil Monkey'],
+    'heart' => ['emoji' => '❤️', 'label' => 'Heavy Black Heart'],
+    'heart_decoration' => ['emoji' => '💟', 'label' => 'Heart Decoration'],
+    'heart_eyes' => ['emoji' => '😍', 'label' => 'Smiling Face With Heart-Shaped Eyes'],
+    'heart_eyes_cat' => ['emoji' => '😻', 'label' => 'Smiling Cat Face With Heart-Shaped Eyes'],
+    'heart_hands' => ['emoji' => '🫶', 'label' => 'Heart Hands'],
+    'heart_on_fire' => ['emoji' => '❤️‍🔥', 'label' => 'Heart On Fire'],
+    'heartbeat' => ['emoji' => '💓', 'label' => 'Beating Heart'],
+    'heartpulse' => ['emoji' => '💗', 'label' => 'Growing Heart'],
+    'hearts' => ['emoji' => '♥️', 'label' => 'Black Heart Suit'],
+    'heavy_check_mark' => ['emoji' => '✔️', 'label' => 'Heavy Check Mark'],
+    'heavy_division_sign' => ['emoji' => '➗', 'label' => 'Heavy Division Sign'],
+    'heavy_dollar_sign' => ['emoji' => '💲', 'label' => 'Heavy Dollar Sign'],
+    'heavy_equals_sign' => ['emoji' => '🟰', 'label' => 'Heavy Equals Sign'],
+    'heavy_heart_exclamation_mark_ornament' => ['emoji' => '❣️', 'label' => 'Heart Exclamation'],
+    'heavy_minus_sign' => ['emoji' => '➖', 'label' => 'Heavy Minus Sign'],
+    'heavy_multiplication_x' => ['emoji' => '✖️', 'label' => 'Heavy Multiplication X'],
+    'heavy_plus_sign' => ['emoji' => '➕', 'label' => 'Heavy Plus Sign'],
+    'hedgehog' => ['emoji' => '🦔', 'label' => 'Hedgehog'],
+    'helicopter' => ['emoji' => '🚁', 'label' => 'Helicopter'],
+    'helmet_with_white_cross' => ['emoji' => '⛑️', 'label' => 'Rescue Worker’S Helmet'],
+    'herb' => ['emoji' => '🌿', 'label' => 'Herb'],
+    'hibiscus' => ['emoji' => '🌺', 'label' => 'Hibiscus'],
+    'high_brightness' => ['emoji' => '🔆', 'label' => 'High Brightness Symbol'],
+    'high_heel' => ['emoji' => '👠', 'label' => 'High-Heeled Shoe'],
+    'hiking_boot' => ['emoji' => '🥾', 'label' => 'Hiking Boot'],
+    'hindu_temple' => ['emoji' => '🛕', 'label' => 'Hindu Temple'],
+    'hippopotamus' => ['emoji' => '🦛', 'label' => 'Hippopotamus'],
+    'hocho' => ['emoji' => '🔪', 'label' => 'Hocho'],
+    'hole' => ['emoji' => '🕳️', 'label' => 'Hole'],
+    'honey_pot' => ['emoji' => '🍯', 'label' => 'Honey Pot'],
+    'hook' => ['emoji' => '🪝', 'label' => 'Hook'],
+    'horse' => ['emoji' => '🐴', 'label' => 'Horse Face'],
+    'horse_racing' => ['emoji' => '🏇', 'label' => 'Horse Racing'],
+    'hospital' => ['emoji' => '🏥', 'label' => 'Hospital'],
+    'hot_face' => ['emoji' => '🥵', 'label' => 'Overheated Face'],
+    'hot_pepper' => ['emoji' => '🌶️', 'label' => 'Hot Pepper'],
+    'hotdog' => ['emoji' => '🌭', 'label' => 'Hot Dog'],
+    'hotel' => ['emoji' => '🏨', 'label' => 'Hotel'],
+    'hotsprings' => ['emoji' => '♨️', 'label' => 'Hot Springs'],
+    'hourglass' => ['emoji' => '⌛', 'label' => 'Hourglass'],
+    'hourglass_flowing_sand' => ['emoji' => '⏳', 'label' => 'Hourglass With Flowing Sand'],
+    'house' => ['emoji' => '🏠', 'label' => 'House Building'],
+    'house_buildings' => ['emoji' => '🏘️', 'label' => 'Houses'],
+    'house_with_garden' => ['emoji' => '🏡', 'label' => 'House With Garden'],
+    'hugging_face' => ['emoji' => '🤗', 'label' => 'Hugging Face'],
+    'hushed' => ['emoji' => '😯', 'label' => 'Hushed Face'],
+    'hut' => ['emoji' => '🛖', 'label' => 'Hut'],
+    'hyacinth' => ['emoji' => '🪻', 'label' => 'Hyacinth'],
+    'i_love_you_hand_sign' => ['emoji' => '🤟', 'label' => 'I Love You Hand Sign'],
+    'ice_cream' => ['emoji' => '🍨', 'label' => 'Ice Cream'],
+    'ice_cube' => ['emoji' => '🧊', 'label' => 'Ice Cube'],
+    'ice_hockey_stick_and_puck' => ['emoji' => '🏒', 'label' => 'Ice Hockey Stick And Puck'],
+    'ice_skate' => ['emoji' => '⛸️', 'label' => 'Ice Skate'],
+    'icecream' => ['emoji' => '🍦', 'label' => 'Soft Ice Cream'],
+    'id' => ['emoji' => '🆔', 'label' => 'Squared Id'],
+    'identification_card' => ['emoji' => '🪪', 'label' => 'Identification Card'],
+    'ideograph_advantage' => ['emoji' => '🉐', 'label' => 'Circled Ideograph Advantage'],
+    'imp' => ['emoji' => '👿', 'label' => 'Imp'],
+    'inbox_tray' => ['emoji' => '📥', 'label' => 'Inbox Tray'],
+    'incoming_envelope' => ['emoji' => '📨', 'label' => 'Incoming Envelope'],
+    'index_pointing_at_the_viewer' => ['emoji' => '🫵', 'label' => 'Index Pointing At The Viewer'],
+    'infinity' => ['emoji' => '♾️', 'label' => 'Infinity'],
+    'information_desk_person' => ['emoji' => '💁', 'label' => 'Information Desk Person'],
+    'information_source' => ['emoji' => 'ℹ️', 'label' => 'Information Source'],
+    'innocent' => ['emoji' => '😇', 'label' => 'Smiling Face With Halo'],
+    'insightful' => ['emoji' => '🤔', 'label' => 'Insightful'],
+    'interrobang' => ['emoji' => '⁉️', 'label' => 'Exclamation Question Mark'],
+    'iphone' => ['emoji' => '📱', 'label' => 'Mobile Phone'],
+    'it' => ['emoji' => '🇮🇹', 'label' => 'Italy Flag'],
+    'izakaya_lantern' => ['emoji' => '🏮', 'label' => 'Izakaya Lantern'],
+    'jack_o_lantern' => ['emoji' => '🎃', 'label' => 'Jack-O-Lantern'],
+    'japan' => ['emoji' => '🗾', 'label' => 'Silhouette Of Japan'],
+    'japanese_castle' => ['emoji' => '🏯', 'label' => 'Japanese Castle'],
+    'japanese_goblin' => ['emoji' => '👺', 'label' => 'Japanese Goblin'],
+    'japanese_ogre' => ['emoji' => '👹', 'label' => 'Japanese Ogre'],
+    'jar' => ['emoji' => '🫙', 'label' => 'Jar'],
+    'jeans' => ['emoji' => '👖', 'label' => 'Jeans'],
+    'jellyfish' => ['emoji' => '🪼', 'label' => 'Jellyfish'],
+    'jigsaw' => ['emoji' => '🧩', 'label' => 'Jigsaw Puzzle Piece'],
+    'joy' => ['emoji' => '😂', 'label' => 'Face With Tears Of Joy'],
+    'joy_cat' => ['emoji' => '😹', 'label' => 'Cat Face With Tears Of Joy'],
+    'joystick' => ['emoji' => '🕹️', 'label' => 'Joystick'],
+    'jp' => ['emoji' => '🇯🇵', 'label' => 'Japan Flag'],
+    'judge' => ['emoji' => '🧑‍⚖️', 'label' => 'Judge'],
+    'juggling' => ['emoji' => '🤹', 'label' => 'Juggling'],
+    'kaaba' => ['emoji' => '🕋', 'label' => 'Kaaba'],
+    'kangaroo' => ['emoji' => '🦘', 'label' => 'Kangaroo'],
+    'key' => ['emoji' => '🔑', 'label' => 'Key'],
+    'keyboard' => ['emoji' => '⌨️', 'label' => 'Keyboard'],
+    'keycap_star' => ['emoji' => '*️⃣', 'label' => 'Keycap: *'],
+    'keycap_ten' => ['emoji' => '🔟', 'label' => 'Keycap Ten'],
+    'khanda' => ['emoji' => '🪯', 'label' => 'Khanda'],
+    'kimono' => ['emoji' => '👘', 'label' => 'Kimono'],
+    'kiss' => ['emoji' => '💋', 'label' => 'Kiss Mark'],
+    'kissing' => ['emoji' => '😗', 'label' => 'Kissing Face'],
+    'kissing_cat' => ['emoji' => '😽', 'label' => 'Kissing Cat Face With Closed Eyes'],
+    'kissing_closed_eyes' => ['emoji' => '😚', 'label' => 'Kissing Face With Closed Eyes'],
+    'kissing_heart' => ['emoji' => '😘', 'label' => 'Face Throwing A Kiss'],
+    'kissing_smiling_eyes' => ['emoji' => '😙', 'label' => 'Kissing Face With Smiling Eyes'],
+    'kite' => ['emoji' => '🪁', 'label' => 'Kite'],
+    'kiwifruit' => ['emoji' => '🥝', 'label' => 'Kiwifruit'],
+    'kneeling_person' => ['emoji' => '🧎', 'label' => 'Kneeling Person'],
+    'knife_fork_plate' => ['emoji' => '🍽️', 'label' => 'Fork And Knife With Plate'],
+    'knot' => ['emoji' => '🪢', 'label' => 'Knot'],
+    'koala' => ['emoji' => '🐨', 'label' => 'Koala'],
+    'koko' => ['emoji' => '🈁', 'label' => 'Squared Katakana Koko'],
+    'kr' => ['emoji' => '🇰🇷', 'label' => 'South Korea Flag'],
+    'lab_coat' => ['emoji' => '🥼', 'label' => 'Lab Coat'],
+    'label' => ['emoji' => '🏷️', 'label' => 'Label'],
+    'lacrosse' => ['emoji' => '🥍', 'label' => 'Lacrosse Stick And Ball'],
+    'ladder' => ['emoji' => '🪜', 'label' => 'Ladder'],
+    'ladybug' => ['emoji' => '🐞', 'label' => 'Lady Beetle'],
+    'large_blue_circle' => ['emoji' => '🔵', 'label' => 'Large Blue Circle'],
+    'large_blue_diamond' => ['emoji' => '🔷', 'label' => 'Large Blue Diamond'],
+    'large_blue_square' => ['emoji' => '🟦', 'label' => 'Large Blue Square'],
+    'large_brown_circle' => ['emoji' => '🟤', 'label' => 'Large Brown Circle'],
+    'large_brown_square' => ['emoji' => '🟫', 'label' => 'Large Brown Square'],
+    'large_green_circle' => ['emoji' => '🟢', 'label' => 'Large Green Circle'],
+    'large_green_square' => ['emoji' => '🟩', 'label' => 'Large Green Square'],
+    'large_orange_circle' => ['emoji' => '🟠', 'label' => 'Large Orange Circle'],
+    'large_orange_diamond' => ['emoji' => '🔶', 'label' => 'Large Orange Diamond'],
+    'large_orange_square' => ['emoji' => '🟧', 'label' => 'Large Orange Square'],
+    'large_purple_circle' => ['emoji' => '🟣', 'label' => 'Large Purple Circle'],
+    'large_purple_square' => ['emoji' => '🟪', 'label' => 'Large Purple Square'],
+    'large_red_square' => ['emoji' => '🟥', 'label' => 'Large Red Square'],
+    'large_yellow_circle' => ['emoji' => '🟡', 'label' => 'Large Yellow Circle'],
+    'large_yellow_square' => ['emoji' => '🟨', 'label' => 'Large Yellow Square'],
+    'last_quarter_moon' => ['emoji' => '🌗', 'label' => 'Last Quarter Moon Symbol'],
+    'last_quarter_moon_with_face' => ['emoji' => '🌜', 'label' => 'Last Quarter Moon With Face'],
+    'latin_cross' => ['emoji' => '✝️', 'label' => 'Latin Cross'],
+    'laughing' => ['emoji' => '😆', 'label' => 'Smiling Face With Open Mouth And Tightly-Closed Eyes'],
+    'leafy_green' => ['emoji' => '🥬', 'label' => 'Leafy Green'],
+    'leaves' => ['emoji' => '🍃', 'label' => 'Leaf Fluttering In Wind'],
+    'ledger' => ['emoji' => '📒', 'label' => 'Ledger'],
+    'left-facing_fist' => ['emoji' => '🤛', 'label' => 'Left-Facing Fist'],
+    'left_luggage' => ['emoji' => '🛅', 'label' => 'Left Luggage'],
+    'left_right_arrow' => ['emoji' => '↔️', 'label' => 'Left Right Arrow'],
+    'left_speech_bubble' => ['emoji' => '🗨️', 'label' => 'Left Speech Bubble'],
+    'leftwards_arrow_with_hook' => ['emoji' => '↩️', 'label' => 'Leftwards Arrow With Hook'],
+    'leftwards_hand' => ['emoji' => '🫲', 'label' => 'Leftwards Hand'],
+    'leftwards_pushing_hand' => ['emoji' => '🫷', 'label' => 'Leftwards Pushing Hand'],
+    'leg' => ['emoji' => '🦵', 'label' => 'Leg'],
+    'lemon' => ['emoji' => '🍋', 'label' => 'Lemon'],
+    'leo' => ['emoji' => '♌', 'label' => 'Leo'],
+    'leopard' => ['emoji' => '🐆', 'label' => 'Leopard'],
+    'level_slider' => ['emoji' => '🎚️', 'label' => 'Level Slider'],
+    'libra' => ['emoji' => '♎', 'label' => 'Libra'],
+    'light_blue_heart' => ['emoji' => '🩵', 'label' => 'Light Blue Heart'],
+    'light_rail' => ['emoji' => '🚈', 'label' => 'Light Rail'],
+    'lightning' => ['emoji' => '🌩️', 'label' => 'Cloud With Lightning'],
+    'like' => ['emoji' => '👍', 'label' => 'Like'],
+    'lime' => ['emoji' => '🍋‍🟩', 'label' => 'Lime'],
+    'link' => ['emoji' => '🔗', 'label' => 'Link Symbol'],
+    'linked_paperclips' => ['emoji' => '🖇️', 'label' => 'Linked Paperclips'],
+    'lion_face' => ['emoji' => '🦁', 'label' => 'Lion Face'],
+    'lips' => ['emoji' => '👄', 'label' => 'Mouth'],
+    'lipstick' => ['emoji' => '💄', 'label' => 'Lipstick'],
+    'lizard' => ['emoji' => '🦎', 'label' => 'Lizard'],
+    'llama' => ['emoji' => '🦙', 'label' => 'Llama'],
+    'lobster' => ['emoji' => '🦞', 'label' => 'Lobster'],
+    'lock' => ['emoji' => '🔒', 'label' => 'Lock'],
+    'lock_with_ink_pen' => ['emoji' => '🔏', 'label' => 'Lock With Ink Pen'],
+    'lollipop' => ['emoji' => '🍭', 'label' => 'Lollipop'],
+    'long_drum' => ['emoji' => '🪘', 'label' => 'Long Drum'],
+    'loop' => ['emoji' => '➿', 'label' => 'Double Curly Loop'],
+    'lotion_bottle' => ['emoji' => '🧴', 'label' => 'Lotion Bottle'],
+    'lotus' => ['emoji' => '🪷', 'label' => 'Lotus'],
+    'loud_sound' => ['emoji' => '🔊', 'label' => 'Speaker With Three Sound Waves'],
+    'loudspeaker' => ['emoji' => '📢', 'label' => 'Public Address Loudspeaker'],
+    'love' => ['emoji' => '❤️', 'label' => 'Love'],
+    'love_hotel' => ['emoji' => '🏩', 'label' => 'Love Hotel'],
+    'love_letter' => ['emoji' => '💌', 'label' => 'Love Letter'],
+    'low_battery' => ['emoji' => '🪫', 'label' => 'Low Battery'],
+    'low_brightness' => ['emoji' => '🔅', 'label' => 'Low Brightness Symbol'],
+    'lower_left_ballpoint_pen' => ['emoji' => '🖊️', 'label' => 'Pen'],
+    'lower_left_crayon' => ['emoji' => '🖍️', 'label' => 'Crayon'],
+    'lower_left_fountain_pen' => ['emoji' => '🖋️', 'label' => 'Fountain Pen'],
+    'lower_left_paintbrush' => ['emoji' => '🖌️', 'label' => 'Paintbrush'],
+    'luggage' => ['emoji' => '🧳', 'label' => 'Luggage'],
+    'lungs' => ['emoji' => '🫁', 'label' => 'Lungs'],
+    'lying_face' => ['emoji' => '🤥', 'label' => 'Lying Face'],
+    'm' => ['emoji' => 'Ⓜ️', 'label' => 'Circled Latin Capital Letter M'],
+    'mag' => ['emoji' => '🔍', 'label' => 'Left-Pointing Magnifying Glass'],
+    'mag_right' => ['emoji' => '🔎', 'label' => 'Right-Pointing Magnifying Glass'],
+    'mage' => ['emoji' => '🧙', 'label' => 'Mage'],
+    'magic_wand' => ['emoji' => '🪄', 'label' => 'Magic Wand'],
+    'magnet' => ['emoji' => '🧲', 'label' => 'Magnet'],
+    'mahjong' => ['emoji' => '🀄', 'label' => 'Mahjong Tile Red Dragon'],
+    'mailbox' => ['emoji' => '📫', 'label' => 'Closed Mailbox With Raised Flag'],
+    'mailbox_closed' => ['emoji' => '📪', 'label' => 'Closed Mailbox With Lowered Flag'],
+    'mailbox_with_mail' => ['emoji' => '📬', 'label' => 'Open Mailbox With Raised Flag'],
+    'mailbox_with_no_mail' => ['emoji' => '📭', 'label' => 'Open Mailbox With Lowered Flag'],
+    'male-artist' => ['emoji' => '👨‍🎨', 'label' => 'Man Artist'],
+    'male-astronaut' => ['emoji' => '👨‍🚀', 'label' => 'Man Astronaut'],
+    'male-construction-worker' => ['emoji' => '👷‍♂️', 'label' => 'Man Construction Worker'],
+    'male-cook' => ['emoji' => '👨‍🍳', 'label' => 'Man Cook'],
+    'male-detective' => ['emoji' => '🕵️‍♂️', 'label' => 'Man Detective'],
+    'male-doctor' => ['emoji' => '👨‍⚕️', 'label' => 'Man Health Worker'],
+    'male-factory-worker' => ['emoji' => '👨‍🏭', 'label' => 'Man Factory Worker'],
+    'male-farmer' => ['emoji' => '👨‍🌾', 'label' => 'Man Farmer'],
+    'male-firefighter' => ['emoji' => '👨‍🚒', 'label' => 'Man Firefighter'],
+    'male-guard' => ['emoji' => '💂‍♂️', 'label' => 'Man Guard'],
+    'male-judge' => ['emoji' => '👨‍⚖️', 'label' => 'Man Judge'],
+    'male-mechanic' => ['emoji' => '👨‍🔧', 'label' => 'Man Mechanic'],
+    'male-office-worker' => ['emoji' => '👨‍💼', 'label' => 'Man Office Worker'],
+    'male-pilot' => ['emoji' => '👨‍✈️', 'label' => 'Man Pilot'],
+    'male-police-officer' => ['emoji' => '👮‍♂️', 'label' => 'Man Police Officer'],
+    'male-scientist' => ['emoji' => '👨‍🔬', 'label' => 'Man Scientist'],
+    'male-singer' => ['emoji' => '👨‍🎤', 'label' => 'Man Singer'],
+    'male-student' => ['emoji' => '👨‍🎓', 'label' => 'Man Student'],
+    'male-teacher' => ['emoji' => '👨‍🏫', 'label' => 'Man Teacher'],
+    'male-technologist' => ['emoji' => '👨‍💻', 'label' => 'Man Technologist'],
+    'male_elf' => ['emoji' => '🧝‍♂️', 'label' => 'Man Elf'],
+    'male_fairy' => ['emoji' => '🧚‍♂️', 'label' => 'Man Fairy'],
+    'male_genie' => ['emoji' => '🧞‍♂️', 'label' => 'Man Genie'],
+    'male_mage' => ['emoji' => '🧙‍♂️', 'label' => 'Man Mage'],
+    'male_sign' => ['emoji' => '♂️', 'label' => 'Male Sign'],
+    'male_superhero' => ['emoji' => '🦸‍♂️', 'label' => 'Man Superhero'],
+    'male_supervillain' => ['emoji' => '🦹‍♂️', 'label' => 'Man Supervillain'],
+    'male_vampire' => ['emoji' => '🧛‍♂️', 'label' => 'Man Vampire'],
+    'male_zombie' => ['emoji' => '🧟‍♂️', 'label' => 'Man Zombie'],
+    'mammoth' => ['emoji' => '🦣', 'label' => 'Mammoth'],
+    'man' => ['emoji' => '👨', 'label' => 'Man'],
+    'man-biking' => ['emoji' => '🚴‍♂️', 'label' => 'Man Biking'],
+    'man-bouncing-ball' => ['emoji' => '⛹️‍♂️', 'label' => 'Man Bouncing Ball'],
+    'man-bowing' => ['emoji' => '🙇‍♂️', 'label' => 'Man Bowing'],
+    'man-boy' => ['emoji' => '👨‍👦', 'label' => 'Family: Man, Boy'],
+    'man-boy-boy' => ['emoji' => '👨‍👦‍👦', 'label' => 'Family: Man, Boy, Boy'],
+    'man-cartwheeling' => ['emoji' => '🤸‍♂️', 'label' => 'Man Cartwheeling'],
+    'man-facepalming' => ['emoji' => '🤦‍♂️', 'label' => 'Man Facepalming'],
+    'man-frowning' => ['emoji' => '🙍‍♂️', 'label' => 'Man Frowning'],
+    'man-gesturing-no' => ['emoji' => '🙅‍♂️', 'label' => 'Man Gesturing No'],
+    'man-gesturing-ok' => ['emoji' => '🙆‍♂️', 'label' => 'Man Gesturing Ok'],
+    'man-getting-haircut' => ['emoji' => '💇‍♂️', 'label' => 'Man Getting Haircut'],
+    'man-getting-massage' => ['emoji' => '💆‍♂️', 'label' => 'Man Getting Massage'],
+    'man-girl' => ['emoji' => '👨‍👧', 'label' => 'Family: Man, Girl'],
+    'man-girl-boy' => ['emoji' => '👨‍👧‍👦', 'label' => 'Family: Man, Girl, Boy'],
+    'man-girl-girl' => ['emoji' => '👨‍👧‍👧', 'label' => 'Family: Man, Girl, Girl'],
+    'man-golfing' => ['emoji' => '🏌️‍♂️', 'label' => 'Man Golfing'],
+    'man-heart-man' => ['emoji' => '👨‍❤️‍👨', 'label' => 'Couple With Heart: Man, Man'],
+    'man-juggling' => ['emoji' => '🤹‍♂️', 'label' => 'Man Juggling'],
+    'man-kiss-man' => ['emoji' => '👨‍❤️‍💋‍👨', 'label' => 'Kiss: Man, Man'],
+    'man-lifting-weights' => ['emoji' => '🏋️‍♂️', 'label' => 'Man Lifting Weights'],
+    'man-man-boy' => ['emoji' => '👨‍👨‍👦', 'label' => 'Family: Man, Man, Boy'],
+    'man-man-boy-boy' => ['emoji' => '👨‍👨‍👦‍👦', 'label' => 'Family: Man, Man, Boy, Boy'],
+    'man-man-girl' => ['emoji' => '👨‍👨‍👧', 'label' => 'Family: Man, Man, Girl'],
+    'man-man-girl-boy' => ['emoji' => '👨‍👨‍👧‍👦', 'label' => 'Family: Man, Man, Girl, Boy'],
+    'man-man-girl-girl' => ['emoji' => '👨‍👨‍👧‍👧', 'label' => 'Family: Man, Man, Girl, Girl'],
+    'man-mountain-biking' => ['emoji' => '🚵‍♂️', 'label' => 'Man Mountain Biking'],
+    'man-playing-handball' => ['emoji' => '🤾‍♂️', 'label' => 'Man Playing Handball'],
+    'man-playing-water-polo' => ['emoji' => '🤽‍♂️', 'label' => 'Man Playing Water Polo'],
+    'man-pouting' => ['emoji' => '🙎‍♂️', 'label' => 'Man Pouting'],
+    'man-raising-hand' => ['emoji' => '🙋‍♂️', 'label' => 'Man Raising Hand'],
+    'man-rowing-boat' => ['emoji' => '🚣‍♂️', 'label' => 'Man Rowing Boat'],
+    'man-running' => ['emoji' => '🏃‍♂️', 'label' => 'Man Running'],
+    'man-shrugging' => ['emoji' => '🤷‍♂️', 'label' => 'Man Shrugging'],
+    'man-surfing' => ['emoji' => '🏄‍♂️', 'label' => 'Man Surfing'],
+    'man-swimming' => ['emoji' => '🏊‍♂️', 'label' => 'Man Swimming'],
+    'man-tipping-hand' => ['emoji' => '💁‍♂️', 'label' => 'Man Tipping Hand'],
+    'man-walking' => ['emoji' => '🚶‍♂️', 'label' => 'Man Walking'],
+    'man-wearing-turban' => ['emoji' => '👳‍♂️', 'label' => 'Man Wearing Turban'],
+    'man-woman-boy' => ['emoji' => '👨‍👩‍👦', 'label' => 'Family: Man, Woman, Boy'],
+    'man-woman-boy-boy' => ['emoji' => '👨‍👩‍👦‍👦', 'label' => 'Family: Man, Woman, Boy, Boy'],
+    'man-woman-girl' => ['emoji' => '👨‍👩‍👧', 'label' => 'Family: Man, Woman, Girl'],
+    'man-woman-girl-boy' => ['emoji' => '👨‍👩‍👧‍👦', 'label' => 'Family: Man, Woman, Girl, Boy'],
+    'man-woman-girl-girl' => ['emoji' => '👨‍👩‍👧‍👧', 'label' => 'Family: Man, Woman, Girl, Girl'],
+    'man-wrestling' => ['emoji' => '🤼‍♂️', 'label' => 'Men Wrestling'],
+    'man_and_woman_holding_hands' => ['emoji' => '👫', 'label' => 'Man And Woman Holding Hands'],
+    'man_climbing' => ['emoji' => '🧗‍♂️', 'label' => 'Man Climbing'],
+    'man_dancing' => ['emoji' => '🕺', 'label' => 'Man Dancing'],
+    'man_feeding_baby' => ['emoji' => '👨‍🍼', 'label' => 'Man Feeding Baby'],
+    'man_in_business_suit_levitating' => ['emoji' => '🕴️', 'label' => 'Person In Suit Levitating'],
+    'man_in_lotus_position' => ['emoji' => '🧘‍♂️', 'label' => 'Man In Lotus Position'],
+    'man_in_manual_wheelchair' => ['emoji' => '👨‍🦽', 'label' => 'Man In Manual Wheelchair'],
+    'man_in_manual_wheelchair_facing_right' => ['emoji' => '👨‍🦽‍➡️', 'label' => 'Man In Manual Wheelchair Facing Right'],
+    'man_in_motorized_wheelchair' => ['emoji' => '👨‍🦼', 'label' => 'Man In Motorized Wheelchair'],
+    'man_in_motorized_wheelchair_facing_right' => ['emoji' => '👨‍🦼‍➡️', 'label' => 'Man In Motorized Wheelchair Facing Right'],
+    'man_in_steamy_room' => ['emoji' => '🧖‍♂️', 'label' => 'Man In Steamy Room'],
+    'man_in_tuxedo' => ['emoji' => '🤵‍♂️', 'label' => 'Man In Tuxedo'],
+    'man_kneeling' => ['emoji' => '🧎‍♂️', 'label' => 'Man Kneeling'],
+    'man_kneeling_facing_right' => ['emoji' => '🧎‍♂️‍➡️', 'label' => 'Man Kneeling Facing Right'],
+    'man_running_facing_right' => ['emoji' => '🏃‍♂️‍➡️', 'label' => 'Man Running Facing Right'],
+    'man_standing' => ['emoji' => '🧍‍♂️', 'label' => 'Man Standing'],
+    'man_walking_facing_right' => ['emoji' => '🚶‍♂️‍➡️', 'label' => 'Man Walking Facing Right'],
+    'man_with_beard' => ['emoji' => '🧔‍♂️', 'label' => 'Man: Beard'],
+    'man_with_gua_pi_mao' => ['emoji' => '👲', 'label' => 'Man With Gua Pi Mao'],
+    'man_with_probing_cane' => ['emoji' => '👨‍🦯', 'label' => 'Man With White Cane'],
+    'man_with_turban' => ['emoji' => '👳', 'label' => 'Man With Turban'],
+    'man_with_veil' => ['emoji' => '👰‍♂️', 'label' => 'Man With Veil'],
+    'man_with_white_cane_facing_right' => ['emoji' => '👨‍🦯‍➡️', 'label' => 'Man With White Cane Facing Right'],
+    'mango' => ['emoji' => '🥭', 'label' => 'Mango'],
+    'mans_shoe' => ['emoji' => '👞', 'label' => 'Mans Shoe'],
+    'mantelpiece_clock' => ['emoji' => '🕰️', 'label' => 'Mantelpiece Clock'],
+    'manual_wheelchair' => ['emoji' => '🦽', 'label' => 'Manual Wheelchair'],
+    'maple_leaf' => ['emoji' => '🍁', 'label' => 'Maple Leaf'],
+    'maracas' => ['emoji' => '🪇', 'label' => 'Maracas'],
+    'martial_arts_uniform' => ['emoji' => '🥋', 'label' => 'Martial Arts Uniform'],
+    'mask' => ['emoji' => '😷', 'label' => 'Face With Medical Mask'],
+    'massage' => ['emoji' => '💆', 'label' => 'Face Massage'],
+    'mate_drink' => ['emoji' => '🧉', 'label' => 'Mate Drink'],
+    'meat_on_bone' => ['emoji' => '🍖', 'label' => 'Meat On Bone'],
+    'mechanic' => ['emoji' => '🧑‍🔧', 'label' => 'Mechanic'],
+    'mechanical_arm' => ['emoji' => '🦾', 'label' => 'Mechanical Arm'],
+    'mechanical_leg' => ['emoji' => '🦿', 'label' => 'Mechanical Leg'],
+    'medal' => ['emoji' => '🎖️', 'label' => 'Military Medal'],
+    'medical_symbol' => ['emoji' => '⚕️', 'label' => 'Medical Symbol'],
+    'mega' => ['emoji' => '📣', 'label' => 'Cheering Megaphone'],
+    'melon' => ['emoji' => '🍈', 'label' => 'Melon'],
+    'melting_face' => ['emoji' => '🫠', 'label' => 'Melting Face'],
+    'memo' => ['emoji' => '📝', 'label' => 'Memo'],
+    'men-with-bunny-ears-partying' => ['emoji' => '👯‍♂️', 'label' => 'Men With Bunny Ears'],
+    'mending_heart' => ['emoji' => '❤️‍🩹', 'label' => 'Mending Heart'],
+    'menorah_with_nine_branches' => ['emoji' => '🕎', 'label' => 'Menorah With Nine Branches'],
+    'mens' => ['emoji' => '🚹', 'label' => 'Mens Symbol'],
+    'mermaid' => ['emoji' => '🧜‍♀️', 'label' => 'Mermaid'],
+    'merman' => ['emoji' => '🧜‍♂️', 'label' => 'Merman'],
+    'merperson' => ['emoji' => '🧜', 'label' => 'Merperson'],
+    'metro' => ['emoji' => '🚇', 'label' => 'Metro'],
+    'microbe' => ['emoji' => '🦠', 'label' => 'Microbe'],
+    'microphone' => ['emoji' => '🎤', 'label' => 'Microphone'],
+    'microscope' => ['emoji' => '🔬', 'label' => 'Microscope'],
+    'middle_finger' => ['emoji' => '🖕', 'label' => 'Reversed Hand With Middle Finger Extended'],
+    'military_helmet' => ['emoji' => '🪖', 'label' => 'Military Helmet'],
+    'milky_way' => ['emoji' => '🌌', 'label' => 'Milky Way'],
+    'minibus' => ['emoji' => '🚐', 'label' => 'Minibus'],
+    'minidisc' => ['emoji' => '💽', 'label' => 'Minidisc'],
+    'mirror' => ['emoji' => '🪞', 'label' => 'Mirror'],
+    'mirror_ball' => ['emoji' => '🪩', 'label' => 'Mirror Ball'],
+    'mobile_phone_off' => ['emoji' => '📴', 'label' => 'Mobile Phone Off'],
+    'money_mouth_face' => ['emoji' => '🤑', 'label' => 'Money-Mouth Face'],
+    'money_with_wings' => ['emoji' => '💸', 'label' => 'Money With Wings'],
+    'moneybag' => ['emoji' => '💰', 'label' => 'Money Bag'],
+    'monkey' => ['emoji' => '🐒', 'label' => 'Monkey'],
+    'monkey_face' => ['emoji' => '🐵', 'label' => 'Monkey Face'],
+    'monorail' => ['emoji' => '🚝', 'label' => 'Monorail'],
+    'moon' => ['emoji' => '🌔', 'label' => 'Waxing Gibbous Moon Symbol'],
+    'moon_cake' => ['emoji' => '🥮', 'label' => 'Moon Cake'],
+    'moose' => ['emoji' => '🫎', 'label' => 'Moose'],
+    'mortar_board' => ['emoji' => '🎓', 'label' => 'Graduation Cap'],
+    'mosque' => ['emoji' => '🕌', 'label' => 'Mosque'],
+    'mosquito' => ['emoji' => '🦟', 'label' => 'Mosquito'],
+    'mostly_sunny' => ['emoji' => '🌤️', 'label' => 'Sun Behind Small Cloud'],
+    'motor_boat' => ['emoji' => '🛥️', 'label' => 'Motor Boat'],
+    'motor_scooter' => ['emoji' => '🛵', 'label' => 'Motor Scooter'],
+    'motorized_wheelchair' => ['emoji' => '🦼', 'label' => 'Motorized Wheelchair'],
+    'motorway' => ['emoji' => '🛣️', 'label' => 'Motorway'],
+    'mount_fuji' => ['emoji' => '🗻', 'label' => 'Mount Fuji'],
+    'mountain' => ['emoji' => '⛰️', 'label' => 'Mountain'],
+    'mountain_bicyclist' => ['emoji' => '🚵', 'label' => 'Mountain Bicyclist'],
+    'mountain_cableway' => ['emoji' => '🚠', 'label' => 'Mountain Cableway'],
+    'mountain_railway' => ['emoji' => '🚞', 'label' => 'Mountain Railway'],
+    'mouse' => ['emoji' => '🐭', 'label' => 'Mouse Face'],
+    'mouse2' => ['emoji' => '🐁', 'label' => 'Mouse'],
+    'mouse_trap' => ['emoji' => '🪤', 'label' => 'Mouse Trap'],
+    'movie_camera' => ['emoji' => '🎥', 'label' => 'Movie Camera'],
+    'moyai' => ['emoji' => '🗿', 'label' => 'Moyai'],
+    'mrs_claus' => ['emoji' => '🤶', 'label' => 'Mother Christmas'],
+    'muscle' => ['emoji' => '💪', 'label' => 'Flexed Biceps'],
+    'mushroom' => ['emoji' => '🍄', 'label' => 'Mushroom'],
+    'musical_keyboard' => ['emoji' => '🎹', 'label' => 'Musical Keyboard'],
+    'musical_note' => ['emoji' => '🎵', 'label' => 'Musical Note'],
+    'musical_score' => ['emoji' => '🎼', 'label' => 'Musical Score'],
+    'mute' => ['emoji' => '🔇', 'label' => 'Speaker With Cancellation Stroke'],
+    'mx_claus' => ['emoji' => '🧑‍🎄', 'label' => 'Mx Claus'],
+    'nail_care' => ['emoji' => '💅', 'label' => 'Nail Polish'],
+    'name_badge' => ['emoji' => '📛', 'label' => 'Name Badge'],
+    'national_park' => ['emoji' => '🏞️', 'label' => 'National Park'],
+    'nauseated_face' => ['emoji' => '🤢', 'label' => 'Nauseated Face'],
+    'nazar_amulet' => ['emoji' => '🧿', 'label' => 'Nazar Amulet'],
+    'necktie' => ['emoji' => '👔', 'label' => 'Necktie'],
+    'negative_squared_cross_mark' => ['emoji' => '❎', 'label' => 'Negative Squared Cross Mark'],
+    'nerd_face' => ['emoji' => '🤓', 'label' => 'Nerd Face'],
+    'nest_with_eggs' => ['emoji' => '🪺', 'label' => 'Nest With Eggs'],
+    'nesting_dolls' => ['emoji' => '🪆', 'label' => 'Nesting Dolls'],
+    'neutral_face' => ['emoji' => '😐', 'label' => 'Neutral Face'],
+    'new' => ['emoji' => '🆕', 'label' => 'Squared New'],
+    'new_moon' => ['emoji' => '🌑', 'label' => 'New Moon Symbol'],
+    'new_moon_with_face' => ['emoji' => '🌚', 'label' => 'New Moon With Face'],
+    'newspaper' => ['emoji' => '📰', 'label' => 'Newspaper'],
+    'ng' => ['emoji' => '🆖', 'label' => 'Squared Ng'],
+    'night_with_stars' => ['emoji' => '🌃', 'label' => 'Night With Stars'],
+    'nine' => ['emoji' => '9️⃣', 'label' => 'Keycap 9'],
+    'ninja' => ['emoji' => '🥷', 'label' => 'Ninja'],
+    'no_bell' => ['emoji' => '🔕', 'label' => 'Bell With Cancellation Stroke'],
+    'no_bicycles' => ['emoji' => '🚳', 'label' => 'No Bicycles'],
+    'no_entry' => ['emoji' => '⛔', 'label' => 'No Entry'],
+    'no_entry_sign' => ['emoji' => '🚫', 'label' => 'No Entry Sign'],
+    'no_good' => ['emoji' => '🙅', 'label' => 'Face With No Good Gesture'],
+    'no_mobile_phones' => ['emoji' => '📵', 'label' => 'No Mobile Phones'],
+    'no_mouth' => ['emoji' => '😶', 'label' => 'Face Without Mouth'],
+    'no_pedestrians' => ['emoji' => '🚷', 'label' => 'No Pedestrians'],
+    'no_smoking' => ['emoji' => '🚭', 'label' => 'No Smoking Symbol'],
+    'non-potable_water' => ['emoji' => '🚱', 'label' => 'Non-Potable Water Symbol'],
+    'nose' => ['emoji' => '👃', 'label' => 'Nose'],
+    'notebook' => ['emoji' => '📓', 'label' => 'Notebook'],
+    'notebook_with_decorative_cover' => ['emoji' => '📔', 'label' => 'Notebook With Decorative Cover'],
+    'notes' => ['emoji' => '🎶', 'label' => 'Multiple Musical Notes'],
+    'nut_and_bolt' => ['emoji' => '🔩', 'label' => 'Nut And Bolt'],
+    'o' => ['emoji' => '⭕', 'label' => 'Heavy Large Circle'],
+    'o2' => ['emoji' => '🅾️', 'label' => 'Negative Squared Latin Capital Letter O'],
+    'ocean' => ['emoji' => '🌊', 'label' => 'Water Wave'],
+    'octagonal_sign' => ['emoji' => '🛑', 'label' => 'Octagonal Sign'],
+    'octopus' => ['emoji' => '🐙', 'label' => 'Octopus'],
+    'oden' => ['emoji' => '🍢', 'label' => 'Oden'],
+    'office' => ['emoji' => '🏢', 'label' => 'Office Building'],
+    'office_worker' => ['emoji' => '🧑‍💼', 'label' => 'Office Worker'],
+    'oil_drum' => ['emoji' => '🛢️', 'label' => 'Oil Drum'],
+    'ok' => ['emoji' => '🆗', 'label' => 'Squared Ok'],
+    'ok_hand' => ['emoji' => '👌', 'label' => 'Ok Hand Sign'],
+    'ok_woman' => ['emoji' => '🙆', 'label' => 'Face With Ok Gesture'],
+    'old_key' => ['emoji' => '🗝️', 'label' => 'Old Key'],
+    'older_adult' => ['emoji' => '🧓', 'label' => 'Older Adult'],
+    'older_man' => ['emoji' => '👴', 'label' => 'Older Man'],
+    'older_woman' => ['emoji' => '👵', 'label' => 'Older Woman'],
+    'olive' => ['emoji' => '🫒', 'label' => 'Olive'],
+    'om_symbol' => ['emoji' => '🕉️', 'label' => 'Om'],
+    'on' => ['emoji' => '🔛', 'label' => 'On With Exclamation Mark With Left Right Arrow Above'],
+    'oncoming_automobile' => ['emoji' => '🚘', 'label' => 'Oncoming Automobile'],
+    'oncoming_bus' => ['emoji' => '🚍', 'label' => 'Oncoming Bus'],
+    'oncoming_police_car' => ['emoji' => '🚔', 'label' => 'Oncoming Police Car'],
+    'oncoming_taxi' => ['emoji' => '🚖', 'label' => 'Oncoming Taxi'],
+    'one' => ['emoji' => '1️⃣', 'label' => 'Keycap 1'],
+    'one-piece_swimsuit' => ['emoji' => '🩱', 'label' => 'One-Piece Swimsuit'],
+    'onion' => ['emoji' => '🧅', 'label' => 'Onion'],
+    'open_file_folder' => ['emoji' => '📂', 'label' => 'Open File Folder'],
+    'open_hands' => ['emoji' => '👐', 'label' => 'Open Hands Sign'],
+    'open_mouth' => ['emoji' => '😮', 'label' => 'Face With Open Mouth'],
+    'ophiuchus' => ['emoji' => '⛎', 'label' => 'Ophiuchus'],
+    'orange_book' => ['emoji' => '📙', 'label' => 'Orange Book'],
+    'orange_heart' => ['emoji' => '🧡', 'label' => 'Orange Heart'],
+    'orangutan' => ['emoji' => '🦧', 'label' => 'Orangutan'],
+    'orthodox_cross' => ['emoji' => '☦️', 'label' => 'Orthodox Cross'],
+    'otter' => ['emoji' => '🦦', 'label' => 'Otter'],
+    'outbox_tray' => ['emoji' => '📤', 'label' => 'Outbox Tray'],
+    'owl' => ['emoji' => '🦉', 'label' => 'Owl'],
+    'ox' => ['emoji' => '🐂', 'label' => 'Ox'],
+    'oyster' => ['emoji' => '🦪', 'label' => 'Oyster'],
+    'package' => ['emoji' => '📦', 'label' => 'Package'],
+    'page_facing_up' => ['emoji' => '📄', 'label' => 'Page Facing Up'],
+    'page_with_curl' => ['emoji' => '📃', 'label' => 'Page With Curl'],
+    'pager' => ['emoji' => '📟', 'label' => 'Pager'],
+    'palm_down_hand' => ['emoji' => '🫳', 'label' => 'Palm Down Hand'],
+    'palm_tree' => ['emoji' => '🌴', 'label' => 'Palm Tree'],
+    'palm_up_hand' => ['emoji' => '🫴', 'label' => 'Palm Up Hand'],
+    'palms_up_together' => ['emoji' => '🤲', 'label' => 'Palms Up Together'],
+    'pancakes' => ['emoji' => '🥞', 'label' => 'Pancakes'],
+    'panda_face' => ['emoji' => '🐼', 'label' => 'Panda Face'],
+    'paperclip' => ['emoji' => '📎', 'label' => 'Paperclip'],
+    'parachute' => ['emoji' => '🪂', 'label' => 'Parachute'],
+    'parking' => ['emoji' => '🅿️', 'label' => 'Negative Squared Latin Capital Letter P'],
+    'parrot' => ['emoji' => '🦜', 'label' => 'Parrot'],
+    'part_alternation_mark' => ['emoji' => '〽️', 'label' => 'Part Alternation Mark'],
+    'partly_sunny' => ['emoji' => '⛅', 'label' => 'Sun Behind Cloud'],
+    'partly_sunny_rain' => ['emoji' => '🌦️', 'label' => 'Sun Behind Rain Cloud'],
+    'partying_face' => ['emoji' => '🥳', 'label' => 'Face With Party Horn And Party Hat'],
+    'passenger_ship' => ['emoji' => '🛳️', 'label' => 'Passenger Ship'],
+    'passport_control' => ['emoji' => '🛂', 'label' => 'Passport Control'],
+    'pea_pod' => ['emoji' => '🫛', 'label' => 'Pea Pod'],
+    'peace_symbol' => ['emoji' => '☮️', 'label' => 'Peace Symbol'],
+    'peach' => ['emoji' => '🍑', 'label' => 'Peach'],
+    'peacock' => ['emoji' => '🦚', 'label' => 'Peacock'],
+    'peanuts' => ['emoji' => '🥜', 'label' => 'Peanuts'],
+    'pear' => ['emoji' => '🍐', 'label' => 'Pear'],
+    'pencil2' => ['emoji' => '✏️', 'label' => 'Pencil'],
+    'penguin' => ['emoji' => '🐧', 'label' => 'Penguin'],
+    'pensive' => ['emoji' => '😔', 'label' => 'Pensive Face'],
+    'people_holding_hands' => ['emoji' => '🧑‍🤝‍🧑', 'label' => 'People Holding Hands'],
+    'people_hugging' => ['emoji' => '🫂', 'label' => 'People Hugging'],
+    'performing_arts' => ['emoji' => '🎭', 'label' => 'Performing Arts'],
+    'persevere' => ['emoji' => '😣', 'label' => 'Persevering Face'],
+    'person_climbing' => ['emoji' => '🧗', 'label' => 'Person Climbing'],
+    'person_doing_cartwheel' => ['emoji' => '🤸', 'label' => 'Person Doing Cartwheel'],
+    'person_feeding_baby' => ['emoji' => '🧑‍🍼', 'label' => 'Person Feeding Baby'],
+    'person_frowning' => ['emoji' => '🙍', 'label' => 'Person Frowning'],
+    'person_in_lotus_position' => ['emoji' => '🧘', 'label' => 'Person In Lotus Position'],
+    'person_in_manual_wheelchair' => ['emoji' => '🧑‍🦽', 'label' => 'Person In Manual Wheelchair'],
+    'person_in_manual_wheelchair_facing_right' => ['emoji' => '🧑‍🦽‍➡️', 'label' => 'Person In Manual Wheelchair Facing Right'],
+    'person_in_motorized_wheelchair' => ['emoji' => '🧑‍🦼', 'label' => 'Person In Motorized Wheelchair'],
+    'person_in_motorized_wheelchair_facing_right' => ['emoji' => '🧑‍🦼‍➡️', 'label' => 'Person In Motorized Wheelchair Facing Right'],
+    'person_in_steamy_room' => ['emoji' => '🧖', 'label' => 'Person In Steamy Room'],
+    'person_in_tuxedo' => ['emoji' => '🤵', 'label' => 'Man In Tuxedo'],
+    'person_kneeling_facing_right' => ['emoji' => '🧎‍➡️', 'label' => 'Person Kneeling Facing Right'],
+    'person_running_facing_right' => ['emoji' => '🏃‍➡️', 'label' => 'Person Running Facing Right'],
+    'person_walking_facing_right' => ['emoji' => '🚶‍➡️', 'label' => 'Person Walking Facing Right'],
+    'person_with_ball' => ['emoji' => '⛹️', 'label' => 'Person Bouncing Ball'],
+    'person_with_blond_hair' => ['emoji' => '👱', 'label' => 'Person With Blond Hair'],
+    'person_with_crown' => ['emoji' => '🫅', 'label' => 'Person With Crown'],
+    'person_with_headscarf' => ['emoji' => '🧕', 'label' => 'Person With Headscarf'],
+    'person_with_pouting_face' => ['emoji' => '🙎', 'label' => 'Person With Pouting Face'],
+    'person_with_probing_cane' => ['emoji' => '🧑‍🦯', 'label' => 'Person With White Cane'],
+    'person_with_white_cane_facing_right' => ['emoji' => '🧑‍🦯‍➡️', 'label' => 'Person With White Cane Facing Right'],
+    'petri_dish' => ['emoji' => '🧫', 'label' => 'Petri Dish'],
+    'phoenix' => ['emoji' => '🐦‍🔥', 'label' => 'Phoenix'],
+    'phone' => ['emoji' => '☎️', 'label' => 'Black Telephone'],
+    'pick' => ['emoji' => '⛏️', 'label' => 'Pick'],
+    'pickup_truck' => ['emoji' => '🛻', 'label' => 'Pickup Truck'],
+    'pie' => ['emoji' => '🥧', 'label' => 'Pie'],
+    'pig' => ['emoji' => '🐷', 'label' => 'Pig Face'],
+    'pig2' => ['emoji' => '🐖', 'label' => 'Pig'],
+    'pig_nose' => ['emoji' => '🐽', 'label' => 'Pig Nose'],
+    'pill' => ['emoji' => '💊', 'label' => 'Pill'],
+    'pilot' => ['emoji' => '🧑‍✈️', 'label' => 'Pilot'],
+    'pinata' => ['emoji' => '🪅', 'label' => 'Pinata'],
+    'pinched_fingers' => ['emoji' => '🤌', 'label' => 'Pinched Fingers'],
+    'pinching_hand' => ['emoji' => '🤏', 'label' => 'Pinching Hand'],
+    'pineapple' => ['emoji' => '🍍', 'label' => 'Pineapple'],
+    'pink_heart' => ['emoji' => '🩷', 'label' => 'Pink Heart'],
+    'pirate_flag' => ['emoji' => '🏴‍☠️', 'label' => 'Pirate Flag'],
+    'pisces' => ['emoji' => '♓', 'label' => 'Pisces'],
+    'pizza' => ['emoji' => '🍕', 'label' => 'Slice Of Pizza'],
+    'placard' => ['emoji' => '🪧', 'label' => 'Placard'],
+    'place_of_worship' => ['emoji' => '🛐', 'label' => 'Place Of Worship'],
+    'playground_slide' => ['emoji' => '🛝', 'label' => 'Playground Slide'],
+    'pleading_face' => ['emoji' => '🥺', 'label' => 'Face With Pleading Eyes'],
+    'plunger' => ['emoji' => '🪠', 'label' => 'Plunger'],
+    'point_down' => ['emoji' => '👇', 'label' => 'White Down Pointing Backhand Index'],
+    'point_left' => ['emoji' => '👈', 'label' => 'White Left Pointing Backhand Index'],
+    'point_right' => ['emoji' => '👉', 'label' => 'White Right Pointing Backhand Index'],
+    'point_up' => ['emoji' => '☝️', 'label' => 'White Up Pointing Index'],
+    'point_up_2' => ['emoji' => '👆', 'label' => 'White Up Pointing Backhand Index'],
+    'polar_bear' => ['emoji' => '🐻‍❄️', 'label' => 'Polar Bear'],
+    'police_car' => ['emoji' => '🚓', 'label' => 'Police Car'],
+    'poodle' => ['emoji' => '🐩', 'label' => 'Poodle'],
+    'popcorn' => ['emoji' => '🍿', 'label' => 'Popcorn'],
+    'post_office' => ['emoji' => '🏣', 'label' => 'Japanese Post Office'],
+    'postal_horn' => ['emoji' => '📯', 'label' => 'Postal Horn'],
+    'postbox' => ['emoji' => '📮', 'label' => 'Postbox'],
+    'potable_water' => ['emoji' => '🚰', 'label' => 'Potable Water Symbol'],
+    'potato' => ['emoji' => '🥔', 'label' => 'Potato'],
+    'potted_plant' => ['emoji' => '🪴', 'label' => 'Potted Plant'],
+    'pouch' => ['emoji' => '👝', 'label' => 'Pouch'],
+    'poultry_leg' => ['emoji' => '🍗', 'label' => 'Poultry Leg'],
+    'pound' => ['emoji' => '💷', 'label' => 'Banknote With Pound Sign'],
+    'pouring_liquid' => ['emoji' => '🫗', 'label' => 'Pouring Liquid'],
+    'pouting_cat' => ['emoji' => '😾', 'label' => 'Pouting Cat Face'],
+    'pray' => ['emoji' => '🙏', 'label' => 'Person With Folded Hands'],
+    'prayer_beads' => ['emoji' => '📿', 'label' => 'Prayer Beads'],
+    'pregnant_man' => ['emoji' => '🫃', 'label' => 'Pregnant Man'],
+    'pregnant_person' => ['emoji' => '🫄', 'label' => 'Pregnant Person'],
+    'pregnant_woman' => ['emoji' => '🤰', 'label' => 'Pregnant Woman'],
+    'pretzel' => ['emoji' => '🥨', 'label' => 'Pretzel'],
+    'prince' => ['emoji' => '🤴', 'label' => 'Prince'],
+    'princess' => ['emoji' => '👸', 'label' => 'Princess'],
+    'printer' => ['emoji' => '🖨️', 'label' => 'Printer'],
+    'probing_cane' => ['emoji' => '🦯', 'label' => 'Probing Cane'],
+    'purple_heart' => ['emoji' => '💜', 'label' => 'Purple Heart'],
+    'purse' => ['emoji' => '👛', 'label' => 'Purse'],
+    'pushpin' => ['emoji' => '📌', 'label' => 'Pushpin'],
+    'put_litter_in_its_place' => ['emoji' => '🚮', 'label' => 'Put Litter In Its Place Symbol'],
+    'question' => ['emoji' => '❓', 'label' => 'Black Question Mark Ornament'],
+    'rabbit' => ['emoji' => '🐰', 'label' => 'Rabbit Face'],
+    'rabbit2' => ['emoji' => '🐇', 'label' => 'Rabbit'],
+    'raccoon' => ['emoji' => '🦝', 'label' => 'Raccoon'],
+    'racehorse' => ['emoji' => '🐎', 'label' => 'Horse'],
+    'racing_car' => ['emoji' => '🏎️', 'label' => 'Racing Car'],
+    'racing_motorcycle' => ['emoji' => '🏍️', 'label' => 'Motorcycle'],
+    'radio' => ['emoji' => '📻', 'label' => 'Radio'],
+    'radio_button' => ['emoji' => '🔘', 'label' => 'Radio Button'],
+    'radioactive_sign' => ['emoji' => '☢️', 'label' => 'Radioactive'],
+    'rage' => ['emoji' => '😡', 'label' => 'Pouting Face'],
+    'railway_car' => ['emoji' => '🚃', 'label' => 'Railway Car'],
+    'railway_track' => ['emoji' => '🛤️', 'label' => 'Railway Track'],
+    'rain_cloud' => ['emoji' => '🌧️', 'label' => 'Cloud With Rain'],
+    'rainbow' => ['emoji' => '🌈', 'label' => 'Rainbow'],
+    'rainbow-flag' => ['emoji' => '🏳️‍🌈', 'label' => 'Rainbow Flag'],
+    'raised_back_of_hand' => ['emoji' => '🤚', 'label' => 'Raised Back Of Hand'],
+    'raised_hand_with_fingers_splayed' => ['emoji' => '🖐️', 'label' => 'Hand With Fingers Splayed'],
+    'raised_hands' => ['emoji' => '🙌', 'label' => 'Person Raising Both Hands In Celebration'],
+    'raising_hand' => ['emoji' => '🙋', 'label' => 'Happy Person Raising One Hand'],
+    'ram' => ['emoji' => '🐏', 'label' => 'Ram'],
+    'ramen' => ['emoji' => '🍜', 'label' => 'Steaming Bowl'],
+    'rat' => ['emoji' => '🐀', 'label' => 'Rat'],
+    'razor' => ['emoji' => '🪒', 'label' => 'Razor'],
+    'receipt' => ['emoji' => '🧾', 'label' => 'Receipt'],
+    'recycle' => ['emoji' => '♻️', 'label' => 'Black Universal Recycling Symbol'],
+    'red_circle' => ['emoji' => '🔴', 'label' => 'Large Red Circle'],
+    'red_envelope' => ['emoji' => '🧧', 'label' => 'Red Gift Envelope'],
+    'red_haired_man' => ['emoji' => '👨‍🦰', 'label' => 'Man: Red Hair'],
+    'red_haired_person' => ['emoji' => '🧑‍🦰', 'label' => 'Person: Red Hair'],
+    'red_haired_woman' => ['emoji' => '👩‍🦰', 'label' => 'Woman: Red Hair'],
+    'registered' => ['emoji' => '®️', 'label' => 'Registered Sign'],
+    'relaxed' => ['emoji' => '☺️', 'label' => 'White Smiling Face'],
+    'relieved' => ['emoji' => '😌', 'label' => 'Relieved Face'],
+    'reminder_ribbon' => ['emoji' => '🎗️', 'label' => 'Reminder Ribbon'],
+    'repeat' => ['emoji' => '🔁', 'label' => 'Clockwise Rightwards And Leftwards Open Circle Arrows'],
+    'repeat_one' => ['emoji' => '🔂', 'label' => 'Clockwise Rightwards And Leftwards Open Circle Arrows With Circled One Overlay'],
+    'restroom' => ['emoji' => '🚻', 'label' => 'Restroom'],
+    'revolving_hearts' => ['emoji' => '💞', 'label' => 'Revolving Hearts'],
+    'rewind' => ['emoji' => '⏪', 'label' => 'Black Left-Pointing Double Triangle'],
+    'rhinoceros' => ['emoji' => '🦏', 'label' => 'Rhinoceros'],
+    'ribbon' => ['emoji' => '🎀', 'label' => 'Ribbon'],
+    'rice' => ['emoji' => '🍚', 'label' => 'Cooked Rice'],
+    'rice_ball' => ['emoji' => '🍙', 'label' => 'Rice Ball'],
+    'rice_cracker' => ['emoji' => '🍘', 'label' => 'Rice Cracker'],
+    'rice_scene' => ['emoji' => '🎑', 'label' => 'Moon Viewing Ceremony'],
+    'right-facing_fist' => ['emoji' => '🤜', 'label' => 'Right-Facing Fist'],
+    'right_anger_bubble' => ['emoji' => '🗯️', 'label' => 'Right Anger Bubble'],
+    'rightwards_hand' => ['emoji' => '🫱', 'label' => 'Rightwards Hand'],
+    'rightwards_pushing_hand' => ['emoji' => '🫸', 'label' => 'Rightwards Pushing Hand'],
+    'ring' => ['emoji' => '💍', 'label' => 'Ring'],
+    'ring_buoy' => ['emoji' => '🛟', 'label' => 'Ring Buoy'],
+    'ringed_planet' => ['emoji' => '🪐', 'label' => 'Ringed Planet'],
+    'robot_face' => ['emoji' => '🤖', 'label' => 'Robot Face'],
+    'rock' => ['emoji' => '🪨', 'label' => 'Rock'],
+    'rocket' => ['emoji' => '🚀', 'label' => 'Rocket'],
+    'roll_of_paper' => ['emoji' => '🧻', 'label' => 'Roll Of Paper'],
+    'rolled_up_newspaper' => ['emoji' => '🗞️', 'label' => 'Rolled-Up Newspaper'],
+    'roller_coaster' => ['emoji' => '🎢', 'label' => 'Roller Coaster'],
+    'roller_skate' => ['emoji' => '🛼', 'label' => 'Roller Skate'],
+    'rolling_on_the_floor_laughing' => ['emoji' => '🤣', 'label' => 'Rolling On The Floor Laughing'],
+    'rooster' => ['emoji' => '🐓', 'label' => 'Rooster'],
+    'rose' => ['emoji' => '🌹', 'label' => 'Rose'],
+    'rosette' => ['emoji' => '🏵️', 'label' => 'Rosette'],
+    'rotating_light' => ['emoji' => '🚨', 'label' => 'Police Cars Revolving Light'],
+    'round_pushpin' => ['emoji' => '📍', 'label' => 'Round Pushpin'],
+    'rowboat' => ['emoji' => '🚣', 'label' => 'Rowboat'],
+    'ru' => ['emoji' => '🇷🇺', 'label' => 'Russia Flag'],
+    'rugby_football' => ['emoji' => '🏉', 'label' => 'Rugby Football'],
+    'runner' => ['emoji' => '🏃', 'label' => 'Runner'],
+    'running_shirt_with_sash' => ['emoji' => '🎽', 'label' => 'Running Shirt With Sash'],
+    'sa' => ['emoji' => '🈂️', 'label' => 'Squared Katakana Sa'],
+    'safety_pin' => ['emoji' => '🧷', 'label' => 'Safety Pin'],
+    'safety_vest' => ['emoji' => '🦺', 'label' => 'Safety Vest'],
+    'sagittarius' => ['emoji' => '♐', 'label' => 'Sagittarius'],
+    'sake' => ['emoji' => '🍶', 'label' => 'Sake Bottle And Cup'],
+    'salt' => ['emoji' => '🧂', 'label' => 'Salt Shaker'],
+    'saluting_face' => ['emoji' => '🫡', 'label' => 'Saluting Face'],
+    'sandal' => ['emoji' => '👡', 'label' => 'Womans Sandal'],
+    'sandwich' => ['emoji' => '🥪', 'label' => 'Sandwich'],
+    'santa' => ['emoji' => '🎅', 'label' => 'Father Christmas'],
+    'sari' => ['emoji' => '🥻', 'label' => 'Sari'],
+    'satellite' => ['emoji' => '🛰️', 'label' => 'Satellite'],
+    'satellite_antenna' => ['emoji' => '📡', 'label' => 'Satellite Antenna'],
+    'sauropod' => ['emoji' => '🦕', 'label' => 'Sauropod'],
+    'saxophone' => ['emoji' => '🎷', 'label' => 'Saxophone'],
+    'scales' => ['emoji' => '⚖️', 'label' => 'Balance Scale'],
+    'scarf' => ['emoji' => '🧣', 'label' => 'Scarf'],
+    'school' => ['emoji' => '🏫', 'label' => 'School'],
+    'school_satchel' => ['emoji' => '🎒', 'label' => 'School Satchel'],
+    'scientist' => ['emoji' => '🧑‍🔬', 'label' => 'Scientist'],
+    'scissors' => ['emoji' => '✂️', 'label' => 'Black Scissors'],
+    'scooter' => ['emoji' => '🛴', 'label' => 'Scooter'],
+    'scorpion' => ['emoji' => '🦂', 'label' => 'Scorpion'],
+    'scorpius' => ['emoji' => '♏', 'label' => 'Scorpius'],
+    'scream' => ['emoji' => '😱', 'label' => 'Face Screaming In Fear'],
+    'scream_cat' => ['emoji' => '🙀', 'label' => 'Weary Cat Face'],
+    'screwdriver' => ['emoji' => '🪛', 'label' => 'Screwdriver'],
+    'scroll' => ['emoji' => '📜', 'label' => 'Scroll'],
+    'seal' => ['emoji' => '🦭', 'label' => 'Seal'],
+    'seat' => ['emoji' => '💺', 'label' => 'Seat'],
+    'second_place_medal' => ['emoji' => '🥈', 'label' => 'Second Place Medal'],
+    'secret' => ['emoji' => '㊙️', 'label' => 'Circled Ideograph Secret'],
+    'see_no_evil' => ['emoji' => '🙈', 'label' => 'See-No-Evil Monkey'],
+    'seedling' => ['emoji' => '🌱', 'label' => 'Seedling'],
+    'selfie' => ['emoji' => '🤳', 'label' => 'Selfie'],
+    'service_dog' => ['emoji' => '🐕‍🦺', 'label' => 'Service Dog'],
+    'seven' => ['emoji' => '7️⃣', 'label' => 'Keycap 7'],
+    'sewing_needle' => ['emoji' => '🪡', 'label' => 'Sewing Needle'],
+    'shaking_face' => ['emoji' => '🫨', 'label' => 'Shaking Face'],
+    'shallow_pan_of_food' => ['emoji' => '🥘', 'label' => 'Shallow Pan Of Food'],
+    'shamrock' => ['emoji' => '☘️', 'label' => 'Shamrock'],
+    'shark' => ['emoji' => '🦈', 'label' => 'Shark'],
+    'shaved_ice' => ['emoji' => '🍧', 'label' => 'Shaved Ice'],
+    'sheep' => ['emoji' => '🐑', 'label' => 'Sheep'],
+    'shell' => ['emoji' => '🐚', 'label' => 'Spiral Shell'],
+    'shield' => ['emoji' => '🛡️', 'label' => 'Shield'],
+    'shinto_shrine' => ['emoji' => '⛩️', 'label' => 'Shinto Shrine'],
+    'ship' => ['emoji' => '🚢', 'label' => 'Ship'],
+    'shirt' => ['emoji' => '👕', 'label' => 'T-Shirt'],
+    'shopping_bags' => ['emoji' => '🛍️', 'label' => 'Shopping Bags'],
+    'shopping_trolley' => ['emoji' => '🛒', 'label' => 'Shopping Trolley'],
+    'shorts' => ['emoji' => '🩳', 'label' => 'Shorts'],
+    'shower' => ['emoji' => '🚿', 'label' => 'Shower'],
+    'shrimp' => ['emoji' => '🦐', 'label' => 'Shrimp'],
+    'shrug' => ['emoji' => '🤷', 'label' => 'Shrug'],
+    'shushing_face' => ['emoji' => '🤫', 'label' => 'Face With Finger Covering Closed Lips'],
+    'signal_strength' => ['emoji' => '📶', 'label' => 'Antenna With Bars'],
+    'singer' => ['emoji' => '🧑‍🎤', 'label' => 'Singer'],
+    'six' => ['emoji' => '6️⃣', 'label' => 'Keycap 6'],
+    'six_pointed_star' => ['emoji' => '🔯', 'label' => 'Six Pointed Star With Middle Dot'],
+    'skateboard' => ['emoji' => '🛹', 'label' => 'Skateboard'],
+    'ski' => ['emoji' => '🎿', 'label' => 'Ski And Ski Boot'],
+    'skier' => ['emoji' => '⛷️', 'label' => 'Skier'],
+    'skin-tone-2' => ['emoji' => '🏻', 'label' => 'Emoji Modifier Fitzpatrick Type-1-2'],
+    'skin-tone-3' => ['emoji' => '🏼', 'label' => 'Emoji Modifier Fitzpatrick Type-3'],
+    'skin-tone-4' => ['emoji' => '🏽', 'label' => 'Emoji Modifier Fitzpatrick Type-4'],
+    'skin-tone-5' => ['emoji' => '🏾', 'label' => 'Emoji Modifier Fitzpatrick Type-5'],
+    'skin-tone-6' => ['emoji' => '🏿', 'label' => 'Emoji Modifier Fitzpatrick Type-6'],
+    'skull' => ['emoji' => '💀', 'label' => 'Skull'],
+    'skull_and_crossbones' => ['emoji' => '☠️', 'label' => 'Skull And Crossbones'],
+    'skunk' => ['emoji' => '🦨', 'label' => 'Skunk'],
+    'sled' => ['emoji' => '🛷', 'label' => 'Sled'],
+    'sleeping' => ['emoji' => '😴', 'label' => 'Sleeping Face'],
+    'sleeping_accommodation' => ['emoji' => '🛌', 'label' => 'Sleeping Accommodation'],
+    'sleepy' => ['emoji' => '😪', 'label' => 'Sleepy Face'],
+    'sleuth_or_spy' => ['emoji' => '🕵️', 'label' => 'Detective'],
+    'slightly_frowning_face' => ['emoji' => '🙁', 'label' => 'Slightly Frowning Face'],
+    'slightly_smiling_face' => ['emoji' => '🙂', 'label' => 'Slightly Smiling Face'],
+    'slot_machine' => ['emoji' => '🎰', 'label' => 'Slot Machine'],
+    'sloth' => ['emoji' => '🦥', 'label' => 'Sloth'],
+    'small_airplane' => ['emoji' => '🛩️', 'label' => 'Small Airplane'],
+    'small_blue_diamond' => ['emoji' => '🔹', 'label' => 'Small Blue Diamond'],
+    'small_orange_diamond' => ['emoji' => '🔸', 'label' => 'Small Orange Diamond'],
+    'small_red_triangle' => ['emoji' => '🔺', 'label' => 'Up-Pointing Red Triangle'],
+    'small_red_triangle_down' => ['emoji' => '🔻', 'label' => 'Down-Pointing Red Triangle'],
+    'smile' => ['emoji' => '😄', 'label' => 'Smiling Face With Open Mouth And Smiling Eyes'],
+    'smile_cat' => ['emoji' => '😸', 'label' => 'Grinning Cat Face With Smiling Eyes'],
+    'smiley' => ['emoji' => '😃', 'label' => 'Smiling Face With Open Mouth'],
+    'smiley_cat' => ['emoji' => '😺', 'label' => 'Smiling Cat Face With Open Mouth'],
+    'smiling_face_with_3_hearts' => ['emoji' => '🥰', 'label' => 'Smiling Face With Smiling Eyes And Three Hearts'],
+    'smiling_face_with_tear' => ['emoji' => '🥲', 'label' => 'Smiling Face With Tear'],
+    'smiling_imp' => ['emoji' => '😈', 'label' => 'Smiling Face With Horns'],
+    'smirk' => ['emoji' => '😏', 'label' => 'Smirking Face'],
+    'smirk_cat' => ['emoji' => '😼', 'label' => 'Cat Face With Wry Smile'],
+    'smoking' => ['emoji' => '🚬', 'label' => 'Smoking Symbol'],
+    'snail' => ['emoji' => '🐌', 'label' => 'Snail'],
+    'snake' => ['emoji' => '🐍', 'label' => 'Snake'],
+    'sneezing_face' => ['emoji' => '🤧', 'label' => 'Sneezing Face'],
+    'snow_capped_mountain' => ['emoji' => '🏔️', 'label' => 'Snow-Capped Mountain'],
+    'snow_cloud' => ['emoji' => '🌨️', 'label' => 'Cloud With Snow'],
+    'snowboarder' => ['emoji' => '🏂', 'label' => 'Snowboarder'],
+    'snowflake' => ['emoji' => '❄️', 'label' => 'Snowflake'],
+    'snowman' => ['emoji' => '☃️', 'label' => 'Snowman'],
+    'snowman_without_snow' => ['emoji' => '⛄', 'label' => 'Snowman Without Snow'],
+    'soap' => ['emoji' => '🧼', 'label' => 'Bar Of Soap'],
+    'sob' => ['emoji' => '😭', 'label' => 'Loudly Crying Face'],
+    'soccer' => ['emoji' => '⚽', 'label' => 'Soccer Ball'],
+    'socks' => ['emoji' => '🧦', 'label' => 'Socks'],
+    'softball' => ['emoji' => '🥎', 'label' => 'Softball'],
+    'soon' => ['emoji' => '🔜', 'label' => 'Soon With Rightwards Arrow Above'],
+    'sos' => ['emoji' => '🆘', 'label' => 'Squared Sos'],
+    'sound' => ['emoji' => '🔉', 'label' => 'Speaker With One Sound Wave'],
+    'space_invader' => ['emoji' => '👾', 'label' => 'Alien Monster'],
+    'spades' => ['emoji' => '♠️', 'label' => 'Black Spade Suit'],
+    'spaghetti' => ['emoji' => '🍝', 'label' => 'Spaghetti'],
+    'sparkle' => ['emoji' => '❇️', 'label' => 'Sparkle'],
+    'sparkler' => ['emoji' => '🎇', 'label' => 'Firework Sparkler'],
+    'sparkles' => ['emoji' => '✨', 'label' => 'Sparkles'],
+    'sparkling_heart' => ['emoji' => '💖', 'label' => 'Sparkling Heart'],
+    'speak_no_evil' => ['emoji' => '🙊', 'label' => 'Speak-No-Evil Monkey'],
+    'speaker' => ['emoji' => '🔈', 'label' => 'Speaker'],
+    'speaking_head_in_silhouette' => ['emoji' => '🗣️', 'label' => 'Speaking Head'],
+    'speech_balloon' => ['emoji' => '💬', 'label' => 'Speech Balloon'],
+    'speedboat' => ['emoji' => '🚤', 'label' => 'Speedboat'],
+    'spider' => ['emoji' => '🕷️', 'label' => 'Spider'],
+    'spider_web' => ['emoji' => '🕸️', 'label' => 'Spider Web'],
+    'spiral_calendar_pad' => ['emoji' => '🗓️', 'label' => 'Spiral Calendar'],
+    'spiral_note_pad' => ['emoji' => '🗒️', 'label' => 'Spiral Notepad'],
+    'spock-hand' => ['emoji' => '🖖', 'label' => 'Raised Hand With Part Between Middle And Ring Fingers'],
+    'sponge' => ['emoji' => '🧽', 'label' => 'Sponge'],
+    'spoon' => ['emoji' => '🥄', 'label' => 'Spoon'],
+    'sports_medal' => ['emoji' => '🏅', 'label' => 'Sports Medal'],
+    'squid' => ['emoji' => '🦑', 'label' => 'Squid'],
+    'stadium' => ['emoji' => '🏟️', 'label' => 'Stadium'],
+    'standing_person' => ['emoji' => '🧍', 'label' => 'Standing Person'],
+    'star' => ['emoji' => '⭐', 'label' => 'White Medium Star'],
+    'star-struck' => ['emoji' => '🤩', 'label' => 'Grinning Face With Star Eyes'],
+    'star2' => ['emoji' => '🌟', 'label' => 'Glowing Star'],
+    'star_and_crescent' => ['emoji' => '☪️', 'label' => 'Star And Crescent'],
+    'star_of_david' => ['emoji' => '✡️', 'label' => 'Star Of David'],
+    'stars' => ['emoji' => '🌠', 'label' => 'Shooting Star'],
+    'station' => ['emoji' => '🚉', 'label' => 'Station'],
+    'statue_of_liberty' => ['emoji' => '🗽', 'label' => 'Statue Of Liberty'],
+    'steam_locomotive' => ['emoji' => '🚂', 'label' => 'Steam Locomotive'],
+    'stethoscope' => ['emoji' => '🩺', 'label' => 'Stethoscope'],
+    'stew' => ['emoji' => '🍲', 'label' => 'Pot Of Food'],
+    'stopwatch' => ['emoji' => '⏱️', 'label' => 'Stopwatch'],
+    'straight_ruler' => ['emoji' => '📏', 'label' => 'Straight Ruler'],
+    'strawberry' => ['emoji' => '🍓', 'label' => 'Strawberry'],
+    'stuck_out_tongue' => ['emoji' => '😛', 'label' => 'Face With Stuck-Out Tongue'],
+    'stuck_out_tongue_closed_eyes' => ['emoji' => '😝', 'label' => 'Face With Stuck-Out Tongue And Tightly-Closed Eyes'],
+    'stuck_out_tongue_winking_eye' => ['emoji' => '😜', 'label' => 'Face With Stuck-Out Tongue And Winking Eye'],
+    'student' => ['emoji' => '🧑‍🎓', 'label' => 'Student'],
+    'studio_microphone' => ['emoji' => '🎙️', 'label' => 'Studio Microphone'],
+    'stuffed_flatbread' => ['emoji' => '🥙', 'label' => 'Stuffed Flatbread'],
+    'sun_with_face' => ['emoji' => '🌞', 'label' => 'Sun With Face'],
+    'sunflower' => ['emoji' => '🌻', 'label' => 'Sunflower'],
+    'sunglasses' => ['emoji' => '😎', 'label' => 'Smiling Face With Sunglasses'],
+    'sunny' => ['emoji' => '☀️', 'label' => 'Black Sun With Rays'],
+    'sunrise' => ['emoji' => '🌅', 'label' => 'Sunrise'],
+    'sunrise_over_mountains' => ['emoji' => '🌄', 'label' => 'Sunrise Over Mountains'],
+    'superhero' => ['emoji' => '🦸', 'label' => 'Superhero'],
+    'supervillain' => ['emoji' => '🦹', 'label' => 'Supervillain'],
+    'support' => ['emoji' => '🙌', 'label' => 'Support'],
+    'surfer' => ['emoji' => '🏄', 'label' => 'Surfer'],
+    'sushi' => ['emoji' => '🍣', 'label' => 'Sushi'],
+    'suspension_railway' => ['emoji' => '🚟', 'label' => 'Suspension Railway'],
+    'swan' => ['emoji' => '🦢', 'label' => 'Swan'],
+    'sweat' => ['emoji' => '😓', 'label' => 'Face With Cold Sweat'],
+    'sweat_drops' => ['emoji' => '💦', 'label' => 'Splashing Sweat Symbol'],
+    'sweat_smile' => ['emoji' => '😅', 'label' => 'Smiling Face With Open Mouth And Cold Sweat'],
+    'sweet_potato' => ['emoji' => '🍠', 'label' => 'Roasted Sweet Potato'],
+    'swimmer' => ['emoji' => '🏊', 'label' => 'Swimmer'],
+    'symbols' => ['emoji' => '🔣', 'label' => 'Input Symbol For Symbols'],
+    'synagogue' => ['emoji' => '🕍', 'label' => 'Synagogue'],
+    'syringe' => ['emoji' => '💉', 'label' => 'Syringe'],
+    't-rex' => ['emoji' => '🦖', 'label' => 'T-Rex'],
+    'table_tennis_paddle_and_ball' => ['emoji' => '🏓', 'label' => 'Table Tennis Paddle And Ball'],
+    'taco' => ['emoji' => '🌮', 'label' => 'Taco'],
+    'tada' => ['emoji' => '🎉', 'label' => 'Party Popper'],
+    'takeout_box' => ['emoji' => '🥡', 'label' => 'Takeout Box'],
+    'tamale' => ['emoji' => '🫔', 'label' => 'Tamale'],
+    'tanabata_tree' => ['emoji' => '🎋', 'label' => 'Tanabata Tree'],
+    'tangerine' => ['emoji' => '🍊', 'label' => 'Tangerine'],
+    'taurus' => ['emoji' => '♉', 'label' => 'Taurus'],
+    'taxi' => ['emoji' => '🚕', 'label' => 'Taxi'],
+    'tea' => ['emoji' => '🍵', 'label' => 'Teacup Without Handle'],
+    'teacher' => ['emoji' => '🧑‍🏫', 'label' => 'Teacher'],
+    'teapot' => ['emoji' => '🫖', 'label' => 'Teapot'],
+    'technologist' => ['emoji' => '🧑‍💻', 'label' => 'Technologist'],
+    'teddy_bear' => ['emoji' => '🧸', 'label' => 'Teddy Bear'],
+    'telephone_receiver' => ['emoji' => '📞', 'label' => 'Telephone Receiver'],
+    'telescope' => ['emoji' => '🔭', 'label' => 'Telescope'],
+    'tennis' => ['emoji' => '🎾', 'label' => 'Tennis Racquet And Ball'],
+    'tent' => ['emoji' => '⛺', 'label' => 'Tent'],
+    'test_tube' => ['emoji' => '🧪', 'label' => 'Test Tube'],
+    'the_horns' => ['emoji' => '🤘', 'label' => 'Sign Of The Horns'],
+    'thermometer' => ['emoji' => '🌡️', 'label' => 'Thermometer'],
+    'thinking_face' => ['emoji' => '🤔', 'label' => 'Thinking Face'],
+    'third_place_medal' => ['emoji' => '🥉', 'label' => 'Third Place Medal'],
+    'thong_sandal' => ['emoji' => '🩴', 'label' => 'Thong Sandal'],
+    'thought_balloon' => ['emoji' => '💭', 'label' => 'Thought Balloon'],
+    'thread' => ['emoji' => '🧵', 'label' => 'Spool Of Thread'],
+    'three' => ['emoji' => '3️⃣', 'label' => 'Keycap 3'],
+    'three_button_mouse' => ['emoji' => '🖱️', 'label' => 'Computer Mouse'],
+    'thunder_cloud_and_rain' => ['emoji' => '⛈️', 'label' => 'Cloud With Lightning And Rain'],
+    'ticket' => ['emoji' => '🎫', 'label' => 'Ticket'],
+    'tiger' => ['emoji' => '🐯', 'label' => 'Tiger Face'],
+    'tiger2' => ['emoji' => '🐅', 'label' => 'Tiger'],
+    'timer_clock' => ['emoji' => '⏲️', 'label' => 'Timer Clock'],
+    'tired_face' => ['emoji' => '😫', 'label' => 'Tired Face'],
+    'tm' => ['emoji' => '™️', 'label' => 'Trade Mark Sign'],
+    'toilet' => ['emoji' => '🚽', 'label' => 'Toilet'],
+    'tokyo_tower' => ['emoji' => '🗼', 'label' => 'Tokyo Tower'],
+    'tomato' => ['emoji' => '🍅', 'label' => 'Tomato'],
+    'tongue' => ['emoji' => '👅', 'label' => 'Tongue'],
+    'toolbox' => ['emoji' => '🧰', 'label' => 'Toolbox'],
+    'tooth' => ['emoji' => '🦷', 'label' => 'Tooth'],
+    'toothbrush' => ['emoji' => '🪥', 'label' => 'Toothbrush'],
+    'top' => ['emoji' => '🔝', 'label' => 'Top With Upwards Arrow Above'],
+    'tophat' => ['emoji' => '🎩', 'label' => 'Top Hat'],
+    'tornado' => ['emoji' => '🌪️', 'label' => 'Tornado'],
+    'trackball' => ['emoji' => '🖲️', 'label' => 'Trackball'],
+    'tractor' => ['emoji' => '🚜', 'label' => 'Tractor'],
+    'traffic_light' => ['emoji' => '🚥', 'label' => 'Horizontal Traffic Light'],
+    'train' => ['emoji' => '🚋', 'label' => 'Tram Car'],
+    'train2' => ['emoji' => '🚆', 'label' => 'Train'],
+    'tram' => ['emoji' => '🚊', 'label' => 'Tram'],
+    'transgender_flag' => ['emoji' => '🏳️‍⚧️', 'label' => 'Transgender Flag'],
+    'transgender_symbol' => ['emoji' => '⚧️', 'label' => 'Transgender Symbol'],
+    'triangular_flag_on_post' => ['emoji' => '🚩', 'label' => 'Triangular Flag On Post'],
+    'triangular_ruler' => ['emoji' => '📐', 'label' => 'Triangular Ruler'],
+    'trident' => ['emoji' => '🔱', 'label' => 'Trident Emblem'],
+    'triumph' => ['emoji' => '😤', 'label' => 'Face With Look Of Triumph'],
+    'troll' => ['emoji' => '🧌', 'label' => 'Troll'],
+    'trolleybus' => ['emoji' => '🚎', 'label' => 'Trolleybus'],
+    'trophy' => ['emoji' => '🏆', 'label' => 'Trophy'],
+    'tropical_drink' => ['emoji' => '🍹', 'label' => 'Tropical Drink'],
+    'tropical_fish' => ['emoji' => '🐠', 'label' => 'Tropical Fish'],
+    'truck' => ['emoji' => '🚚', 'label' => 'Delivery Truck'],
+    'trumpet' => ['emoji' => '🎺', 'label' => 'Trumpet'],
+    'tulip' => ['emoji' => '🌷', 'label' => 'Tulip'],
+    'tumbler_glass' => ['emoji' => '🥃', 'label' => 'Tumbler Glass'],
+    'turkey' => ['emoji' => '🦃', 'label' => 'Turkey'],
+    'turtle' => ['emoji' => '🐢', 'label' => 'Turtle'],
+    'tv' => ['emoji' => '📺', 'label' => 'Television'],
+    'twisted_rightwards_arrows' => ['emoji' => '🔀', 'label' => 'Twisted Rightwards Arrows'],
+    'two' => ['emoji' => '2️⃣', 'label' => 'Keycap 2'],
+    'two_hearts' => ['emoji' => '💕', 'label' => 'Two Hearts'],
+    'two_men_holding_hands' => ['emoji' => '👬', 'label' => 'Two Men Holding Hands'],
+    'two_women_holding_hands' => ['emoji' => '👭', 'label' => 'Two Women Holding Hands'],
+    'u5272' => ['emoji' => '🈹', 'label' => 'Squared Cjk Unified Ideograph-5272'],
+    'u5408' => ['emoji' => '🈴', 'label' => 'Squared Cjk Unified Ideograph-5408'],
+    'u55b6' => ['emoji' => '🈺', 'label' => 'Squared Cjk Unified Ideograph-55B6'],
+    'u6307' => ['emoji' => '🈯', 'label' => 'Squared Cjk Unified Ideograph-6307'],
+    'u6708' => ['emoji' => '🈷️', 'label' => 'Squared Cjk Unified Ideograph-6708'],
+    'u6709' => ['emoji' => '🈶', 'label' => 'Squared Cjk Unified Ideograph-6709'],
+    'u6e80' => ['emoji' => '🈵', 'label' => 'Squared Cjk Unified Ideograph-6E80'],
+    'u7121' => ['emoji' => '🈚', 'label' => 'Squared Cjk Unified Ideograph-7121'],
+    'u7533' => ['emoji' => '🈸', 'label' => 'Squared Cjk Unified Ideograph-7533'],
+    'u7981' => ['emoji' => '🈲', 'label' => 'Squared Cjk Unified Ideograph-7981'],
+    'u7a7a' => ['emoji' => '🈳', 'label' => 'Squared Cjk Unified Ideograph-7A7A'],
+    'umbrella' => ['emoji' => '☂️', 'label' => 'Umbrella'],
+    'umbrella_on_ground' => ['emoji' => '⛱️', 'label' => 'Umbrella On Ground'],
+    'umbrella_with_rain_drops' => ['emoji' => '☔', 'label' => 'Umbrella With Rain Drops'],
+    'unamused' => ['emoji' => '😒', 'label' => 'Unamused Face'],
+    'underage' => ['emoji' => '🔞', 'label' => 'No One Under Eighteen Symbol'],
+    'unicorn_face' => ['emoji' => '🦄', 'label' => 'Unicorn Face'],
+    'unlock' => ['emoji' => '🔓', 'label' => 'Open Lock'],
+    'up' => ['emoji' => '🆙', 'label' => 'Squared Up With Exclamation Mark'],
+    'upside_down_face' => ['emoji' => '🙃', 'label' => 'Upside-Down Face'],
+    'us' => ['emoji' => '🇺🇸', 'label' => 'United States Flag'],
+    'v' => ['emoji' => '✌️', 'label' => 'Victory Hand'],
+    'vampire' => ['emoji' => '🧛', 'label' => 'Vampire'],
+    'vertical_traffic_light' => ['emoji' => '🚦', 'label' => 'Vertical Traffic Light'],
+    'vhs' => ['emoji' => '📼', 'label' => 'Videocassette'],
+    'vibration_mode' => ['emoji' => '📳', 'label' => 'Vibration Mode'],
+    'video_camera' => ['emoji' => '📹', 'label' => 'Video Camera'],
+    'video_game' => ['emoji' => '🎮', 'label' => 'Video Game'],
+    'violin' => ['emoji' => '🎻', 'label' => 'Violin'],
+    'virgo' => ['emoji' => '♍', 'label' => 'Virgo'],
+    'volcano' => ['emoji' => '🌋', 'label' => 'Volcano'],
+    'volleyball' => ['emoji' => '🏐', 'label' => 'Volleyball'],
+    'vs' => ['emoji' => '🆚', 'label' => 'Squared Vs'],
+    'waffle' => ['emoji' => '🧇', 'label' => 'Waffle'],
+    'walking' => ['emoji' => '🚶', 'label' => 'Pedestrian'],
+    'waning_crescent_moon' => ['emoji' => '🌘', 'label' => 'Waning Crescent Moon Symbol'],
+    'waning_gibbous_moon' => ['emoji' => '🌖', 'label' => 'Waning Gibbous Moon Symbol'],
+    'warning' => ['emoji' => '⚠️', 'label' => 'Warning Sign'],
+    'wastebasket' => ['emoji' => '🗑️', 'label' => 'Wastebasket'],
+    'watch' => ['emoji' => '⌚', 'label' => 'Watch'],
+    'water_buffalo' => ['emoji' => '🐃', 'label' => 'Water Buffalo'],
+    'water_polo' => ['emoji' => '🤽', 'label' => 'Water Polo'],
+    'watermelon' => ['emoji' => '🍉', 'label' => 'Watermelon'],
+    'wave' => ['emoji' => '👋', 'label' => 'Waving Hand Sign'],
+    'waving_black_flag' => ['emoji' => '🏴', 'label' => 'Waving Black Flag'],
+    'waving_white_flag' => ['emoji' => '🏳️', 'label' => 'White Flag'],
+    'wavy_dash' => ['emoji' => '〰️', 'label' => 'Wavy Dash'],
+    'waxing_crescent_moon' => ['emoji' => '🌒', 'label' => 'Waxing Crescent Moon Symbol'],
+    'wc' => ['emoji' => '🚾', 'label' => 'Water Closet'],
+    'weary' => ['emoji' => '😩', 'label' => 'Weary Face'],
+    'wedding' => ['emoji' => '💒', 'label' => 'Wedding'],
+    'weight_lifter' => ['emoji' => '🏋️', 'label' => 'Person Lifting Weights'],
+    'whale' => ['emoji' => '🐳', 'label' => 'Spouting Whale'],
+    'whale2' => ['emoji' => '🐋', 'label' => 'Whale'],
+    'wheel' => ['emoji' => '🛞', 'label' => 'Wheel'],
+    'wheel_of_dharma' => ['emoji' => '☸️', 'label' => 'Wheel Of Dharma'],
+    'wheelchair' => ['emoji' => '♿', 'label' => 'Wheelchair Symbol'],
+    'white_check_mark' => ['emoji' => '✅', 'label' => 'White Heavy Check Mark'],
+    'white_circle' => ['emoji' => '⚪', 'label' => 'Medium White Circle'],
+    'white_flower' => ['emoji' => '💮', 'label' => 'White Flower'],
+    'white_frowning_face' => ['emoji' => '☹️', 'label' => 'Frowning Face'],
+    'white_haired_man' => ['emoji' => '👨‍🦳', 'label' => 'Man: White Hair'],
+    'white_haired_person' => ['emoji' => '🧑‍🦳', 'label' => 'Person: White Hair'],
+    'white_haired_woman' => ['emoji' => '👩‍🦳', 'label' => 'Woman: White Hair'],
+    'white_heart' => ['emoji' => '🤍', 'label' => 'White Heart'],
+    'white_large_square' => ['emoji' => '⬜', 'label' => 'White Large Square'],
+    'white_medium_small_square' => ['emoji' => '◽', 'label' => 'White Medium Small Square'],
+    'white_medium_square' => ['emoji' => '◻️', 'label' => 'White Medium Square'],
+    'white_small_square' => ['emoji' => '▫️', 'label' => 'White Small Square'],
+    'white_square_button' => ['emoji' => '🔳', 'label' => 'White Square Button'],
+    'wilted_flower' => ['emoji' => '🥀', 'label' => 'Wilted Flower'],
+    'wind_blowing_face' => ['emoji' => '🌬️', 'label' => 'Wind Face'],
+    'wind_chime' => ['emoji' => '🎐', 'label' => 'Wind Chime'],
+    'window' => ['emoji' => '🪟', 'label' => 'Window'],
+    'wine_glass' => ['emoji' => '🍷', 'label' => 'Wine Glass'],
+    'wing' => ['emoji' => '🪽', 'label' => 'Wing'],
+    'wink' => ['emoji' => '😉', 'label' => 'Winking Face'],
+    'wireless' => ['emoji' => '🛜', 'label' => 'Wireless'],
+    'wolf' => ['emoji' => '🐺', 'label' => 'Wolf Face'],
+    'woman' => ['emoji' => '👩', 'label' => 'Woman'],
+    'woman-biking' => ['emoji' => '🚴‍♀️', 'label' => 'Woman Biking'],
+    'woman-bouncing-ball' => ['emoji' => '⛹️‍♀️', 'label' => 'Woman Bouncing Ball'],
+    'woman-bowing' => ['emoji' => '🙇‍♀️', 'label' => 'Woman Bowing'],
+    'woman-boy' => ['emoji' => '👩‍👦', 'label' => 'Family: Woman, Boy'],
+    'woman-boy-boy' => ['emoji' => '👩‍👦‍👦', 'label' => 'Family: Woman, Boy, Boy'],
+    'woman-cartwheeling' => ['emoji' => '🤸‍♀️', 'label' => 'Woman Cartwheeling'],
+    'woman-facepalming' => ['emoji' => '🤦‍♀️', 'label' => 'Woman Facepalming'],
+    'woman-frowning' => ['emoji' => '🙍‍♀️', 'label' => 'Woman Frowning'],
+    'woman-gesturing-no' => ['emoji' => '🙅‍♀️', 'label' => 'Woman Gesturing No'],
+    'woman-gesturing-ok' => ['emoji' => '🙆‍♀️', 'label' => 'Woman Gesturing Ok'],
+    'woman-getting-haircut' => ['emoji' => '💇‍♀️', 'label' => 'Woman Getting Haircut'],
+    'woman-getting-massage' => ['emoji' => '💆‍♀️', 'label' => 'Woman Getting Massage'],
+    'woman-girl' => ['emoji' => '👩‍👧', 'label' => 'Family: Woman, Girl'],
+    'woman-girl-boy' => ['emoji' => '👩‍👧‍👦', 'label' => 'Family: Woman, Girl, Boy'],
+    'woman-girl-girl' => ['emoji' => '👩‍👧‍👧', 'label' => 'Family: Woman, Girl, Girl'],
+    'woman-golfing' => ['emoji' => '🏌️‍♀️', 'label' => 'Woman Golfing'],
+    'woman-heart-man' => ['emoji' => '👩‍❤️‍👨', 'label' => 'Couple With Heart: Woman, Man'],
+    'woman-heart-woman' => ['emoji' => '👩‍❤️‍👩', 'label' => 'Couple With Heart: Woman, Woman'],
+    'woman-juggling' => ['emoji' => '🤹‍♀️', 'label' => 'Woman Juggling'],
+    'woman-kiss-man' => ['emoji' => '👩‍❤️‍💋‍👨', 'label' => 'Kiss: Woman, Man'],
+    'woman-kiss-woman' => ['emoji' => '👩‍❤️‍💋‍👩', 'label' => 'Kiss: Woman, Woman'],
+    'woman-lifting-weights' => ['emoji' => '🏋️‍♀️', 'label' => 'Woman Lifting Weights'],
+    'woman-mountain-biking' => ['emoji' => '🚵‍♀️', 'label' => 'Woman Mountain Biking'],
+    'woman-playing-handball' => ['emoji' => '🤾‍♀️', 'label' => 'Woman Playing Handball'],
+    'woman-playing-water-polo' => ['emoji' => '🤽‍♀️', 'label' => 'Woman Playing Water Polo'],
+    'woman-pouting' => ['emoji' => '🙎‍♀️', 'label' => 'Woman Pouting'],
+    'woman-raising-hand' => ['emoji' => '🙋‍♀️', 'label' => 'Woman Raising Hand'],
+    'woman-rowing-boat' => ['emoji' => '🚣‍♀️', 'label' => 'Woman Rowing Boat'],
+    'woman-running' => ['emoji' => '🏃‍♀️', 'label' => 'Woman Running'],
+    'woman-shrugging' => ['emoji' => '🤷‍♀️', 'label' => 'Woman Shrugging'],
+    'woman-surfing' => ['emoji' => '🏄‍♀️', 'label' => 'Woman Surfing'],
+    'woman-swimming' => ['emoji' => '🏊‍♀️', 'label' => 'Woman Swimming'],
+    'woman-tipping-hand' => ['emoji' => '💁‍♀️', 'label' => 'Woman Tipping Hand'],
+    'woman-walking' => ['emoji' => '🚶‍♀️', 'label' => 'Woman Walking'],
+    'woman-wearing-turban' => ['emoji' => '👳‍♀️', 'label' => 'Woman Wearing Turban'],
+    'woman-woman-boy' => ['emoji' => '👩‍👩‍👦', 'label' => 'Family: Woman, Woman, Boy'],
+    'woman-woman-boy-boy' => ['emoji' => '👩‍👩‍👦‍👦', 'label' => 'Family: Woman, Woman, Boy, Boy'],
+    'woman-woman-girl' => ['emoji' => '👩‍👩‍👧', 'label' => 'Family: Woman, Woman, Girl'],
+    'woman-woman-girl-boy' => ['emoji' => '👩‍👩‍👧‍👦', 'label' => 'Family: Woman, Woman, Girl, Boy'],
+    'woman-woman-girl-girl' => ['emoji' => '👩‍👩‍👧‍👧', 'label' => 'Family: Woman, Woman, Girl, Girl'],
+    'woman-wrestling' => ['emoji' => '🤼‍♀️', 'label' => 'Women Wrestling'],
+    'woman_climbing' => ['emoji' => '🧗‍♀️', 'label' => 'Woman Climbing'],
+    'woman_feeding_baby' => ['emoji' => '👩‍🍼', 'label' => 'Woman Feeding Baby'],
+    'woman_in_lotus_position' => ['emoji' => '🧘‍♀️', 'label' => 'Woman In Lotus Position'],
+    'woman_in_manual_wheelchair' => ['emoji' => '👩‍🦽', 'label' => 'Woman In Manual Wheelchair'],
+    'woman_in_manual_wheelchair_facing_right' => ['emoji' => '👩‍🦽‍➡️', 'label' => 'Woman In Manual Wheelchair Facing Right'],
+    'woman_in_motorized_wheelchair' => ['emoji' => '👩‍🦼', 'label' => 'Woman In Motorized Wheelchair'],
+    'woman_in_motorized_wheelchair_facing_right' => ['emoji' => '👩‍🦼‍➡️', 'label' => 'Woman In Motorized Wheelchair Facing Right'],
+    'woman_in_steamy_room' => ['emoji' => '🧖‍♀️', 'label' => 'Woman In Steamy Room'],
+    'woman_in_tuxedo' => ['emoji' => '🤵‍♀️', 'label' => 'Woman In Tuxedo'],
+    'woman_kneeling' => ['emoji' => '🧎‍♀️', 'label' => 'Woman Kneeling'],
+    'woman_kneeling_facing_right' => ['emoji' => '🧎‍♀️‍➡️', 'label' => 'Woman Kneeling Facing Right'],
+    'woman_running_facing_right' => ['emoji' => '🏃‍♀️‍➡️', 'label' => 'Woman Running Facing Right'],
+    'woman_standing' => ['emoji' => '🧍‍♀️', 'label' => 'Woman Standing'],
+    'woman_walking_facing_right' => ['emoji' => '🚶‍♀️‍➡️', 'label' => 'Woman Walking Facing Right'],
+    'woman_with_beard' => ['emoji' => '🧔‍♀️', 'label' => 'Woman: Beard'],
+    'woman_with_probing_cane' => ['emoji' => '👩‍🦯', 'label' => 'Woman With White Cane'],
+    'woman_with_veil' => ['emoji' => '👰‍♀️', 'label' => 'Woman With Veil'],
+    'woman_with_white_cane_facing_right' => ['emoji' => '👩‍🦯‍➡️', 'label' => 'Woman With White Cane Facing Right'],
+    'womans_clothes' => ['emoji' => '👚', 'label' => 'Womans Clothes'],
+    'womans_flat_shoe' => ['emoji' => '🥿', 'label' => 'Flat Shoe'],
+    'womans_hat' => ['emoji' => '👒', 'label' => 'Womans Hat'],
+    'women-with-bunny-ears-partying' => ['emoji' => '👯‍♀️', 'label' => 'Women With Bunny Ears'],
+    'womens' => ['emoji' => '🚺', 'label' => 'Womens Symbol'],
+    'wood' => ['emoji' => '🪵', 'label' => 'Wood'],
+    'woozy_face' => ['emoji' => '🥴', 'label' => 'Face With Uneven Eyes And Wavy Mouth'],
+    'world_map' => ['emoji' => '🗺️', 'label' => 'World Map'],
+    'worm' => ['emoji' => '🪱', 'label' => 'Worm'],
+    'worried' => ['emoji' => '😟', 'label' => 'Worried Face'],
+    'wrench' => ['emoji' => '🔧', 'label' => 'Wrench'],
+    'wrestlers' => ['emoji' => '🤼', 'label' => 'Wrestlers'],
+    'writing_hand' => ['emoji' => '✍️', 'label' => 'Writing Hand'],
+    'x' => ['emoji' => '❌', 'label' => 'Cross Mark'],
+    'x-ray' => ['emoji' => '🩻', 'label' => 'X-Ray'],
+    'yarn' => ['emoji' => '🧶', 'label' => 'Ball Of Yarn'],
+    'yawning_face' => ['emoji' => '🥱', 'label' => 'Yawning Face'],
+    'yellow_heart' => ['emoji' => '💛', 'label' => 'Yellow Heart'],
+    'yen' => ['emoji' => '💴', 'label' => 'Banknote With Yen Sign'],
+    'yin_yang' => ['emoji' => '☯️', 'label' => 'Yin Yang'],
+    'yo-yo' => ['emoji' => '🪀', 'label' => 'Yo-Yo'],
+    'yum' => ['emoji' => '😋', 'label' => 'Face Savouring Delicious Food'],
+    'zany_face' => ['emoji' => '🤪', 'label' => 'Grinning Face With One Large And One Small Eye'],
+    'zap' => ['emoji' => '⚡', 'label' => 'High Voltage Sign'],
+    'zebra_face' => ['emoji' => '🦓', 'label' => 'Zebra Face'],
+    'zero' => ['emoji' => '0️⃣', 'label' => 'Keycap 0'],
+    'zipper_mouth_face' => ['emoji' => '🤐', 'label' => 'Zipper-Mouth Face'],
+    'zombie' => ['emoji' => '🧟', 'label' => 'Zombie'],
+    'zzz' => ['emoji' => '💤', 'label' => 'Sleeping Symbol'],
+];

--- a/your-share-plugin.php
+++ b/your-share-plugin.php
@@ -14,6 +14,7 @@ if (!defined('ABSPATH')) {
 
 require_once __DIR__ . '/includes/activator.php';
 require_once __DIR__ . '/includes/class-container.php';
+require_once __DIR__ . '/includes/class-emoji-library.php';
 require_once __DIR__ . '/includes/class-plugin.php';
 require_once __DIR__ . '/includes/class-options.php';
 require_once __DIR__ . '/includes/class-networks.php';


### PR DESCRIPTION
## Summary
- inline the Katumia emoji PNGs as base64 data URIs in the bundled emoji dataset and record their intrinsic dimensions
- teach the emoji library to retain optional width/height metadata and accept data/absolute image sources
- update reaction asset preparation to recognise inline image strings and fill in any missing dimensions without needing on-disk files

## Testing
- php -l includes/class-emoji-library.php
- php -l includes/class-reactions.php
- php -l includes/data/emoji.php

------
https://chatgpt.com/codex/tasks/task_e_68cfc4310590832cbf2b7c9be2a37898