### PR TITLE
Define referer base before rendering settings form

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -115,6 +115,7 @@ class Admin
 
         $tabs        = $this->tabs();
         $current_tab = $this->current_tab();
+        $referer_base = add_query_arg('page', $this->slug, admin_url('options-general.php'));
 
         ?>
         <div class="wrap your-share-settings" data-your-share-admin>
@@ -171,9 +172,6 @@ class Admin
                         </div>
                     <?php endforeach; ?>
                 </div>
-                <?php
-                $referer_base = add_query_arg('page', $this->slug, admin_url('options-general.php'));
-                ?>
                 <?php submit_button(__('Save settings', $this->text_domain)); ?>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- define the admin referer base URL before outputting the settings form
- remove the redundant late assignment that previously caused an undefined variable warning

## Testing
- php -l includes/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d012ad4584832cb4e384815dfd324d