### PR TITLE
Ensure share buttons respect selected networks

### DIFF
--- a/includes/class-render.php
+++ b/includes/class-render.php
@@ -87,12 +87,6 @@ class Render
 
         $visible_limit = count($networks);
 
-        foreach (array_keys($map) as $slug) {
-            if (!in_array($slug, $networks, true)) {
-                $networks[] = $slug;
-            }
-        }
-
         $classes = [
             'waki-share',
             'waki-size-' . sanitize_html_class($atts['size'] ?? 'md'),


### PR DESCRIPTION
## Summary
- prevent share rendering from appending every available network to the visible/hidden lists so that only selected defaults show on the frontend

## Testing
- php -l includes/class-render.php

------
https://chatgpt.com/codex/tasks/task_e_68d04e02bc04832c875294173c747354