### PR TITLE
Fix share layout alignment preview

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -783,12 +783,14 @@
     var styleSelect = qs(root, '[data-your-share-shortcode-prop="style"]');
     var sizeSelect = qs(root, '[data-your-share-shortcode-prop="size"]');
     var labelsSelect = qs(root, '[data-your-share-shortcode-prop="labels"]');
+    var alignSelect = qs(root, '[data-your-share-shortcode-prop="align"]');
     var brandToggle = qs(root, '[data-your-share-shortcode-prop="brand"]');
 
     var networks = networksInput ? networksInput.value.trim() : '';
     var style = styleSelect ? styleSelect.value : 'solid';
     var size = sizeSelect ? sizeSelect.value : 'md';
     var labels = labelsSelect ? labelsSelect.value : 'auto';
+    var align = alignSelect ? alignSelect.value : 'left';
     var brand = '0';
     if (brandToggle){
       if (brandToggle.type === 'checkbox'){
@@ -803,6 +805,7 @@
     shortcode += ' style="' + style + '"';
     shortcode += ' size="' + size + '"';
     shortcode += ' labels="' + labels + '"';
+    shortcode += ' align="' + align + '"';
     shortcode += ' brand="' + brand + '"';
     shortcode += ']';
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -868,7 +868,7 @@ class Admin
         <div class="your-share-field-grid">
             <label for="<?php echo esc_attr($this->field_id('share_align')); ?>">
                 <span><?php esc_html_e('Alignment', $this->text_domain); ?></span>
-                <select id="<?php echo esc_attr($this->field_id('share_align')); ?>" name="<?php echo esc_attr($this->name('share_align')); ?>" data-your-share-follow-prop="align">
+                <select id="<?php echo esc_attr($this->field_id('share_align')); ?>" name="<?php echo esc_attr($this->name('share_align')); ?>" data-your-share-shortcode-prop="align" data-your-share-follow-prop="align">
                     <option value="left" <?php selected($values['share_align'], 'left'); ?>><?php esc_html_e('Left', $this->text_domain); ?></option>
                     <option value="center" <?php selected($values['share_align'], 'center'); ?>><?php esc_html_e('Center', $this->text_domain); ?></option>
                     <option value="right" <?php selected($values['share_align'], 'right'); ?>><?php esc_html_e('Right', $this->text_domain); ?></option>


### PR DESCRIPTION
## Summary
- ensure the share alignment selector updates both shortcode previews
- include the align attribute when generating the share shortcode sample

## Testing
- php -l includes/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d1a7fcfc68832cb874f2558882736e