### PR TITLE
Integrate inline reactions into share row

### DIFF
--- a/assets/share.css
+++ b/assets/share.css
@@ -56,7 +56,6 @@
 .waki-reaction-emoji{display:inline-flex;align-items:center;justify-content:center;font-size:1.15rem;line-height:1}
 .waki-reaction-emoji.is-image{width:1.65rem;height:1.65rem}
 .waki-reaction-emoji.is-image img{display:block;width:100%;height:100%;object-fit:contain}
-.waki-reaction-label{font-size:.8rem}
 .waki-reaction-count{font-size:.8rem;font-variant-numeric:tabular-nums;color:rgba(15,23,42,.8)}
 #wakiShareToast{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);background:#111;color:#fff;padding:.5rem .75rem;border-radius:8px;font-size:.875rem;opacity:0;pointer-events:none;transition:opacity .25s ease}
 #wakiShareToast.show{opacity:1}
@@ -94,9 +93,18 @@
 .waki-share .waki-count{display:inline-flex;align-items:center;justify-content:center;margin-left:0;padding:.15rem .45rem;border-radius:9999px;font-size:.75rem;font-weight:600;line-height:1;flex:0 0 auto}
 .waki-style-solid .waki-count{background:rgba(255,255,255,.28);color:#fff}
 .waki-style-outline .waki-count,.waki-style-ghost .waki-count{background:rgba(17,24,39,.08);color:inherit}
-.waki-share-total{display:flex;flex-direction:column;align-items:flex-start;gap:.25rem;margin-right:auto;font-size:.85rem;font-weight:600;line-height:1.2}
+.waki-share-total{display:flex;flex-direction:column;align-items:flex-start;gap:.25rem;margin-right:0;margin-bottom:0;font-size:.85rem;font-weight:600;line-height:1.2}
 .waki-share-total .waki-total-value{font-size:1.25rem;font-weight:700}
+.waki-share-row{display:flex;flex-wrap:wrap;align-items:center;width:100%;gap:var(--waki-gap);flex:1 1 100%}
+.waki-share-inline .waki-share-row{gap:0;row-gap:var(--waki-gap)}
+.waki-share-inline .waki-share-row .waki-share-total{margin-right:var(--waki-gap)}
+.waki-share-floating .waki-share-row{flex-direction:column;align-items:stretch;gap:var(--waki-gap)}
+.waki-share-row .waki-share-buttons{flex:1 1 auto}
 .waki-share-buttons{display:flex;flex-wrap:wrap;gap:var(--waki-gap);align-items:center}
 .waki-share-extra{display:flex;flex-wrap:wrap;gap:var(--waki-gap);width:100%;margin-top:var(--waki-gap)}
 .waki-share-extra[hidden]{display:none}
+.waki-share-react-field{display:flex;flex-wrap:wrap;align-items:center;gap:var(--waki-gap);flex:1 1 100%;width:100%}
+.waki-share-react-label{font-size:.85rem;font-weight:600;line-height:1.2;white-space:nowrap}
+.waki-share-react-field .waki-reactions-inline{margin-top:0;flex:1 1 auto}
+.waki-share-react-field .waki-reactions{flex:1 1 auto}
 .waki-btn--toggle.is-active{box-shadow:0 0 0 2px rgba(37,99,235,.18)}

--- a/includes/class-reactions.php
+++ b/includes/class-reactions.php
@@ -456,6 +456,7 @@ class Reactions
                     data-reaction="<?php echo esc_attr($slug); ?>"
                     aria-pressed="<?php echo $is_current ? 'true' : 'false'; ?>"
                     aria-label="<?php echo esc_attr(sprintf(__('React with %s', $this->text_domain), $label)); ?>"
+                    title="<?php echo esc_attr($label); ?>"
                 >
                     <span class="<?php echo esc_attr($emoji_classes); ?>" aria-hidden="true">
                         <?php if ($image_url !== '') : ?>
@@ -464,7 +465,6 @@ class Reactions
                             <?php echo esc_html($emoji); ?>
                         <?php endif; ?>
                     </span>
-                    <span class="waki-reaction-label"><?php echo esc_html($label); ?></span>
                     <span class="waki-reaction-count" data-your-share-reaction-count><?php echo esc_html((string) $count); ?></span>
                 </button>
             <?php endforeach; ?>

--- a/includes/class-render.php
+++ b/includes/class-render.php
@@ -144,6 +144,12 @@ class Render
             $classes[] = 'waki-has-counts';
         }
 
+        $inline_reactions_markup = '';
+
+        if ($placement === 'inline') {
+            $inline_reactions_markup = $this->reactions->render_inline($post_id);
+        }
+
         $max_visible     = 5;
         $visible_buttons = [];
         $hidden_buttons  = [];
@@ -228,31 +234,33 @@ class Render
             'data-your-share-count-ttl'      => $counts_state['ttl'],
         ]); ?>
         <div class="<?php echo esc_attr(implode(' ', $classes)); ?>" style="<?php echo esc_attr($style_inline); ?>"<?php echo $data_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-            <?php if ($counts_state['enabled'] && !empty($opts['counts_show_total'])) : ?>
-                <div class="waki-share-total" data-your-share-total>
-                    <span class="waki-total-label"><?php esc_html_e('Shares', $this->text_domain); ?></span>
-                    <span class="waki-total-value" data-your-share-total-value data-value="<?php echo esc_attr((string) $counts_state['total']); ?>"><?php echo esc_html($this->format_count($counts_state['total'])); ?></span>
-                </div>
-            <?php endif; ?>
-            <div class="waki-share-buttons" data-your-share-buttons>
-                <?php foreach ($visible_buttons as $button_markup) :
-                    echo $button_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                endforeach; ?>
-                <?php if (!empty($hidden_buttons)) : ?>
-                    <button
-                        type="button"
-                        class="waki-btn waki-btn--toggle"
-                        data-net="more"
-                        data-share-toggle="more"
-                        aria-expanded="false"
-                        aria-label="<?php esc_attr_e('More share options', $this->text_domain); ?>"
-                        <?php if ($more_id !== '') : ?>aria-controls="<?php echo esc_attr($more_id); ?>"<?php endif; ?>
-                    >
-                        <span class="waki-icon" aria-hidden="true">
-                            <?php echo $this->icons->svg('share-toggle'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                        </span>
-                    </button>
+            <div class="waki-share-row">
+                <?php if ($counts_state['enabled'] && !empty($opts['counts_show_total'])) : ?>
+                    <div class="waki-share-total" data-your-share-total>
+                        <span class="waki-total-label"><?php esc_html_e('Shares', $this->text_domain); ?></span>
+                        <span class="waki-total-value" data-your-share-total-value data-value="<?php echo esc_attr((string) $counts_state['total']); ?>"><?php echo esc_html($this->format_count($counts_state['total'])); ?></span>
+                    </div>
                 <?php endif; ?>
+                <div class="waki-share-buttons" data-your-share-buttons>
+                    <?php foreach ($visible_buttons as $button_markup) :
+                        echo $button_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                    endforeach; ?>
+                    <?php if (!empty($hidden_buttons)) : ?>
+                        <button
+                            type="button"
+                            class="waki-btn waki-btn--toggle"
+                            data-net="more"
+                            data-share-toggle="more"
+                            aria-expanded="false"
+                            aria-label="<?php esc_attr_e('More share options', $this->text_domain); ?>"
+                            <?php if ($more_id !== '') : ?>aria-controls="<?php echo esc_attr($more_id); ?>"<?php endif; ?>
+                        >
+                            <span class="waki-icon" aria-hidden="true">
+                                <?php echo $this->icons->svg('share-toggle'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                            </span>
+                        </button>
+                    <?php endif; ?>
+                </div>
             </div>
             <?php if (!empty($hidden_buttons)) : ?>
                 <div class="waki-share-extra" data-your-share-extra<?php echo $more_id !== '' ? ' id="' . esc_attr($more_id) . '"' : ''; ?> hidden aria-hidden="true">
@@ -261,18 +269,13 @@ class Render
                     endforeach; ?>
                 </div>
             <?php endif; ?>
+            <?php if ($inline_reactions_markup !== '') : ?>
+                <div class="waki-share-react-field" data-your-share-react>
+                    <span class="waki-share-react-label"><?php esc_html_e('React', $this->text_domain); ?></span>
+                    <?php echo $inline_reactions_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                </div>
+            <?php endif; ?>
         </div>
-        <?php
-        if ($placement === 'inline') {
-            $post_id = 0;
-
-            if (isset($share_ctx['post']) && $share_ctx['post'] instanceof \WP_Post) {
-                $post_id = (int) $share_ctx['post']->ID;
-            }
-
-            echo $this->reactions->render_inline($post_id); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        }
-        ?>
         <?php
         return trim((string) ob_get_clean());
     }


### PR DESCRIPTION
## Summary
- embed inline reactions inside the share interface under a React label so they stay with the social icons
- adjust share layout styles to remove the gap between the Shares counter and buttons while accommodating the new React field
- replace persistent reaction labels with hover tooltips so users can pick and unpick emojis without visual clutter

## Testing
- php -l includes/class-render.php
- php -l includes/class-reactions.php

------
https://chatgpt.com/codex/tasks/task_e_68d03bd63408832c910bd8473c6e7b74