### PR TITLE
Improve reactions emoji picker UI

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -186,6 +186,108 @@
   padding: 0.25rem 0.6rem;
 }
 
+.your-share-reaction-manager {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.your-share-reaction-summary__header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 1rem;
+}
+
+.your-share-reaction-summary__count {
+  color: #6b7280;
+  font-weight: 600;
+}
+
+.your-share-reaction-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.your-share-reaction-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.your-share-reaction-chip__symbol {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.your-share-reaction-chip__symbol.has-image {
+  font-size: 0;
+}
+
+.your-share-reaction-chip__symbol.has-image img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.your-share-reaction-chip__text {
+  white-space: nowrap;
+}
+
+.your-share-reaction-empty {
+  margin-top: 0.75rem;
+  color: #6b7280;
+}
+
+.your-share-reaction-library {
+  border: 1px solid #dcdcde;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.your-share-reaction-library__summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+  margin: 0;
+}
+
+.your-share-reaction-library__summary::-webkit-details-marker {
+  display: none;
+}
+
+.your-share-reaction-library__summary::after {
+  content: '\25BC';
+  font-size: 0.7rem;
+  margin-left: auto;
+  transition: transform 0.2s ease;
+}
+
+.your-share-reaction-library[open] .your-share-reaction-library__summary::after {
+  transform: rotate(-180deg);
+}
+
+.your-share-reaction-library__body {
+  padding: 0 1rem 1rem;
+  border-top: 1px solid #dcdcde;
+}
+
 .your-share-reaction-picker {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- show enabled reaction emojis ahead of the library with counts and empty state messaging
- wrap the full emoji library in a collapsible section while keeping search/filter controls and metadata for chips
- style the updated reaction manager, chips, and library toggle to streamline browsing the emoji set

## Testing
- php -l includes/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d0439f6524832c82d3bea446c3d1c6