### PR TITLE
Add divider between share buttons and reactions

### DIFF
--- a/assets/share.css
+++ b/assets/share.css
@@ -122,6 +122,7 @@
 .waki-share-extra{display:flex;flex-wrap:wrap;gap:var(--waki-gap);width:100%;margin-top:var(--waki-gap)}
 .waki-share-extra[hidden]{display:none}
 .waki-share-react-field{display:flex;flex-wrap:wrap;align-items:center;gap:var(--waki-gap);flex:1 1 100%;width:100%}
+.waki-share-row+.waki-share-react-field{border-top:1px solid rgba(148,163,184,.35);margin-top:calc(var(--waki-gap)*-1);padding-top:var(--waki-gap)}
 .waki-share-react-label{font-size:.95rem;font-weight:700;line-height:1.2;white-space:nowrap}
 .waki-share-react-field .waki-reactions-inline{margin-top:0;flex:1 1 auto}
 .waki-share-react-field .waki-reactions{flex:1 1 auto}


### PR DESCRIPTION
## Summary
- add a light grey dividing line between the share buttons and reaction section to better separate the areas

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d053a1e79c832cb22f2f5288e98d42