### PR TITLE
Refine share toggle icon behavior

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,8 @@
+# Implementation Tasks
+
+- [x] Enable visitors to toggle reactions on and off without throttling so they can change their support at any time.
+- [x] Persist multiple concurrent reactions per visitor on the front end and in REST responses.
+- [x] Bundle the full emoji dictionary used by the reaction picker so administrators can curate the available set.
+- [x] Expose admin controls for toggling individual emojis and syncing those settings to the front-end reaction bars.
+- [x] Update the share interface so that the first five networks render immediately and the remaining options sit behind a share icon toggle.
+- [x] Adjust the share totals layout to use a stacked "Shares" label above the numeric counter.

--- a/includes/class-render.php
+++ b/includes/class-render.php
@@ -245,12 +245,12 @@ class Render
                         data-net="more"
                         data-share-toggle="more"
                         aria-expanded="false"
+                        aria-label="<?php esc_attr_e('More share options', $this->text_domain); ?>"
                         <?php if ($more_id !== '') : ?>aria-controls="<?php echo esc_attr($more_id); ?>"<?php endif; ?>
                     >
                         <span class="waki-icon" aria-hidden="true">
                             <?php echo $this->icons->svg('share-toggle'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
                         </span>
-                        <span class="waki-label"><?php esc_html_e('More options', $this->text_domain); ?></span>
                     </button>
                 <?php endif; ?>
             </div>


### PR DESCRIPTION
## Summary
- update the hidden share options toggle to rely on the share icon with an accessibility label
- add a TASKS.md file that captures the completed implementation work items

## Testing
- php -l includes/class-render.php

------
https://chatgpt.com/codex/tasks/task_e_68cfee50cb50832c8e25db791495b71f