### PR TITLE
Ensure Your Share settings redirect back to plugin page

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -393,11 +393,17 @@
         } else {
           url.searchParams.delete('tab');
         }
-        refererInput.value = url.pathname + url.search;
+        refererInput.value = url.toString();
       } catch (error) {
         var cleaned = base.replace(/([?&])tab=[^&#]*/g, '$1').replace(/[?&]$/, '');
+        var origin = window.location && window.location.origin ? window.location.origin : '';
+        if (cleaned.indexOf('://') === -1 && origin){
+          var needsSlash = cleaned.charAt(0) !== '/';
+          cleaned = origin.replace(/\/$/, '') + (needsSlash ? '/' : '') + cleaned;
+        }
         if (tab){
-          refererInput.value = cleaned + (cleaned.indexOf('?') === -1 ? '?' : '&') + 'tab=' + tab;
+          var separator = cleaned.indexOf('?') === -1 ? '?' : '&';
+          refererInput.value = cleaned + separator + 'tab=' + tab;
         } else {
           refererInput.value = cleaned;
         }


### PR DESCRIPTION
## Summary
- hook into `wp_redirect` to guarantee settings saves always return to the Your Share screen while keeping the active tab selected
- stop forcing a relative `_wp_http_referer` and let JavaScript maintain an absolute referer for tab switching

## Testing
- php -l includes/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cff65d1d70832cb501753a76440ebd