### PR TITLE
Add automatic inline share placement controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,6 @@ The plugin adds a **Follow** tab under *Settings → Your Share* with:
 - Drag-and-drop ordering for the default follow button order.
 - A live shortcode preview for `[share_follow]`.
 
-Configure the existing Share, Sticky Bar, Smart Share, and Analytics tabs to control the behaviour of share buttons.
+Configure the existing Share, Sticky Bar, Smart Share, and Analytics tabs to control the behaviour of share buttons. The **Share** tab now includes automatic inline placement controls so you can enable buttons for specific post types and choose whether they appear before or after the content. Editors can override those defaults, toggle share counts, and adjust button corners from the Inline Share Buttons panel that appears in the post sidebar.
+
+Fine-tune share count presentation from the **Share Counts** tab by adjusting badge rounding alongside the existing badge and total toggles.

--- a/assets/share.css
+++ b/assets/share.css
@@ -107,7 +107,7 @@
 .waki-share-media[data-trigger="always"] .waki-share-overlay__menu{opacity:1;visibility:visible;pointer-events:auto;transform:none}
 .waki-share-media[data-trigger="always"] .waki-share-overlay__toggle{display:none}
 @media (max-width:640px){.waki-share-overlay__menu{max-width:min(100vw - 1.5rem,20rem)}.waki-share-overlay[data-position="center"]{inset-block-start:auto;inset-inline-start:50%;inset-block-end:var(--waki-overlay-gap);transform:translate(-50%,0)}}
-.waki-share .waki-count{display:inline-flex;align-items:center;justify-content:center;margin-left:0;padding:.15rem .45rem;border-radius:9999px;font-size:.75rem;font-weight:600;line-height:1;flex:0 0 auto}
+.waki-share .waki-count{display:inline-flex;align-items:center;justify-content:center;margin-left:0;padding:.15rem .45rem;border-radius:var(--waki-count-radius,9999px);font-size:.75rem;font-weight:600;line-height:1;flex:0 0 auto}
 .waki-style-solid .waki-count{background:rgba(255,255,255,.28);color:#fff}
 .waki-style-outline .waki-count,.waki-style-ghost .waki-count{background:rgba(17,24,39,.08);color:inherit}
 .waki-share-total{display:flex;flex-direction:column;align-items:flex-start;justify-content:center;gap:.25rem;margin-right:0;margin-bottom:0;font-size:.9rem;font-weight:700;line-height:1.2}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -321,6 +321,23 @@ class Admin
         );
 
         add_settings_section(
+            'your_share_share_inline',
+            __('Automatic placement', $this->text_domain),
+            function (): void {
+                echo '<p>' . esc_html__('Decide where inline share buttons should appear by default.', $this->text_domain) . '</p>';
+            },
+            $page
+        );
+
+        add_settings_field(
+            'share_inline_auto',
+            __('Inline display', $this->text_domain),
+            [$this, 'field_share_inline_auto'],
+            $page,
+            'your_share_share_inline'
+        );
+
+        add_settings_section(
             'your_share_share_reference',
             __('Network reference', $this->text_domain),
             function (): void {
@@ -876,6 +893,53 @@ class Admin
         <?php
     }
 
+    public function field_share_inline_auto(): void
+    {
+        $values      = $this->values();
+        $enabled     = !empty($values['share_inline_auto_enabled']);
+        $post_types  = is_array($values['share_inline_post_types'] ?? null) ? $values['share_inline_post_types'] : [];
+        $position    = $values['share_inline_position'] ?? 'after';
+        $field_id    = $this->field_id('share_inline_position');
+        $objects     = get_post_types(['public' => true, 'show_ui' => true], 'objects');
+
+        if (!is_array($objects)) {
+            $objects = [];
+        }
+
+        ?>
+        <div class="your-share-field-stack">
+            <label class="your-share-toggle">
+                <input type="checkbox" name="<?php echo esc_attr($this->name('share_inline_auto_enabled')); ?>" value="1" <?php checked($enabled, 1); ?>>
+                <?php esc_html_e('Enable inline buttons on single views', $this->text_domain); ?>
+            </label>
+            <fieldset class="your-share-field-stack">
+                <legend><?php esc_html_e('Post types', $this->text_domain); ?></legend>
+                <?php if (!empty($objects)) : ?>
+                    <?php foreach ($objects as $slug => $object) :
+                        $label = $object->labels->singular_name ?? $object->label ?? $slug;
+                        ?>
+                        <label>
+                            <input type="checkbox" name="<?php echo esc_attr($this->name('share_inline_post_types')); ?>[]" value="<?php echo esc_attr($slug); ?>" <?php checked(in_array($slug, $post_types, true)); ?>>
+                            <?php echo esc_html($label); ?>
+                        </label>
+                    <?php endforeach; ?>
+                <?php else : ?>
+                    <p class="description"><?php esc_html_e('No public post types available.', $this->text_domain); ?></p>
+                <?php endif; ?>
+            </fieldset>
+            <label for="<?php echo esc_attr($field_id); ?>">
+                <span><?php esc_html_e('Placement relative to content', $this->text_domain); ?></span>
+                <select id="<?php echo esc_attr($field_id); ?>" name="<?php echo esc_attr($this->name('share_inline_position')); ?>">
+                    <option value="after" <?php selected($position, 'after'); ?>><?php esc_html_e('After the content', $this->text_domain); ?></option>
+                    <option value="before" <?php selected($position, 'before'); ?>><?php esc_html_e('Before the content', $this->text_domain); ?></option>
+                    <option value="both" <?php selected($position, 'both'); ?>><?php esc_html_e('Before and after the content', $this->text_domain); ?></option>
+                </select>
+            </label>
+            <p class="description"><?php esc_html_e('Editors can override visibility, corner radius, and share counts for each post from the Inline Share Buttons panel.', $this->text_domain); ?></p>
+        </div>
+        <?php
+    }
+
     public function field_share_shortcode_preview(): void
     {
         $values   = $this->values();
@@ -1121,6 +1185,13 @@ class Admin
             <label class="your-share-toggle">
                 <input type="checkbox" name="<?php echo esc_attr($this->name('counts_show_total')); ?>" value="1" <?php checked($values['counts_show_total'], 1); ?>>
                 <?php esc_html_e('Display the combined total above the button list', $this->text_domain); ?>
+            </label>
+            <label for="<?php echo esc_attr($this->field_id('counts_badge_radius')); ?>">
+                <span><?php esc_html_e('Badge corner radius', $this->text_domain); ?></span>
+                <div class="your-share-input-suffix">
+                    <input type="number" min="0" id="<?php echo esc_attr($this->field_id('counts_badge_radius')); ?>" name="<?php echo esc_attr($this->name('counts_badge_radius')); ?>" value="<?php echo esc_attr($values['counts_badge_radius']); ?>">
+                    <span>px</span>
+                </div>
             </label>
             <p class="description"><?php esc_html_e('Counts reuse the last successful response if a provider is unavailable.', $this->text_domain); ?></p>
         </div>

--- a/includes/class-inline.php
+++ b/includes/class-inline.php
@@ -1,0 +1,340 @@
+<?php
+
+namespace YourShare;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Inline
+{
+    private const META_DISPLAY       = '_your_share_inline_display';
+    private const META_COUNTS_BADGES = '_your_share_inline_counts_badges';
+    private const META_COUNTS_TOTAL  = '_your_share_inline_counts_total';
+    private const META_RADIUS        = '_your_share_inline_radius';
+    private const NONCE_FIELD        = 'your_share_inline_meta_nonce';
+
+    /** @var Options */
+    private $options;
+
+    /** @var Render */
+    private $renderer;
+
+    /** @var string */
+    private $text_domain;
+
+    public function __construct(Options $options, Render $renderer, string $text_domain)
+    {
+        $this->options     = $options;
+        $this->renderer    = $renderer;
+        $this->text_domain = $text_domain;
+    }
+
+    public function register_hooks(): void
+    {
+        add_filter('the_content', [$this, 'maybe_inject_inline'], 20);
+        add_action('add_meta_boxes', [$this, 'register_meta_boxes']);
+        add_action('save_post', [$this, 'save_post_meta']);
+    }
+
+    public function register_meta_boxes(): void
+    {
+        $post_types = $this->eligible_post_types();
+
+        foreach ($post_types as $post_type) {
+            add_meta_box(
+                'your-share-inline',
+                __('Inline Share Buttons', $this->text_domain),
+                [$this, 'render_meta_box'],
+                $post_type,
+                'side',
+                'high'
+            );
+        }
+    }
+
+    public function render_meta_box(\WP_Post $post): void
+    {
+        $display       = $this->get_choice_meta($post->ID, self::META_DISPLAY);
+        $counts_badges = $this->get_choice_meta($post->ID, self::META_COUNTS_BADGES);
+        $counts_total  = $this->get_choice_meta($post->ID, self::META_COUNTS_TOTAL);
+        $radius        = get_post_meta($post->ID, self::META_RADIUS, true);
+
+        if (!is_string($radius) || $radius === '') {
+            $radius = '';
+        }
+
+        wp_nonce_field(self::NONCE_FIELD, self::NONCE_FIELD);
+        ?>
+        <p><?php esc_html_e('Control whether inline share buttons appear automatically for this content.', $this->text_domain); ?></p>
+        <fieldset class="your-share-meta-field">
+            <legend class="screen-reader-text"><?php esc_html_e('Inline share buttons visibility', $this->text_domain); ?></legend>
+            <label>
+                <input type="radio" name="your_share_inline_display" value="default" <?php checked($display, 'default'); ?>>
+                <?php esc_html_e('Use global default', $this->text_domain); ?>
+            </label><br>
+            <label>
+                <input type="radio" name="your_share_inline_display" value="show" <?php checked($display, 'show'); ?>>
+                <?php esc_html_e('Always show inline buttons', $this->text_domain); ?>
+            </label><br>
+            <label>
+                <input type="radio" name="your_share_inline_display" value="hide" <?php checked($display, 'hide'); ?>>
+                <?php esc_html_e('Hide inline buttons', $this->text_domain); ?>
+            </label>
+        </fieldset>
+        <hr>
+        <fieldset class="your-share-meta-field">
+            <legend><?php esc_html_e('Share counts', $this->text_domain); ?></legend>
+            <label>
+                <span><?php esc_html_e('Button badges', $this->text_domain); ?></span><br>
+                <select name="your_share_inline_counts_badges">
+                    <option value="default" <?php selected($counts_badges, 'default'); ?>><?php esc_html_e('Use global default', $this->text_domain); ?></option>
+                    <option value="show" <?php selected($counts_badges, 'show'); ?>><?php esc_html_e('Show badges', $this->text_domain); ?></option>
+                    <option value="hide" <?php selected($counts_badges, 'hide'); ?>><?php esc_html_e('Hide badges', $this->text_domain); ?></option>
+                </select>
+            </label>
+            <label>
+                <span><?php esc_html_e('Total label', $this->text_domain); ?></span><br>
+                <select name="your_share_inline_counts_total">
+                    <option value="default" <?php selected($counts_total, 'default'); ?>><?php esc_html_e('Use global default', $this->text_domain); ?></option>
+                    <option value="show" <?php selected($counts_total, 'show'); ?>><?php esc_html_e('Show total', $this->text_domain); ?></option>
+                    <option value="hide" <?php selected($counts_total, 'hide'); ?>><?php esc_html_e('Hide total', $this->text_domain); ?></option>
+                </select>
+            </label>
+        </fieldset>
+        <hr>
+        <label for="your-share-inline-radius">
+            <span><?php esc_html_e('Corner radius (px)', $this->text_domain); ?></span><br>
+            <input type="number" min="0" id="your-share-inline-radius" name="your_share_inline_radius" value="<?php echo esc_attr($radius); ?>" class="small-text">
+        </label>
+        <p class="description"><?php esc_html_e('Leave empty to inherit the default radius.', $this->text_domain); ?></p>
+        <?php
+    }
+
+    public function save_post_meta(int $post_id): void
+    {
+        if (!isset($_POST[self::NONCE_FIELD])) {
+            return;
+        }
+
+        $nonce = wp_unslash($_POST[self::NONCE_FIELD]);
+        if (!is_string($nonce) || !wp_verify_nonce($nonce, self::NONCE_FIELD)) {
+            return;
+        }
+
+        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+            return;
+        }
+
+        if (wp_is_post_revision($post_id)) {
+            return;
+        }
+
+        $post = get_post($post_id);
+        if (!$post instanceof \WP_Post) {
+            return;
+        }
+
+        if (!current_user_can('edit_post', $post_id)) {
+            return;
+        }
+
+        $display = isset($_POST['your_share_inline_display']) ? sanitize_key(wp_unslash($_POST['your_share_inline_display'])) : 'default';
+        $display = $this->sanitize_choice($display);
+
+        $counts_badges = isset($_POST['your_share_inline_counts_badges']) ? sanitize_key(wp_unslash($_POST['your_share_inline_counts_badges'])) : 'default';
+        $counts_badges = $this->sanitize_choice($counts_badges);
+
+        $counts_total = isset($_POST['your_share_inline_counts_total']) ? sanitize_key(wp_unslash($_POST['your_share_inline_counts_total'])) : 'default';
+        $counts_total = $this->sanitize_choice($counts_total);
+
+        $radius = isset($_POST['your_share_inline_radius']) ? wp_unslash($_POST['your_share_inline_radius']) : '';
+        $radius = is_scalar($radius) ? (string) $radius : '';
+        $radius = trim($radius);
+
+        if ($display === 'default') {
+            delete_post_meta($post_id, self::META_DISPLAY);
+        } else {
+            update_post_meta($post_id, self::META_DISPLAY, $display);
+        }
+
+        if ($counts_badges === 'default') {
+            delete_post_meta($post_id, self::META_COUNTS_BADGES);
+        } else {
+            update_post_meta($post_id, self::META_COUNTS_BADGES, $counts_badges);
+        }
+
+        if ($counts_total === 'default') {
+            delete_post_meta($post_id, self::META_COUNTS_TOTAL);
+        } else {
+            update_post_meta($post_id, self::META_COUNTS_TOTAL, $counts_total);
+        }
+
+        if ($radius === '') {
+            delete_post_meta($post_id, self::META_RADIUS);
+        } else {
+            $radius_value = max(0, intval($radius));
+            update_post_meta($post_id, self::META_RADIUS, (string) $radius_value);
+        }
+    }
+
+    public function maybe_inject_inline($content)
+    {
+        if (!is_string($content)) {
+            return $content;
+        }
+
+        if (is_admin() || is_feed() || is_embed()) {
+            return $content;
+        }
+
+        if (!is_singular()) {
+            return $content;
+        }
+
+        if (!in_the_loop() || !is_main_query()) {
+            return $content;
+        }
+
+        $post = get_post();
+        if (!$post instanceof \WP_Post) {
+            return $content;
+        }
+
+        if (post_password_required($post)) {
+            return $content;
+        }
+
+        $options = $this->options->all();
+        $display = $this->get_choice_meta($post->ID, self::META_DISPLAY);
+        $force_show = ($display === 'show');
+
+        if ($display === 'hide') {
+            return $content;
+        }
+
+        if (!$force_show && empty($options['share_inline_auto_enabled'])) {
+            return $content;
+        }
+
+        if (!$force_show && !$this->is_post_type_enabled($post->post_type, $options['share_inline_post_types'] ?? [])) {
+            return $content;
+        }
+
+        if ($this->has_explicit_share_markup($post, $content)) {
+            return $content;
+        }
+
+        $atts = [];
+
+        $counts_badges = $this->get_choice_meta($post->ID, self::META_COUNTS_BADGES);
+        if ($counts_badges === 'show') {
+            $atts['counts_enabled']      = 1;
+            $atts['counts_show_badges']  = 1;
+        } elseif ($counts_badges === 'hide') {
+            $atts['counts_show_badges'] = 0;
+        }
+
+        $counts_total = $this->get_choice_meta($post->ID, self::META_COUNTS_TOTAL);
+        if ($counts_total === 'show') {
+            $atts['counts_enabled']     = 1;
+            $atts['counts_show_total']  = 1;
+        } elseif ($counts_total === 'hide') {
+            $atts['counts_show_total'] = 0;
+        }
+
+        if ((isset($atts['counts_show_badges']) && (int) $atts['counts_show_badges'] === 0)
+            && (isset($atts['counts_show_total']) && (int) $atts['counts_show_total'] === 0)
+        ) {
+            $atts['counts_enabled'] = 0;
+        }
+
+        $radius = get_post_meta($post->ID, self::META_RADIUS, true);
+        if (is_string($radius) && $radius !== '') {
+            $atts['share_radius'] = max(0, intval($radius));
+        }
+
+        $markup = $this->renderer->render_share_inline($atts);
+
+        if ($markup === '') {
+            return $content;
+        }
+
+        $position = $options['share_inline_position'] ?? 'after';
+
+        if ($position === 'before') {
+            return $markup . $content;
+        }
+
+        if ($position === 'both') {
+            return $markup . $content . $markup;
+        }
+
+        return $content . $markup;
+    }
+
+    private function sanitize_choice(string $value): string
+    {
+        $allowed = ['default', 'show', 'hide'];
+
+        if (!in_array($value, $allowed, true)) {
+            return 'default';
+        }
+
+        return $value;
+    }
+
+    private function get_choice_meta(int $post_id, string $key): string
+    {
+        $value = get_post_meta($post_id, $key, true);
+
+        if (!is_string($value) || $value === '') {
+            return 'default';
+        }
+
+        return $this->sanitize_choice($value);
+    }
+
+    private function eligible_post_types(): array
+    {
+        $post_types = get_post_types(['public' => true, 'show_ui' => true], 'names');
+
+        if (!is_array($post_types)) {
+            return [];
+        }
+
+        return array_values($post_types);
+    }
+
+    private function is_post_type_enabled(string $post_type, array $selected): bool
+    {
+        if (empty($selected)) {
+            return true;
+        }
+
+        return in_array($post_type, $selected, true);
+    }
+
+    private function has_explicit_share_markup(\WP_Post $post, string $content): bool
+    {
+        $shortcodes = ['your_share', 'waki_share', 'share_suite', 'waki_share_suite'];
+
+        foreach ($shortcodes as $shortcode) {
+            if (has_shortcode($content, $shortcode)) {
+                return true;
+            }
+        }
+
+        if (function_exists('has_block')) {
+            if (has_block('your-share/share', $post) || has_block('your-share/share-suite', $post)) {
+                return true;
+            }
+        }
+
+        if (strpos($content, 'data-your-share') !== false) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -31,6 +31,9 @@ class Options
             'share_align'               => 'left',
             'share_gap'                 => 8,
             'share_radius'              => 9999,
+            'share_inline_auto_enabled' => 0,
+            'share_inline_post_types'   => ['post', 'page'],
+            'share_inline_position'     => 'after',
             'share_networks_default'    => ['facebook', 'x', 'whatsapp', 'telegram', 'linkedin', 'reddit', 'email', 'copy'],
             'follow_networks'           => ['x', 'instagram', 'facebook-page', 'tiktok', 'youtube', 'linkedin'],
             'follow_profiles'           => [
@@ -77,6 +80,7 @@ class Options
             'counts_show_badges'        => 1,
             'counts_show_total'         => 1,
             'counts_refresh_interval'   => 60,
+            'counts_badge_radius'       => 9999,
             'counts_facebook_app_id'    => '',
             'counts_facebook_app_secret'=> '',
             'counts_reddit_app_id'      => '',
@@ -121,6 +125,14 @@ class Options
         $options['floating_breakpoint']    = $options['sticky_breakpoint'];
         $options['gap']                    = (string) $options['share_gap'];
         $options['radius']                 = (string) $options['share_radius'];
+        $options['share_inline_auto_enabled'] = !empty($options['share_inline_auto_enabled']) ? 1 : 0;
+        $options['share_inline_post_types']   = $this->normalize_post_types(
+            $options['share_inline_post_types'] ?? $defaults['share_inline_post_types'],
+            $defaults['share_inline_post_types']
+        );
+        $position = sanitize_key($options['share_inline_position'] ?? $defaults['share_inline_position']);
+        $options['share_inline_position'] = in_array($position, ['after', 'before', 'both'], true)
+            ? $position : $defaults['share_inline_position'];
         $options['reactions_inline_enabled'] = !empty($options['reactions_inline_enabled']) ? 1 : 0;
         $options['reactions_sticky_enabled'] = !empty($options['reactions_sticky_enabled']) ? 1 : 0;
         $options['reactions_enabled']        = $this->normalize_reaction_toggles($options['reactions_enabled'] ?? [], true);
@@ -128,6 +140,7 @@ class Options
         $options['counts_show_badges']     = !empty($options['counts_show_badges']) ? 1 : 0;
         $options['counts_show_total']      = !empty($options['counts_show_total']) ? 1 : 0;
         $options['counts_refresh_interval']= max(0, (int) $options['counts_refresh_interval']);
+        $options['counts_badge_radius']    = max(0, (int) ($options['counts_badge_radius'] ?? $defaults['counts_badge_radius']));
         $options['follow_networks']        = $this->normalize_follow_networks($options['follow_networks'], $defaults['follow_networks']);
         $options['follow_profiles']        = $this->normalize_follow_profiles($options['follow_profiles'], $defaults['follow_profiles']);
         return $options;
@@ -163,6 +176,18 @@ class Options
 
         $output['share_gap']    = max(0, intval($input['share_gap'] ?? $defaults['share_gap']));
         $output['share_radius'] = max(0, intval($input['share_radius'] ?? $defaults['share_radius']));
+
+        $output['share_inline_auto_enabled'] = !empty($input['share_inline_auto_enabled']) ? 1 : 0;
+        $output['share_inline_post_types']   = $this->normalize_post_types(
+            $input['share_inline_post_types'] ?? $defaults['share_inline_post_types'],
+            $defaults['share_inline_post_types']
+        );
+        $position = sanitize_key($input['share_inline_position'] ?? $defaults['share_inline_position']);
+        $allowed_positions = ['after', 'before', 'both'];
+        if (!in_array($position, $allowed_positions, true)) {
+            $position = $defaults['share_inline_position'];
+        }
+        $output['share_inline_position'] = $position;
 
         $output['follow_networks'] = $this->normalize_follow_networks($input['follow_networks'] ?? $defaults['follow_networks'], $defaults['follow_networks']);
         $output['follow_profiles'] = $this->normalize_follow_profiles($input['follow_profiles'] ?? [], $defaults['follow_profiles']);
@@ -224,6 +249,7 @@ class Options
         $output['counts_show_badges'] = !empty($input['counts_show_badges']) ? 1 : 0;
         $output['counts_show_total'] = !empty($input['counts_show_total']) ? 1 : 0;
         $output['counts_refresh_interval'] = max(0, intval($input['counts_refresh_interval'] ?? $defaults['counts_refresh_interval']));
+        $output['counts_badge_radius'] = max(0, intval($input['counts_badge_radius'] ?? $defaults['counts_badge_radius']));
         $output['counts_facebook_app_id']     = sanitize_text_field($input['counts_facebook_app_id'] ?? '');
         $output['counts_facebook_app_secret'] = sanitize_text_field($input['counts_facebook_app_secret'] ?? '');
         $output['counts_reddit_app_id']       = sanitize_text_field($input['counts_reddit_app_id'] ?? '');
@@ -320,6 +346,36 @@ class Options
         }, $value));
 
         return array_values(array_unique($value));
+    }
+
+    private function normalize_post_types($post_types, array $fallback = []): array
+    {
+        if (is_string($post_types)) {
+            $post_types = array_map('trim', explode(',', $post_types));
+        }
+
+        if (!is_array($post_types)) {
+            $post_types = [];
+        }
+
+        $post_types = array_map('sanitize_key', $post_types);
+        $post_types = array_filter($post_types, static function ($value) {
+            return $value !== '';
+        });
+
+        $allowed = get_post_types(['public' => true], 'names');
+        if (!is_array($allowed)) {
+            $allowed = [];
+        }
+
+        $allowed = array_values($allowed);
+        $post_types = array_values(array_unique(array_intersect($post_types, $allowed)));
+
+        if (empty($post_types) && !empty($fallback)) {
+            $post_types = array_values(array_unique(array_intersect($fallback, $allowed)));
+        }
+
+        return $post_types;
     }
 
     private function normalize_follow_networks($value, array $allowed): array

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -38,6 +38,7 @@ class Plugin
         $this->container->get(Rest::class)->register_hooks();
         $this->container->get(Analytics::class)->register_hooks();
         $this->container->get(Shortcode::class)->register_hooks();
+        $this->container->get(Inline::class)->register_hooks();
         $this->container->get(Blocks::class)->register_hooks();
 
         do_action('your_share_plugin_booted', $this);
@@ -96,6 +97,14 @@ class Plugin
                 $c->get(Reactions::class),
                 self::TEXT_DOMAIN,
                 $c->get(Counts::class)
+            );
+        });
+
+        $this->container->set(Inline::class, function (Container $c): Inline {
+            return new Inline(
+                $c->get(Options::class),
+                $c->get(Render::class),
+                self::TEXT_DOMAIN
             );
         });
 

--- a/includes/class-render.php
+++ b/includes/class-render.php
@@ -66,6 +66,30 @@ class Render
         $allowed    = array_keys($map);
         $placement  = $context['placement'] ?? 'inline';
 
+        if (isset($atts['share_radius'])) {
+            $opts['share_radius'] = max(0, (int) $atts['share_radius']);
+        }
+
+        if (isset($atts['counts_enabled'])) {
+            $opts['counts_enabled'] = !empty($atts['counts_enabled']) ? 1 : 0;
+        }
+
+        if (isset($atts['counts_show_badges'])) {
+            $opts['counts_show_badges'] = !empty($atts['counts_show_badges']) ? 1 : 0;
+        }
+
+        if (isset($atts['counts_show_total'])) {
+            $opts['counts_show_total'] = !empty($atts['counts_show_total']) ? 1 : 0;
+        }
+
+        if (isset($atts['counts_badge_radius'])) {
+            $opts['counts_badge_radius'] = max(0, (int) $atts['counts_badge_radius']);
+        }
+
+        if (empty($opts['counts_show_badges']) && empty($opts['counts_show_total'])) {
+            $opts['counts_enabled'] = 0;
+        }
+
         $geo       = $this->resolve_geo_country($opts, $context, $atts);
         $matrix    = $opts['smart_share_matrix'] ?? [];
         $networks  = $this->prepare_networks($atts['networks'] ?? '', $allowed);
@@ -122,6 +146,8 @@ class Render
         }
 
         $style_inline = sprintf('--waki-gap:%dpx;--waki-radius:%dpx;', $gap, $radius);
+        $badge_radius = absint($opts['counts_badge_radius'] ?? $defaults['counts_badge_radius'] ?? 0);
+        $style_inline .= sprintf('--waki-count-radius:%dpx;', $badge_radius);
 
         if ($placement === 'floating') {
             $classes[]    = 'waki-share-floating';

--- a/your-share-plugin.php
+++ b/your-share-plugin.php
@@ -23,6 +23,7 @@ require_once __DIR__ . '/includes/class-utm.php';
 require_once __DIR__ . '/includes/class-reactions.php';
 require_once __DIR__ . '/includes/class-counts.php';
 require_once __DIR__ . '/includes/class-render.php';
+require_once __DIR__ . '/includes/class-inline.php';
 require_once __DIR__ . '/includes/class-asset-loader.php';
 require_once __DIR__ . '/includes/class-analytics.php';
 require_once __DIR__ . '/includes/class-admin.php';


### PR DESCRIPTION
## Summary
- add automatic inline share placement settings with post type targeting and placement controls
- introduce inline share meta box for per-post overrides including counts and corner radius adjustments
- support configurable share count badge radius and update documentation and styling variables

## Testing
- php -l your-share-plugin.php
- php -l includes/class-plugin.php
- php -l includes/class-options.php
- php -l includes/class-admin.php
- php -l includes/class-render.php
- php -l includes/class-inline.php

------
https://chatgpt.com/codex/tasks/task_e_68d19958eb24832cb88b40f5a44a3aa1