### PR TITLE
Center inline share container

### DIFF
--- a/assets/share.css
+++ b/assets/share.css
@@ -114,6 +114,7 @@
 .waki-share-total .waki-total-label{font-size:.72rem;font-weight:600;color:rgba(15,23,42,.65);text-transform:uppercase;letter-spacing:.32em}
 .waki-share-total .waki-total-value{font-size:clamp(2rem,3.4vw,2.75rem);font-weight:800;line-height:1;font-variant-numeric:tabular-nums;letter-spacing:-.02em;color:#0f172a}
 .waki-share-row{display:flex;flex-wrap:wrap;align-items:center;width:100%;gap:var(--waki-gap);flex:1 1 100%}
+.waki-share-inline{margin-inline:auto;width:min(100%,66.6667%)}
 .waki-share-inline .waki-share-row{gap:0;row-gap:var(--waki-gap)}
 .waki-share-inline .waki-share-row .waki-share-total{margin-right:var(--waki-gap)}
 .waki-share-floating .waki-share-row{flex-direction:column;align-items:stretch;gap:var(--waki-gap)}


### PR DESCRIPTION
## Summary
- limit the inline share container width so it sits within the central eight-column space instead of spanning edge to edge

## Testing
- Not run (CSS change only)


------
https://chatgpt.com/codex/tasks/task_e_68deb946dccc832cb56d0e1cc455f367