### PR TITLE
Fix analytics chart canvas height growth

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -424,8 +424,9 @@
 }
 
 .your-share-analytics__canvas canvas {
+  display: block;
   width: 100% !important;
-  height: 100% !important;
+  height: auto;
 }
 
 .your-share-analytics__lists {


### PR DESCRIPTION
## Summary
- stop the analytics chart canvas from forcing its container to keep growing by letting Chart.js manage its own height

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0560e8acc832c8a252318867307c4