### PR TITLE
Prevent inline share toggle collisions between placements

### DIFF
--- a/includes/class-inline.php
+++ b/includes/class-inline.php
@@ -279,7 +279,13 @@ class Inline
         }
 
         if ($position === 'both') {
-            return $markup . $content . $markup;
+            $second_markup = $this->renderer->render_share_inline($atts);
+
+            if ($second_markup === '') {
+                return $markup . $content;
+            }
+
+            return $markup . $content . $second_markup;
         }
 
         return $content . $markup;


### PR DESCRIPTION
## Summary
- render a fresh inline share markup when both pre- and post-content placements are enabled to avoid duplicated IDs
- ensure the bottom "more" toggle controls its own panel instead of the top placement

## Testing
- php -l includes/class-inline.php

------
https://chatgpt.com/codex/tasks/task_e_68d1af56d12c832c9aaeb28e55517b7c